### PR TITLE
Issue-#14: remove net addr in wallet when not delegating

### DIFF
--- a/.docs/CHANGELOG.md
+++ b/.docs/CHANGELOG.md
@@ -1,6 +1,9 @@
 # CHANGELOG
 
 ## [Unreleased] - 1/28/2024
+- Remove net addr in wallet when not delegating
+
+## [Unreleased] - 1/28/2024
 - Add max amount form button
 
 ## [Unreleased] - 1/28/2024

--- a/cmd/rpc/web/wallet/components/account.jsx
+++ b/cmd/rpc/web/wallet/components/account.jsx
@@ -320,6 +320,8 @@ export default function Accounts({ keygroup, account, validator }) {
     };
 
     const doRenderForm = (v, i) => {
+      if (v.shouldNotRender && v.shouldNotRender(keygroup, account, validator)) return null;
+
       return (
         <Form.Group key={i} className="mb-3">
           <InputGroup size="lg">

--- a/cmd/rpc/web/wallet/components/util.js
+++ b/cmd/rpc/web/wallet/components/util.js
@@ -76,7 +76,8 @@ export function getFormInputs(type, keyGroup, account, validator) {
             required: true,
             type: "text",
             minLength: 5,
-            maxLength: 50
+            maxLength: 50,
+            shouldNotRender : (keygroup, account, validator) => validator?.delegate === true
         },
         earlyWithdrawal: {
             placeholder: "early withdrawal rewards for 20% penalty",


### PR DESCRIPTION
## Description
Prevent `net-add` form field to be rendered when `delegating=true`

## Related Issues
Closes: #14

## Changes Made
- Added a `shouldNotRender` field in forms to customize when not to render a form field

## Checklist
- [x] I have tested the changes locally and verified they work as intended.
- [x] I have appropriately titled my branch `issue-#<issue-number>`.
- [x] I have updated documentation (if applicable).
- [ ] I have included tests for the changes (if applicable).
