### PR TITLE
feat: make password mandatory also in backend

### DIFF
--- a/cmd/cli/admin.go
+++ b/cmd/cli/admin.go
@@ -419,6 +419,10 @@ func getPassword() string {
 		if err != nil {
 			l.Fatal(err.Error())
 		}
+		if password == nil {
+			fmt.Println("Password cannot be empty")
+			return getPassword()
+		}
 		return string(password)
 	}
 	return pwd

--- a/cmd/cli/main.go
+++ b/cmd/cli/main.go
@@ -152,8 +152,7 @@ func InitializeDataDirectory(dataDirPath string, log lib.LoggerI) (c lib.Config,
 			log.Fatal(e.Error())
 		}
 		// import the validator key
-		address, e := k.ImportRaw(blsPrivateKey.Bytes(), crypto.ImportRawOpts{
-			Password: pwd,
+		address, e := k.ImportRaw(blsPrivateKey.Bytes(), pwd, crypto.ImportRawOpts{
 			Nickname: nick,
 		})
 		if e != nil {

--- a/cmd/cli/main.go
+++ b/cmd/cli/main.go
@@ -105,6 +105,25 @@ func waitForKill() {
 	l.Infof("Exit command %s received", s)
 }
 
+func getFirstPassword(log lib.LoggerI) string {
+	// allow flag config to skip initial password
+	if pwd == "" {
+		// get the password from the user
+		log.Infof("Enter password for your new private key:")
+		password, e := term.ReadPassword(int(os.Stdin.Fd()))
+		if e != nil {
+			log.Fatal(e.Error())
+		}
+		if password == nil {
+			log.Infof("Password cannot be empty")
+			return getFirstPassword(log)
+		}
+		return string(password)
+	}
+
+	return pwd
+}
+
 // InitializeDataDirectory() populates the data directory with configuration and data files if missing
 func InitializeDataDirectory(dataDirPath string, log lib.LoggerI) (c lib.Config, privateValKey crypto.PrivateKeyI) {
 	// make the data dir if missing
@@ -127,16 +146,7 @@ func InitializeDataDirectory(dataDirPath string, log lib.LoggerI) (c lib.Config,
 		if err = crypto.PrivateKeyToFile(blsPrivateKey, privateValKeyPath); err != nil {
 			log.Fatal(err.Error())
 		}
-		// allow flag config to skip initial password
-		if pwd == "" {
-			// get the password from the user
-			log.Infof("Enter password for your new private key:")
-			password, e := term.ReadPassword(int(os.Stdin.Fd()))
-			if e != nil {
-				log.Fatal(e.Error())
-			}
-			pwd = string(password)
-		}
+		pwd = getFirstPassword(log)
 		// allow flag config to skip initial nickname
 		if nick == "" {
 			// get nickname from the user

--- a/cmd/rpc/server.go
+++ b/cmd/rpc/server.go
@@ -771,8 +771,7 @@ func KeystoreNewKey(w http.ResponseWriter, r *http.Request, _ httprouter.Params)
 		if err != nil {
 			return nil, err
 		}
-		address, err := k.ImportRaw(pk.Bytes(), crypto.ImportRawOpts{
-			Password: ptr.Password,
+		address, err := k.ImportRaw(pk.Bytes(), ptr.Password, crypto.ImportRawOpts{
 			Nickname: ptr.Nickname,
 		})
 		if err != nil {
@@ -796,8 +795,7 @@ func KeystoreImport(w http.ResponseWriter, r *http.Request, _ httprouter.Params)
 
 func KeystoreImportRaw(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
 	keystoreHandler(w, r, func(k *crypto.Keystore, ptr *keystoreRequest) (any, error) {
-		address, err := k.ImportRaw(ptr.PrivateKey, crypto.ImportRawOpts{
-			Password: ptr.Password,
+		address, err := k.ImportRaw(ptr.PrivateKey, ptr.Password, crypto.ImportRawOpts{
 			Nickname: ptr.Nickname,
 		})
 		if err != nil {

--- a/lib/crypto/keystore.go
+++ b/lib/crypto/keystore.go
@@ -106,18 +106,21 @@ func (ks *Keystore) Import(encrypted *EncryptedPrivateKey, opts ImportOpts) erro
 
 type ImportRawOpts struct {
 	Nickname string
-	Password string
 }
 
 // ImportRaw() imports a non-encrypted private key to the store, but encrypts it given a password
-func (ks *Keystore) ImportRaw(privateKeyBytes []byte, opts ImportRawOpts) (address string, err error) {
+func (ks *Keystore) ImportRaw(privateKeyBytes []byte, password string, opts ImportRawOpts) (address string, err error) {
+	if password == "" {
+		return "", fmt.Errorf("invalid password")
+	}
+
 	privateKey, err := NewPrivateKeyFromBytes(privateKeyBytes)
 	if err != nil {
 		return
 	}
 	publicKey := privateKey.PublicKey()
 
-	encrypted, err := EncryptPrivateKey(publicKey.Bytes(), privateKeyBytes, []byte(opts.Password), address)
+	encrypted, err := EncryptPrivateKey(publicKey.Bytes(), privateKeyBytes, []byte(password), address)
 	if err != nil {
 		return
 	}

--- a/lib/crypto/keystore_test.go
+++ b/lib/crypto/keystore_test.go
@@ -48,9 +48,7 @@ func TestKeystoreImportRawWithOpts(t *testing.T) {
 	// create a new in-memory keystore
 	ks := NewKeystoreInMemory()
 	// execute the function call
-	gotAddress, err := ks.ImportRaw(private.Bytes(), ImportRawOpts{
-		Password: password,
-	})
+	gotAddress, err := ks.ImportRaw(private.Bytes(), password, ImportRawOpts{})
 	require.NoError(t, err)
 	// validate got address vs expected
 	require.Equal(t, hex.EncodeToString(address), gotAddress)
@@ -75,8 +73,7 @@ func TestKeystoreDeleteKeyWithOpts(t *testing.T) {
 	// create a new in-memory keystore
 	ks := NewKeystoreInMemory()
 	// execute the function call
-	gotAddress, err := ks.ImportRaw(private.Bytes(), ImportRawOpts{
-		Password: password,
+	gotAddress, err := ks.ImportRaw(private.Bytes(), password, ImportRawOpts{
 		Nickname: "pablito",
 	})
 	require.NoError(t, err)
@@ -96,8 +93,7 @@ func TestKeystoreDeleteKeyWithOpts(t *testing.T) {
 	require.ErrorContains(t, err, "key not found")
 
 	// execute the function call
-	gotAddress, err = ks.ImportRaw(private.Bytes(), ImportRawOpts{
-		Password: password,
+	gotAddress, err = ks.ImportRaw(private.Bytes(), password, ImportRawOpts{
 		Nickname: "pablito",
 	})
 	require.NoError(t, err)


### PR DESCRIPTION
## Description
Make password mandatory in backend

## Related Issues
Closes: #22

## Changes Made
- Make password a mandatory field in `Import` func and update code througout the code for the change.
- Make it a mandatory param in CLI

## Checklist
- [x] I have tested the changes locally and verified they work as intended.
- [x] I have appropriately titled my branch `issue-#<issue-number>`.
- [x] I have run re-built the web-wallet and/or block explorer (if applicable).
- [] I have updated documentation (if applicable).
- [x] I have included tests for the changes (if applicable).

## Notes
Password was already mandatory in front