### PR TITLE
Issue-#12: Max amount form button

### DIFF
--- a/.docs/CHANGELOG.md
+++ b/.docs/CHANGELOG.md
@@ -1,6 +1,9 @@
 # CHANGELOG
 
 ## [Unreleased] - 1/28/2024
+- Add max amount form button
+
+## [Unreleased] - 1/28/2024
 - Fix UI transactions table Issue
 
 ## [Unreleased] - 1/24/2024

--- a/cmd/rpc/web/wallet/components/account.jsx
+++ b/cmd/rpc/web/wallet/components/account.jsx
@@ -302,23 +302,67 @@ export default function Accounts({ keygroup, account, validator }) {
   }
 
   // renderForm() returns a form input group for the transaction execution
-  function renderForm(v, i) {
+  function renderForm(fields) {
+    // Manage all form input values in a single state object to allow for dynamic form generation
+    // and state management
+    const [formValues, setFormValues] = useState(
+      fields.reduce((form, field) => {
+        form[field.label] = field.defaultValue || "";
+        return form;
+      }, {}),
+    );
+
+    const handleInputChange = (key, value, type) => {
+      setFormValues((prev) => ({
+        ...prev,
+        [key]: type === "number" ? formatNumberInput(value) : sanitizeInput(value),
+      }));
+    };
+
+    const doRenderForm = (v, i) => {
+      return (
+        <Form.Group key={i} className="mb-3">
+          <InputGroup size="lg">
+            {withTooltip(<InputGroup.Text className="input-text">{v.inputText}</InputGroup.Text>, v.tooltip, i, "auto")}
+            <Form.Control
+              className="input-text-field"
+              onChange={(e) => handleInputChange(v.label, e.target.value, v.type)}
+              type={v.type == "number" ? "text" : v.type}
+              value={formValues[v.label]}
+              placeholder={v.placeholder}
+              required={v.required}
+              min={0}
+              minLength={v.minLength}
+              maxLength={v.maxLength}
+              aria-label={v.label}
+              aria-describedby="emailHelp"
+            />
+          </InputGroup>
+          {v.label === "amount" ? renderAmountInput(handleInputChange, v) : null}
+        </Form.Group>
+      );
+    };
+
+    return fields.map(doRenderForm);
+  }
+
+  // renderAmountInput() renders the amount input with the option to set the amount to max
+  function renderAmountInput(onchange, v) {
+    const amount = formatNumber(account.account.amount);
     return (
-      <InputGroup key={i} className="mb-3" size="lg">
-        {withTooltip(<InputGroup.Text className="input-text">{v.inputText}</InputGroup.Text>, v.tooltip, i, "auto")}
-        <Form.Control
-          className="input-text-field"
-          onChange={v.type === "number" ? formatNumberInput : sanitizeInput}
-          type={v.type == "number" ? "text" : v.type}
-          defaultValue={v.type === "number" ? numberWithCommas(v.defaultValue || "") : v.defaultValue}
-          placeholder={v.placeholder}
-          required={v.required}
-          min={0}
-          minLength={v.minLength}
-          maxLength={v.maxLength}
-          aria-label={v.label}
-        />
-      </InputGroup>
+      <div className="text-end">
+        <Form.Text>
+          Available: <span className="fw-bold">{amount} </span>
+          <Button
+            aria-label="max-button"
+            onClick={() => onchange(v.label, Math.ceil(numberFromCommas(amount)).toString(), v.type)}
+            variant="link"
+            bsPrefix="max-amount-btn"
+          >
+            MAX
+          </Button>
+        </Form.Text>
+      </div>
     );
   }
 
@@ -331,7 +375,7 @@ export default function Accounts({ keygroup, account, validator }) {
             <Modal.Title>{title}</Modal.Title>
           </Modal.Header>
           <Modal.Body className="modal-body">
-            {getFormInputs(txType, keyGroup, acc, val).map((v, i) => renderForm(v, i))}
+            {renderForm(getFormInputs(txType, keyGroup, acc, val))}
             {renderJSONViewer()}
             <Spinner style={{ display: state.showSpinner ? "block" : "none", margin: "0 auto" }} />
           </Modal.Body>

--- a/cmd/rpc/web/wallet/components/util.js
+++ b/cmd/rpc/web/wallet/components/util.js
@@ -524,24 +524,23 @@ export const disallowedCharacters = ["\t", "\""];
 
 // sanitizeInput removes disallowed characters from the given event target value.
 // It is meant to be used as an onChange event handler
-export const sanitizeInput = (event) => {
-    let value = event.target.value;
+export const sanitizeInput = (value) => {
     disallowedCharacters.forEach((char) => {
         value = value.split(char).join("");
     });
-    event.target.value = value;
+    return value;
 };
 
 // formatNumberInput is a function that formats a number input with commas as thousand separators.
-// It is meant to be used as an onChange event handler
-export const formatNumberInput = (e) => {
-    // remove all non-digit characters but keep leading zeros
-    let input = e.target.value.replace(/[^\d]/g, "");
-    // check if the input is a valid number (digits only)
+export const formatNumberInput = (value) => {
+    // Removes all non-digit characters and leading zeros from the input value.
+    let input = value.replace(/[^\d]/g, "").replace(/^0/, "");
+    // Check if the input is a number and is greater than 0, a regex is used as isNaN
+    // may allow for unexpected input like empty strings or null values.
     if (/^\d+$/.test(input)) {
-        input = numberWithCommas(input);
+        return numberWithCommas(input);
     }
-    e.target.value = input;
+    return input;
 };
 
 // numberFromCommas is a function that converts a string of numbers formatted with commas

--- a/cmd/rpc/web/wallet/styles/globals.css
+++ b/cmd/rpc/web/wallet/styles/globals.css
@@ -4,6 +4,18 @@
   height: 100vh;
 }
 
+.max-amount-btn {
+  color: #3caaa8;
+  padding: 0;
+  border: 0;
+  background-color: unset;
+  font-weight: bold;
+}
+
+.max-amount-btn:hover {
+  color: #287170;
+}
+
 #pageContent {
   margin: 0 auto;
   width: 95%;


### PR DESCRIPTION
## Description
Add max amount form button

## Related Issues
Closes: #12 

## Changes Made
- Added max amount form button
- Changed `renderForm` function to manage the state internally as an object 

## Checklist
- [x] I have tested the changes locally and verified they work as intended.
- [x] I have appropriately titled my branch `issue-#<issue-number>`.
- [x] I have updated documentation (if applicable).
- [ ] I have included tests for the changes (if applicable).

## Additional Notes
The `renderForm` function may seem to make the object a bit more complex and while its true, it is necessary to allow for react to manage its fields, because the`renderFom` may render different forms with different amount of fields, making use of `useState` per field leads to an `"Error: Rendered more hooks than during the previous render.` if you change to any other form, this new approach allows forms to be of any size without disrupting react rendering and allow for more complex interactions and checks for the future against any kind of form.

<img width="828" alt="image" src="https://github.com/user-attachments/assets/013a2d82-71a1-49a2-aa6f-e2aae12ee7fb" />
(as it can be seem there's a small issue on  `formatNumber` when dealing with decimals, that can be tackled on another issue)
