### PR TITLE
Issue-#38: close and set import key as main

### DIFF
--- a/cmd/rpc/web/wallet/components/account.jsx
+++ b/cmd/rpc/web/wallet/components/account.jsx
@@ -57,11 +57,6 @@ export default function Accounts({ keygroup, account, validator, setActiveKey })
   const ks = Keystore();
   const ksRef = useRef(ks);
 
-  // Keep ksRef updated when context changes
-  useEffect(() => {
-    ksRef.current = ks;
-  }, [ks]);
-
   const [state, setState] = useState({
       showModal: false,
       txType: "send",
@@ -78,10 +73,11 @@ export default function Accounts({ keygroup, account, validator, setActiveKey })
 
   const stateRef = useRef(state);
 
-  // Keep stateRef updated when `state` changes
+  // Keep variables updated whenever they change
   useEffect(() => {
+    ksRef.current = ks;
     stateRef.current = state;
-  }, [state]);
+  }, [ks, state]);
 
   // resetState() resets the state back to its initial
   function resetState() {

--- a/cmd/rpc/web/wallet/components/account.jsx
+++ b/cmd/rpc/web/wallet/components/account.jsx
@@ -1,4 +1,4 @@
-import { useState, useContext } from "react";
+import { useState, useContext, useRef, useEffect } from "react";
 import JsonView from "@uiw/react-json-view";
 import Truncate from "react-truncate-inside";
 import { Button, Card, Col, Form, Modal, Row, Spinner, Table } from "react-bootstrap";
@@ -29,6 +29,7 @@ import {
   withTooltip,
   toUCNPY,
   toCNPY,
+  retryWithDelay,
 } from "@/components/util";
 import { KeystoreContext } from "@/pages";
 
@@ -52,8 +53,15 @@ const transactionButtons = [
 ];
 
 // Accounts() returns the main component of this file
-export default function Accounts({ keygroup, account, validator }) {
+export default function Accounts({ keygroup, account, validator, setActiveKey }) {
   const ks = Keystore();
+  const ksRef = useRef(ks);
+
+  // Keep ksRef updated when context changes
+  useEffect(() => {
+    ksRef.current = ks;
+  }, [ks]);
+
   const [state, setState] = useState({
       showModal: false,
       txType: "send",
@@ -67,6 +75,13 @@ export default function Accounts({ keygroup, account, validator }) {
       showSpinner: false,
     }),
     acc = account.account;
+
+  const stateRef = useRef(state);
+
+  // Keep stateRef updated when `state` changes
+  useEffect(() => {
+    stateRef.current = state;
+  }, [state]);
 
   // resetState() resets the state back to its initial
   function resetState() {
@@ -115,6 +130,28 @@ export default function Accounts({ keygroup, account, validator }) {
     }
   }
 
+  // setActivePrivateKey() sets the active key to the newly added privte key if it is successfully imported
+  function setActivePrivateKey(nickname, closeModal) {
+    const resetState = () =>
+      setState({ ...stateRef.current, showSpinner: false, ...(closeModal && { [closeModal]: false }) });
+
+    retryWithDelay(
+      () => {
+        let idx = Object.keys(ksRef.current).findIndex((k) => k === nickname);
+        if (idx >= 0) {
+          setActiveKey(idx);
+          resetState();
+        } else {
+          throw new Error("failed to find key");
+        }
+      },
+      resetState,
+      10,
+      1000,
+      false,
+    );
+  }
+
   // onPKFormSubmit() handles the submission of the private key form and updates the state with the retrieved key
   function onPKFormSubmit(e) {
     onFormSubmit(state, e, ks, (r) =>
@@ -129,6 +166,7 @@ export default function Accounts({ keygroup, account, validator }) {
     onFormSubmit(state, e, ks, (r) =>
       KeystoreNew(r.password, r.nickname).then((r) => {
         setState({ ...state, showSubmit: Object.keys(state.txResult).length === 0, pk: r });
+        setActivePrivateKey(r.nickname);
       }),
     );
   }
@@ -137,11 +175,15 @@ export default function Accounts({ keygroup, account, validator }) {
   function onImportOrGenerateSubmit(e) {
     onFormSubmit(state, e, ks, (r) => {
       if (r.private_key) {
-        void KeystoreImport(r.private_key, r.password, r.nickname).then((_) =>
-          setState({ ...state, showSpinner: false }),
-        );
+        void KeystoreImport(r.private_key, r.password, r.nickname).then((_) => {
+          setState({ ...state, showSpinner: true });
+          setActivePrivateKey(r.nickname, "showPKImportModal");
+        });
       } else {
-        void KeystoreNew(r.password, r.nickname).then((_) => setState({ ...state, showSpinner: false }));
+        void KeystoreNew(r.password, r.nickname).then((_) => {
+          setState({ ...state, showSpinner: true });
+          setActivePrivateKey(r.nickname, "showPKImportModal");
+        });
       }
     });
   }

--- a/cmd/rpc/web/wallet/components/util.js
+++ b/cmd/rpc/web/wallet/components/util.js
@@ -585,3 +585,23 @@ export const formatLocaleNumber = (num, minFractionDigits = 0, maxFractionDigits
     minimumFractionDigits: minFractionDigits,
   });
 };
+
+// retryWithDelay() retries a function with a delay between each attempt
+export async function retryWithDelay(fn, onFailure, retries = 8, delayMs = 1000, throwOnFailure = false) {
+  for (let attempt = 1; attempt <= retries; attempt++) {
+    try {
+      return await fn();
+    } catch (error) {
+      if (attempt < retries) {
+        await new Promise((resolve) => setTimeout(resolve, delayMs));
+      } else {
+        onFailure();
+        if (throwOnFailure) {
+          throw new Error(`All ${retries} attempts failed`);
+        } else {
+          return;
+        }
+      }
+    }
+  }
+}

--- a/cmd/rpc/web/wallet/pages/index.js
+++ b/cmd/rpc/web/wallet/pages/index.js
@@ -9,7 +9,15 @@ import { Spinner } from "react-bootstrap";
 export const KeystoreContext = createContext();
 
 export default function Home() {
-  const [state, setState] = useState({ navIdx: 0, keystore: null, keyIdx: 0, account: {}, validator: {}, height: 0 });
+  const [state, setState] = useState({
+    navIdx: 0,
+    keystore: null,
+    keyIdx: 0,
+    account: {},
+    validator: {},
+    height: 0,
+    keys: [],
+  });
   const setNavIdx = (i) => setState({ ...state, navIdx: i });
 
   function queryAPI(i = state.keyIdx) {
@@ -31,7 +39,15 @@ export default function Home() {
         Validator(0, mergedKS[Object.keys(mergedKS)[i]].keyAddress, Object.keys(mergedKS)[i]),
         Height(),
       ]).then((r) => {
-        setState({ ...state, keyIdx: i, keystore: mergedKS, account: r[0], validator: r[1], height: r[2] });
+        setState({
+          ...state,
+          keys: Object.keys(mergedKS),
+          keyIdx: i,
+          keystore: mergedKS,
+          account: r[0],
+          validator: r[1],
+          height: r[2],
+        });
       });
     });
   }
@@ -56,7 +72,9 @@ export default function Home() {
       <div id="container">
         <Navigation {...state} setActiveKey={queryAPI} setNavIdx={setNavIdx} />
         <div id="pageContent">
-          {state.navIdx == 0 && <Accounts keygroup={Object.values(state.keystore)[state.keyIdx]} {...state} />}
+          {state.navIdx == 0 && (
+            <Accounts keygroup={Object.values(state.keystore)[state.keyIdx]} setActiveKey={queryAPI} {...state} />
+          )}
           {state.navIdx == 1 && <Governance keygroup={Object.values(state.keystore)[state.keyIdx]} {...state} />}
           {state.navIdx == 2 && <Dashboard />}
         </div>


### PR DESCRIPTION
## Description
Fixed bug where importing a key does not close the modal after is done and added a loading screen until is shown in the wallet

## Checklist
- [x] I have tested the changes locally and verified they work as intended.
- [x] I have appropriately titled my branch `issue-#<issue-number>`.
- [x] I have run re-built the web-wallet and/or block explorer (if applicable).
- [ ] I have updated documentation (if applicable).
- [ ] I have included tests for the changes (if applicable).

## Additional Notes

![wallet](https://github.com/user-attachments/assets/0056339a-074f-4d49-83ee-debbc698dd00)
