### PR TITLE
Issue #4 - Failed Transaction cache + display

### DIFF
--- a/.docs/CHANGELOG.md
+++ b/.docs/CHANGELOG.md
@@ -1,11 +1,18 @@
 # CHANGELOG
 
+## [Unrelease] - 1/23/24
+- Add Failure transactions cache
+- Add Simple paginator query with no additional params
+- Implement Failure transactions endpoint
+- Display failed user transactions in the wallet
+- Fix Wallet Bug on number input
+
 ## [Unreleased] - 1/21/2024
 - Set up prettier for both Wallet and Explorer
 
 ## [Unreleased] - 1/20/2024
 - Wallet UI fixes
-- Added wallet text input sanitizaiton
+- Added wallet text input sanitization
 - Added wallet number input formatting 
 
 ## [Unreleased] - 1/19/2024

--- a/cmd/rpc/server.go
+++ b/cmd/rpc/server.go
@@ -243,10 +243,10 @@ func StartRPC(a *controller.Controller, c lib.Config, l lib.LoggerI) {
 	}()
 	go updatePollResults()
 	go PollBaseChainInfo()
-	// l.Infof("Starting Web Wallet 🔑 http://localhost:%s ⬅️", c.WalletPort)
-	// runStaticFileServer(walletFS, walletStaticDir, c.WalletPort)
-	// l.Infof("Starting Block Explorer 🔍️ http://localhost:%s ⬅️", c.ExplorerPort)
-	// runStaticFileServer(explorerFS, explorerStaticDir, c.ExplorerPort)
+	l.Infof("Starting Web Wallet 🔑 http://localhost:%s ⬅️", c.WalletPort)
+	runStaticFileServer(walletFS, walletStaticDir, c.WalletPort)
+	l.Infof("Starting Block Explorer 🔍️ http://localhost:%s ⬅️", c.ExplorerPort)
+	runStaticFileServer(explorerFS, explorerStaticDir, c.ExplorerPort)
 }
 
 // PollBaseChainInfo() retrieves the information from the base-chain required for consensus

--- a/cmd/rpc/server.go
+++ b/cmd/rpc/server.go
@@ -335,8 +335,8 @@ func Pending(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
 }
 
 func FailedTxs(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
-	pageIndexer(w, r, func(_ lib.StoreI, _ crypto.AddressI, p lib.PageParams) (any, lib.ErrorI) {
-		return app.GetFailedTxsPage(p)
+	addrIndexer(w, r, func(_ lib.StoreI, address crypto.AddressI, p lib.PageParams) (any, lib.ErrorI) {
+		return app.GetFailedTxsPage(address.String(), p)
 	})
 }
 

--- a/cmd/rpc/web/wallet/components/account.jsx
+++ b/cmd/rpc/web/wallet/components/account.jsx
@@ -402,7 +402,7 @@ export default function Accounts({ keygroup, account, validator }) {
         <Table className="table-fixed" bordered hover style={{ marginTop: "10px" }}>
           <thead>
             <tr>
-              {["Height", "Amount", "Recipient", "Type", "Hash"].map((k, i) => (
+              {["Height", "Amount", "Recipient", "Type", "Hash", "Status"].map((k, i) => (
                 <th key={i}>{k}</th>
               ))}
             </tr>
@@ -410,11 +410,12 @@ export default function Accounts({ keygroup, account, validator }) {
           <tbody>
             {account.combined.slice(0, 5).map((v, i) => (
               <tr key={i}>
-                <td>{v.height}</td>
+                <td>{v.height || "N/A"}</td>
                 <td>{v.transaction.msg.amount ?? v.transaction.msg.AmountForSale ?? "N/A"}</td>
-                {renderAccSumTabCol(v.recipient ?? v.sender, i)}
-                <td>{v.message_type}</td>
-                {renderAccSumTabCol(v.tx_hash, i)}
+                {renderAccSumTabCol(v.recipient ?? v.sender ?? v.transaction.msg.from_address, i)}
+                <td>{v.message_type || v.transaction.type}</td>
+                {renderAccSumTabCol(v.tx_hash, i + 1)}
+                <td>{v.status ?? ""}</td>
               </tr>
             ))}
           </tbody>

--- a/cmd/rpc/web/wallet/components/account.jsx
+++ b/cmd/rpc/web/wallet/components/account.jsx
@@ -412,7 +412,7 @@ export default function Accounts({ keygroup, account, validator }) {
               <tr key={i}>
                 <td>{v.height || "N/A"}</td>
                 <td>{v.transaction.msg.amount ?? v.transaction.msg.AmountForSale ?? "N/A"}</td>
-                {renderAccSumTabCol(v.recipient ?? v.sender ?? v.transaction.msg.from_address, i)}
+                {renderAccSumTabCol(v.recipient ?? v.sender ?? v.address, i)}
                 <td>{v.message_type || v.transaction.type}</td>
                 {renderAccSumTabCol(v.tx_hash, i + 1)}
                 <td>{v.status ?? ""}</td>

--- a/cmd/rpc/web/wallet/components/api.js
+++ b/cmd/rpc/web/wallet/components/api.js
@@ -73,10 +73,6 @@ export async function POST(url, path, request) {
   return resp.json();
 }
 
-function pageRequest(page) {
-  return JSON.stringify({ pageNumber: page, perPage: 5 });
-}
-
 function heightAndAddrRequest(height, address) {
   return JSON.stringify({ height: height, address: address });
 }
@@ -249,7 +245,7 @@ export async function AccountWithTxs(height, address, page) {
   result.rec_transactions = await TransactionsByRec(page, address);
   result.sent_transactions.results?.forEach(setStatus("included"));
 
-  result.failed_transactions = await FailedTransactions(page);
+  result.failed_transactions = await FailedTransactions(page, address);
   result.failed_transactions.results?.forEach((tx) => {
     tx.status = "failure: ".concat(tx.error.Msg);
   });
@@ -266,6 +262,8 @@ export async function AccountWithTxs(height, address, page) {
       : b.transaction.time - a.transaction.time;
   });
 
+  console.log(result.combined);
+
   return result;
 }
 
@@ -277,8 +275,8 @@ export function TransactionsByRec(page, rec) {
   return POST(rpcURL, txsByRec, pageAddrReq(page, rec));
 }
 
-export function FailedTransactions(page) {
-  return POST(rpcURL, failedTxs, pageRequest(page));
+export function FailedTransactions(page, sender) {
+  return POST(rpcURL, failedTxs, pageAddrReq(page, sender));
 }
 
 export async function Validator(height, address) {

--- a/cmd/rpc/web/wallet/components/api.js
+++ b/cmd/rpc/web/wallet/components/api.js
@@ -29,7 +29,6 @@ const validatorPath = "/v1/query/validator";
 const txsBySender = "/v1/query/txs-by-sender";
 const txsByRec = "/v1/query/txs-by-rec";
 const failedTxs = "/v1/query/failed-txs";
-const pendingTxs = "/v1/query/pending";
 const pollPath = "/v1/gov/poll";
 const proposalsPath = "/v1/gov/proposals";
 const addVotePath = "/v1/gov/add-vote";
@@ -250,9 +249,6 @@ export async function AccountWithTxs(height, address, page) {
   result.rec_transactions = await TransactionsByRec(page, address);
   result.sent_transactions.results?.forEach(setStatus("included"));
 
-  result.pending_transactions = await PendingTransactions(page, address);
-  result.pending_transactions.results?.forEach(setStatus("pending"));
-
   result.failed_transactions = await FailedTransactions(page);
   result.failed_transactions.results?.forEach((tx) => {
     tx.status = "failure: ".concat(tx.error.Msg);
@@ -260,7 +256,6 @@ export async function AccountWithTxs(height, address, page) {
 
   result.combined = (result.rec_transactions.results || [])
     .concat(result.sent_transactions.results || [])
-    .concat(result.pending_transactions.results || [])
     .concat(result.failed_transactions.results || []);
 
   result.combined.sort(function (a, b) {
@@ -284,10 +279,6 @@ export function TransactionsByRec(page, rec) {
 
 export function FailedTransactions(page) {
   return POST(rpcURL, failedTxs, pageRequest(page));
-}
-
-export function PendingTransactions(page, rec) {
-  return POST(rpcURL, pendingTxs, pageAddrReq(page, rec));
 }
 
 export async function Validator(height, address) {

--- a/cmd/rpc/web/wallet/components/api.js
+++ b/cmd/rpc/web/wallet/components/api.js
@@ -262,8 +262,6 @@ export async function AccountWithTxs(height, address, page) {
       : b.transaction.time - a.transaction.time;
   });
 
-  console.log(result.combined);
-
   return result;
 }
 

--- a/cmd/rpc/web/wallet/components/api.js
+++ b/cmd/rpc/web/wallet/components/api.js
@@ -255,11 +255,11 @@ export async function AccountWithTxs(height, address, page) {
     .concat(result.failed_transactions.results || []);
 
   result.combined.sort(function (a, b) {
-    return b.transaction.time === a.transaction.time
-      ? b.height === a.height
-        ? b.index - a.index
-        : b.height - a.height
-      : b.transaction.time - a.transaction.time;
+    return a.transaction.time !== b.transaction.time
+      ? b.transaction.time - a.transaction.time
+      : a.height !== b.height
+        ? b.height - a.height
+        : b.index - a.index;
   });
 
   return result;

--- a/cmd/rpc/web/wallet/components/util.js
+++ b/cmd/rpc/web/wallet/components/util.js
@@ -525,12 +525,14 @@ export const sanitizeInput = (event) => {
 // formatNumberInput is a function that formats a number input with commas as thousand separators.
 // It is meant to be used as an onChange event handler.
 export const formatNumberInput = (e) => {
-  const rawValue = e.target.value.replace(/,/g, "");
+  // Removes all non-digit characters and leading zeros from the input value.
+  let input = e.target.value.replace(/[^\d]/g, "").replace(/^0/, "");
   // Check if the input is a number and is greater than 0, a regex is used as isNaN
   // may allow for unexpected input like empty strings or null values.
-  if (/^\d*$/.test(rawValue) && rawValue[0] !== "0") {
-    e.target.value = numberWithCommas(rawValue);
+  if (/^\d+$/.test(input)) {
+    input = numberWithCommas(input);
   }
+  e.target.value = input;
 };
 
 // numberFromCommas is a function that converts a string of numbers formatted with commas

--- a/controller/fsm.go
+++ b/controller/fsm.go
@@ -445,12 +445,12 @@ func (c *Controller) GetPendingPage(p lib.PageParams) (page *lib.Page, err lib.E
 }
 
 // GetFailedTxsPage() returns a list of failed mempool transactions
-func (c *Controller) GetFailedTxsPage(p lib.PageParams) (page *lib.Page, err lib.ErrorI) {
+func (c *Controller) GetFailedTxsPage(address string, p lib.PageParams) (page *lib.Page, err lib.ErrorI) {
 	// lock the controller for thread safety
 	c.Lock()
 	defer c.Unlock()
 	page, failedTxs := lib.NewPage(p, lib.FailedTxsPageName), make(lib.FailedTxs, 0)
-	err = page.LoadArray(c.Mempool.cachedFailedTxs.GetAll(), &failedTxs, func(i any) lib.ErrorI {
+	err = page.LoadArray(c.Mempool.cachedFailedTxs.GetAddr(address), &failedTxs, func(i any) lib.ErrorI {
 		v, ok := i.(*lib.FailedTx)
 		if !ok {
 			return lib.ErrInvalidArgument()
@@ -485,7 +485,7 @@ func NewMempool(fsm *fsm.StateMachine, config lib.MempoolConfig, log lib.LoggerI
 	m = &Mempool{
 		log:             log,
 		Mempool:         lib.NewMempool(config),
-		cachedFailedTxs: lib.NewFailedTxCache([]string{types.MessageSendName}),
+		cachedFailedTxs: lib.NewFailedTxCache(),
 	}
 	// make an 'mempool (ephemeral copy) state' so the mempool can maintain only 'valid' transactions
 	// despite dependencies and conflicts

--- a/controller/fsm.go
+++ b/controller/fsm.go
@@ -501,7 +501,7 @@ func (m *Mempool) HandleTransaction(tx []byte) (err lib.ErrorI) {
 	defer func() {
 		// cache failed txs for RPC display
 		if err != nil {
-			m.cachedFailedTxs.Add(tx, crypto.HashString(tx), err.Error())
+			m.cachedFailedTxs.Add(tx, crypto.HashString(tx), err)
 		}
 	}()
 
@@ -578,7 +578,7 @@ func (m *Mempool) checkMempool() {
 			m.log.Error(err.Error())
 			remove = append(remove, tx)
 			// and cache it
-			m.cachedFailedTxs.Add(tx, crypto.HashString(tx), err.Error())
+			m.cachedFailedTxs.Add(tx, crypto.HashString(tx), err)
 			continue
 		}
 		// cache the results

--- a/controller/fsm.go
+++ b/controller/fsm.go
@@ -2,13 +2,14 @@ package controller
 
 import (
 	"bytes"
+	"math"
+	"time"
+
 	"github.com/canopy-network/canopy/bft"
 	"github.com/canopy-network/canopy/fsm"
 	"github.com/canopy-network/canopy/fsm/types"
 	"github.com/canopy-network/canopy/lib"
 	"github.com/canopy-network/canopy/lib/crypto"
-	"math"
-	"time"
 )
 
 // HandleTransaction() accepts or rejects inbound txs based on the mempool state
@@ -443,6 +444,26 @@ func (c *Controller) GetPendingPage(p lib.PageParams) (page *lib.Page, err lib.E
 	return
 }
 
+// GetFailedTxsPage() returns a list of failed mempool transactions
+func (c *Controller) GetFailedTxsPage(p lib.PageParams) (page *lib.Page, err lib.ErrorI) {
+	// lock the controller for thread safety
+	c.Lock()
+	defer c.Unlock()
+	page, failedTxs := lib.NewPage(p, lib.FailedTxsPageName), make(lib.FailedTxs, 0)
+	err = page.LoadArray(c.Mempool.cachedFailedTxs.GetAll(), &failedTxs, func(i any) lib.ErrorI {
+		v, ok := i.(*lib.FailedTx)
+		if !ok {
+			return lib.ErrInvalidArgument()
+		}
+		failedTxs = append(failedTxs, v)
+		return nil
+	})
+	return
+}
+
+// GetFailedTxsPage() returns a list of failed transactions
+// func (c *Contoller) GetFailedTxPage(p lib.PageParams) (page *lib.Page)
+
 // Mempool accepts or rejects incoming txs based on the mempool (ephemeral copy) state
 // - recheck when
 //   - mempool dropped some percent of the lowest fee txs
@@ -451,9 +472,10 @@ func (c *Controller) GetPendingPage(p lib.PageParams) (page *lib.Page, err lib.E
 // - notes:
 //   - new tx added may also be evicted, this is expected behavior
 type Mempool struct {
-	log           lib.LoggerI
-	FSM           *fsm.StateMachine
-	cachedResults lib.TxResults
+	log             lib.LoggerI
+	FSM             *fsm.StateMachine
+	cachedResults   lib.TxResults
+	cachedFailedTxs *lib.FailedTxCache
 	lib.Mempool
 }
 
@@ -461,8 +483,9 @@ type Mempool struct {
 func NewMempool(fsm *fsm.StateMachine, config lib.MempoolConfig, log lib.LoggerI) (m *Mempool, err lib.ErrorI) {
 	// initialize the structure
 	m = &Mempool{
-		log:     log,
-		Mempool: lib.NewMempool(config),
+		log:             log,
+		Mempool:         lib.NewMempool(config),
+		cachedFailedTxs: lib.NewFailedTxCache([]string{types.MessageSendName}),
 	}
 	// make an 'mempool (ephemeral copy) state' so the mempool can maintain only 'valid' transactions
 	// despite dependencies and conflicts
@@ -474,7 +497,14 @@ func NewMempool(fsm *fsm.StateMachine, config lib.MempoolConfig, log lib.LoggerI
 }
 
 // HandleTransaction() attempts to add a transaction to the mempool by validating, adding, and evicting overfull or newly invalid txs
-func (m *Mempool) HandleTransaction(tx []byte) lib.ErrorI {
+func (m *Mempool) HandleTransaction(tx []byte) (err lib.ErrorI) {
+	defer func() {
+		// cache failed txs for RPC display
+		if err != nil {
+			m.cachedFailedTxs.Add(tx, crypto.HashString(tx), err.Error())
+		}
+	}()
+
 	// validate the transaction against the mempool (ephemeral copy) state
 	result, err := m.applyAndWriteTx(tx)
 	if err != nil {
@@ -547,6 +577,8 @@ func (m *Mempool) checkMempool() {
 			// if invalid, add to the remove list
 			m.log.Error(err.Error())
 			remove = append(remove, tx)
+			// and cache it
+			m.cachedFailedTxs.Add(tx, crypto.HashString(tx), err.Error())
 			continue
 		}
 		// cache the results

--- a/fsm/types/error.go
+++ b/fsm/types/error.go
@@ -2,6 +2,7 @@ package types
 
 import (
 	"fmt"
+
 	"github.com/canopy-network/canopy/lib"
 )
 
@@ -308,5 +309,5 @@ func ErrInvalidProposerRewardPercent() lib.ErrorI {
 }
 
 func ErrInvalidDelegateReward(address lib.HexBytes, cut uint64) lib.ErrorI {
-	return lib.NewError(lib.CodeInvalidDelegatorReward, lib.StateMachineModule, fmt.Sprintf("invalid delegate reward:\naddress: %s\ncut: %d%", address, cut))
+	return lib.NewError(lib.CodeInvalidDelegatorReward, lib.StateMachineModule, fmt.Sprintf("invalid delegate reward:\naddress: %s\ncut: %d", address, cut))
 }

--- a/lib/peer.go
+++ b/lib/peer.go
@@ -6,7 +6,6 @@ import (
 	"net/url"
 	"slices"
 	"strings"
-	sync "sync"
 	"time"
 
 	"github.com/canopy-network/canopy/lib/crypto"
@@ -265,54 +264,4 @@ type peerInfoJSON struct {
 	IsMustConnect bool         `json:"is_must_connect"`
 	IsTrusted     bool         `json:"is_trusted"`
 	Reputation    int32        `json:"reputation"`
-}
-
-// FailedTxCache is a cache of failed transactions that is used to inform
-// the user of the failure
-type FailedTxCache struct {
-	// txs is a map of tx hashes to errors
-	txs map[string]error
-	m   sync.Mutex
-}
-
-// NewFailedTxCache returns a new FailedTxCache
-func NewFailedTxCache() *FailedTxCache {
-	return &FailedTxCache{
-		txs: map[string]error{},
-		m:   sync.Mutex{},
-	}
-}
-
-// Add adds a transaction hash and error to the cache
-func (f *FailedTxCache) Add(hash string, err error) bool {
-	f.m.Lock()
-	defer f.m.Unlock()
-	if _, ok := f.txs[hash]; ok {
-		return false
-	}
-
-	f.txs[hash] = err
-	return true
-}
-
-// Get returns the error associated with a transaction hash
-func (f *FailedTxCache) Get(hash string) error {
-	f.m.Lock()
-	defer f.m.Unlock()
-	return f.txs[hash]
-}
-
-func (f *FailedTxCache) GetAll() map[string]error {
-	f.m.Lock()
-	defer f.m.Unlock()
-	return f.txs
-}
-
-// Remove removes a transaction hash from the cache
-func (f *FailedTxCache) Remove(hashes ...string) {
-	f.m.Lock()
-	defer f.m.Unlock()
-	for _, hash := range hashes {
-		delete(f.txs, hash)
-	}
 }

--- a/lib/peer.go
+++ b/lib/peer.go
@@ -3,12 +3,14 @@ package lib
 import (
 	"container/list"
 	"encoding/json"
-	"github.com/canopy-network/canopy/lib/crypto"
-	"google.golang.org/protobuf/proto"
 	"net/url"
 	"slices"
 	"strings"
+	sync "sync"
 	"time"
+
+	"github.com/canopy-network/canopy/lib/crypto"
+	"google.golang.org/protobuf/proto"
 )
 
 // MESSAGE CODE BELOW
@@ -263,4 +265,54 @@ type peerInfoJSON struct {
 	IsMustConnect bool         `json:"is_must_connect"`
 	IsTrusted     bool         `json:"is_trusted"`
 	Reputation    int32        `json:"reputation"`
+}
+
+// FailedTxCache is a cache of failed transactions that is used to inform
+// the user of the failure
+type FailedTxCache struct {
+	// txs is a map of tx hashes to errors
+	txs map[string]error
+	m   sync.Mutex
+}
+
+// NewFailedTxCache returns a new FailedTxCache
+func NewFailedTxCache() *FailedTxCache {
+	return &FailedTxCache{
+		txs: map[string]error{},
+		m:   sync.Mutex{},
+	}
+}
+
+// Add adds a transaction hash and error to the cache
+func (f *FailedTxCache) Add(hash string, err error) bool {
+	f.m.Lock()
+	defer f.m.Unlock()
+	if _, ok := f.txs[hash]; ok {
+		return false
+	}
+
+	f.txs[hash] = err
+	return true
+}
+
+// Get returns the error associated with a transaction hash
+func (f *FailedTxCache) Get(hash string) error {
+	f.m.Lock()
+	defer f.m.Unlock()
+	return f.txs[hash]
+}
+
+func (f *FailedTxCache) GetAll() map[string]error {
+	f.m.Lock()
+	defer f.m.Unlock()
+	return f.txs
+}
+
+// Remove removes a transaction hash from the cache
+func (f *FailedTxCache) Remove(hashes ...string) {
+	f.m.Lock()
+	defer f.m.Unlock()
+	for _, hash := range hashes {
+		delete(f.txs, hash)
+	}
 }

--- a/lib/tx.go
+++ b/lib/tx.go
@@ -301,6 +301,7 @@ type jsonSignature struct {
 // FailedTx contains a failed transaction and its error
 type FailedTx struct {
 	Transaction *Transaction `json:"transaction,omitempty"`
+	Hash        string       `json:"tx_hash,omitempty"`
 	Error       error        `json:"error,omitempty"`
 }
 
@@ -352,6 +353,7 @@ func (f *FailedTxCache) Add(tx []byte, hash string, err error) bool {
 	f.cache[hash] = failedTx{
 		tx: &FailedTx{
 			Transaction: libTx,
+			Hash:        hash,
 			Error:       err,
 		},
 		timestamp: time.Now(),

--- a/lib/tx.go
+++ b/lib/tx.go
@@ -300,8 +300,8 @@ type jsonSignature struct {
 
 // FailedTx contains a failed transaction and its error
 type FailedTx struct {
-	Transaction *Transaction
-	Err         string
+	Transaction *Transaction `json:"transaction,omitempty"`
+	Error       error        `json:"error,omitempty"`
 }
 
 type FailedTxs []*FailedTx
@@ -322,7 +322,6 @@ type FailedTxCache struct {
 	// reject all transactions that are not of these types
 	allowdMessageTypes []string
 	m                  sync.Mutex
-	cleanupInterval    time.Duration
 }
 
 // NewFailedTxCache returns a new FailedTxCache
@@ -337,7 +336,7 @@ func NewFailedTxCache(allowedMessageTypes []string) *FailedTxCache {
 }
 
 // Add adds a failed transaction with its error to the cache
-func (f *FailedTxCache) Add(tx []byte, hash string, err string) bool {
+func (f *FailedTxCache) Add(tx []byte, hash string, err error) bool {
 	f.m.Lock()
 	defer f.m.Unlock()
 
@@ -353,7 +352,7 @@ func (f *FailedTxCache) Add(tx []byte, hash string, err string) bool {
 	f.cache[hash] = failedTx{
 		tx: &FailedTx{
 			Transaction: libTx,
-			Err:         err,
+			Error:       err,
 		},
 		timestamp: time.Now(),
 	}

--- a/lib/tx.go
+++ b/lib/tx.go
@@ -322,6 +322,7 @@ type FailedTxCache struct {
 	// reject all transactions that are not of these types
 	allowdMessageTypes []string
 	m                  sync.Mutex
+	cleanupInterval    time.Duration
 }
 
 // NewFailedTxCache returns a new FailedTxCache
@@ -360,10 +361,16 @@ func (f *FailedTxCache) Add(tx []byte, hash string, err string) bool {
 }
 
 // Get returns the failed transaction associated with its hash
-func (f *FailedTxCache) Get(txHash string) *FailedTx {
+func (f *FailedTxCache) Get(txHash string) (*FailedTx, bool) {
 	f.m.Lock()
 	defer f.m.Unlock()
-	return f.cache[txHash].tx
+
+	failedTx, ok := f.cache[txHash]
+
+	if !ok {
+		return nil, ok
+	}
+	return failedTx.tx, ok
 }
 
 // GetAll returns all the failed transactions in the cache

--- a/lib/tx.go
+++ b/lib/tx.go
@@ -4,7 +4,13 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"sync"
+	"time"
+
+	"slices"
+
 	"github.com/canopy-network/canopy/lib/crypto"
+
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/anypb"
 )
@@ -19,6 +25,7 @@ var (
 const (
 	TxResultsPageName      = "tx-results-page"      // the name of a page of transactions
 	PendingResultsPageName = "pending-results-page" //  the name of a page of mempool pending transactions
+	FailedTxsPageName      = "failed-txs-page"      // the name of a page of failed transactions
 )
 
 // Messages must be pre-registered for Transaction JSON unmarshalling
@@ -28,6 +35,7 @@ func init() {
 	RegisteredMessages = make(map[string]MessageI)
 	RegisteredPageables[TxResultsPageName] = new(TxResults)      // preregister the page type for unmarshalling
 	RegisteredPageables[PendingResultsPageName] = new(TxResults) // preregister the page type for unmarshalling
+	RegisteredPageables[FailedTxsPageName] = new(FailedTxs)      // preregister the page type for unmarshalling
 }
 
 // TRANSACTION INTERFACES BELOW
@@ -286,4 +294,110 @@ func (x *Signature) UnmarshalJSON(b []byte) (err error) {
 type jsonSignature struct {
 	PublicKey HexBytes `json:"public_key,omitempty"`
 	Signature HexBytes `json:"signature,omitempty"`
+}
+
+// FAILED TX CACHE CODE BELOW
+
+// FailedTx contains a failed transaction and its error
+type FailedTx struct {
+	Transaction *Transaction
+	Err         string
+}
+
+type FailedTxs []*FailedTx
+
+func (t *FailedTxs) Len() int      { return len(*t) }
+func (t *FailedTxs) New() Pageable { return &FailedTxs{} }
+
+type failedTx struct {
+	tx        *FailedTx
+	timestamp time.Time
+}
+
+// FailedTxCache is a cache of failed transactions that is used to inform
+// the user of the failure
+type FailedTxCache struct {
+	// map tx hashes to errors
+	cache map[string]failedTx
+	// reject all transactions that are not of these types
+	allowdMessageTypes []string
+	m                  sync.Mutex
+}
+
+// NewFailedTxCache returns a new FailedTxCache
+func NewFailedTxCache(allowedMessageTypes []string) *FailedTxCache {
+	cache := &FailedTxCache{
+		cache:              map[string]failedTx{},
+		m:                  sync.Mutex{},
+		allowdMessageTypes: allowedMessageTypes,
+	}
+	go cache.clean()
+	return cache
+}
+
+// Add adds a failed transaction with its error to the cache
+func (f *FailedTxCache) Add(tx []byte, hash string, err string) bool {
+	f.m.Lock()
+	defer f.m.Unlock()
+
+	libTx := new(Transaction)
+	if err := Unmarshal(tx, libTx); err != nil {
+		return false
+	}
+
+	if !slices.Contains(f.allowdMessageTypes, libTx.MessageType) {
+		return false
+	}
+
+	f.cache[hash] = failedTx{
+		tx: &FailedTx{
+			Transaction: libTx,
+			Err:         err,
+		},
+		timestamp: time.Now(),
+	}
+	return true
+}
+
+// Get returns the failed transaction associated with its hash
+func (f *FailedTxCache) Get(txHash string) *FailedTx {
+	f.m.Lock()
+	defer f.m.Unlock()
+	return f.cache[txHash].tx
+}
+
+// GetAll returns all the failed transactions in the cache
+func (f *FailedTxCache) GetAll() []*FailedTx {
+	f.m.Lock()
+	defer f.m.Unlock()
+
+	failedTxs := make([]*FailedTx, 0, len(f.cache))
+	for _, failedTx := range f.cache {
+		failedTxs = append(failedTxs, failedTx.tx)
+	}
+
+	return failedTxs
+}
+
+// Remove removes a transaction hash from the cache
+func (f *FailedTxCache) Remove(txHashes ...string) {
+	f.m.Lock()
+	defer f.m.Unlock()
+	for _, hash := range txHashes {
+		delete(f.cache, hash)
+	}
+}
+
+// clean periodically removes transactions from the cache that are older than 5 minutes
+func (f *FailedTxCache) clean() {
+	ticker := time.NewTicker(2 * time.Minute)
+	for range ticker.C {
+		f.m.Lock()
+		for hash, tx := range f.cache {
+			if time.Since(tx.timestamp) >= 5*time.Minute {
+				delete(f.cache, hash)
+			}
+		}
+		f.m.Unlock()
+	}
 }

--- a/lib/tx_test.go
+++ b/lib/tx_test.go
@@ -2,6 +2,7 @@ package lib
 
 import (
 	"encoding/json"
+	"errors"
 	"strings"
 	"testing"
 	"time"
@@ -340,7 +341,7 @@ func TestFailedTxCache(t *testing.T) {
 		allowedMessageTypes []string
 		txBytes             []byte
 		hash                string
-		err                 string
+		err                 error
 		expectedResult      bool
 	}{
 		{
@@ -348,7 +349,7 @@ func TestFailedTxCache(t *testing.T) {
 			allowedMessageTypes: []string{testMessageName},
 			txBytes:             txBytes,
 			hash:                "validHash",
-			err:                 "some error",
+			err:                 nil,
 			expectedResult:      true,
 		},
 		{
@@ -356,7 +357,7 @@ func TestFailedTxCache(t *testing.T) {
 			allowedMessageTypes: []string{"invalidMessageType"},
 			txBytes:             txBytes,
 			hash:                "invalidHash",
-			err:                 "some error",
+			err:                 nil,
 			expectedResult:      false,
 		},
 		{
@@ -364,7 +365,7 @@ func TestFailedTxCache(t *testing.T) {
 			allowedMessageTypes: []string{testMessageName},
 			txBytes:             []byte("invalidBytes"),
 			hash:                "unmarshalErrorHash",
-			err:                 "some error",
+			err:                 ErrUnmarshal(errors.New("unmarshal error")),
 			expectedResult:      false,
 		},
 	}
@@ -381,7 +382,7 @@ func TestFailedTxCache(t *testing.T) {
 				// validate cache
 				failedTx, ok := cache.Get(test.hash)
 				require.True(t, ok)
-				require.Equal(t, test.err, failedTx.Err)
+				require.Equal(t, test.err, failedTx.Error)
 				require.EqualExportedValues(t, tx, failedTx.Transaction)
 
 				// validate get all


### PR DESCRIPTION
## Description
Implemented a failure transactions cache on the mempool, to check on failed transactions, added a server endpoint for it and display those transactions in the wallet.

## Related Issues
Closes: #4 

## Changes Made
- Adds a failed transactions cache to the mempool, which continuously monitors for failed transactions and their accompanied error
- Implemented a `FailedTransactions` endpoint to be consumed by the wallet at the moment
- Display failed transactions on the wallet under the "recent" transactions table
- Fix a minor bug on wallet number formatting which could allow numbers in certain cases

## Checklist
- [x] I have tested the changes locally and verified they work as intended.
- [x] I have appropriately titled my branch `issue-#<issue-number>`.
- [x] I have run re-built the web-wallet and/or block explorer (if applicable).
- [x] I have updated documentation (if applicable).
- [x] I have included tests for the changes (if applicable).

## Additional Notes
> If a transaction is included in a block - remove it from the cache

Although this is mentioned on the issue, such check is not implemented, my reasoning is that once a transaction has been marked as false, either right away or after a recheck of the mempool, it is completely remove, so there's no need to check for the block transactions as the failed ones will never be submitted, feel free to correct me if I'm wrong

Also, a comment could be made o why I made a separate struct type instead of converting a `map[string]FailedTx` into it's own type like:

```go
type FailedTxCache map[string]*FailedTx
```

And that's because I then wouldn't have complete control of which items could be added, such as only allowing specific message types or unmarshalling the tx bytes into a `lib.Transaction` by having a struct I can fully control the access and perform safety checks on the input.
