### PR TITLE
Fixes Issue #78

### DIFF
--- a/cmd/rpc/web/wallet/components/account.jsx
+++ b/cmd/rpc/web/wallet/components/account.jsx
@@ -42,8 +42,10 @@ import {
   SwapIcon,
   UnstakeIcon,
 } from "@/components/svg_icons";
-import JsonView from "@uiw/react-json-view";
 import { useContext, useEffect, useRef, useState } from "react";
+import JsonView from "@uiw/react-json-view";
+import { lightTheme } from '@uiw/react-json-view/light';
+import { darkTheme } from '@uiw/react-json-view/dark';
 import { Button, Card, Col, Form, Modal, Row, Spinner, Table } from "react-bootstrap";
 import Alert from "react-bootstrap/Alert";
 import Truncate from "react-truncate-inside";
@@ -90,7 +92,23 @@ export default function Accounts({ keygroup, account, validator, setActiveKey })
     }),
     acc = account.account;
 
-    const stateRef = useRef(state);
+  const stateRef = useRef(state);
+  const [buttonVariant, setButtonVariant] = useState('outline-dark');
+  const [JsonViewVariant, setJsonViewVariant] = useState(darkTheme);
+
+  // Using a standalone useEffect here to isolate the color states 
+  useEffect(() => {
+    // Check data-bs-theme on mount
+    const currentTheme = document.documentElement.getAttribute('data-bs-theme');
+
+    if (currentTheme === 'dark') {
+      setButtonVariant('outline-light');
+      setJsonViewVariant(lightTheme);
+    } else {
+      setButtonVariant('outline-dark');
+      setJsonViewVariant(darkTheme);
+    }
+  }, []);
 
   useEffect(() => {
     // Ensure document is available
@@ -347,6 +365,7 @@ export default function Accounts({ keygroup, account, validator, setActiveKey })
         keystore={ks}
         showAlert={state.showAlert}
         alertMsg={state.alertMsg}
+        JsonViewVariant={JsonViewVariant}
       />
       {transactionButtons.map((v, i) => (
         <RenderActionButton key={i} v={v} i={i} showModal={showModal} />
@@ -456,7 +475,7 @@ function KeyDetail({ i, title, info, state, setState }) {
 }
 
 // JSONViewer() returns a raw JSON viewer based on the state of pk and txResult
-function JSONViewer({ pk, txResult }) {
+function JSONViewer({ pk, txResult, JsonViewVariant }) {
   const isEmptyPK = objEmpty(pk);
   const isEmptyTxRes = objEmpty(txResult);
 
@@ -466,6 +485,7 @@ function JSONViewer({ pk, txResult }) {
       value={isEmptyPK ? { result: txResult } : { result: pk }}
       shortenTextAfterLength={100}
       displayDataTypes={false}
+      style={JsonViewVariant}
     />
   );
 }
@@ -564,6 +584,7 @@ function RenderModal({
   keystore,
   showAlert = false,
   alertMsg,
+  JsonViewVariant,
 }) {
   return (
     <Modal show={show} size="lg" onHide={onHide}>
@@ -590,7 +611,7 @@ function RenderModal({
             validator={validator}
           />
           {showAlert && <Alert variant={"danger"}>{alertMsg}</Alert>}
-          <JSONViewer pk={state.pk} txResult={state.txResult} />
+          <JSONViewer pk={state.pk} txResult={state.txResult} JsonViewVariant={JsonViewVariant} />
           <Spinner style={{ display: state.showSpinner ? "block" : "none", margin: "0 auto" }} />
         </Modal.Body>
 

--- a/cmd/rpc/web/wallet/components/dashboard.jsx
+++ b/cmd/rpc/web/wallet/components/dashboard.jsx
@@ -200,7 +200,7 @@ export default function Dashboard() {
           src={state.pauseLogs ? "./unpause.png" : "./pause.png"}
         />
       </div>
-      <LazyLog enableSearch={true} id="lazy-log" text={state.logs.replace("\n", "")}/>
+      <LazyLog enableSearch={true} id="lazy-log" text={state.logs.replace("\n", "")} />
       <Container id="charts-container">
         {[
           [

--- a/cmd/rpc/web/wallet/components/dashboard.jsx
+++ b/cmd/rpc/web/wallet/components/dashboard.jsx
@@ -29,7 +29,7 @@ export default function Dashboard() {
     consensusInfo: {},
     peerInfo: {},
   });
-
+  
   // queryAPI() executes the page api calls
   function queryAPI() {
     const promises = [ConsensusInfo(), PeerInfo(), Resource()];
@@ -156,7 +156,7 @@ export default function Dashboard() {
       </Carousel.Item>
     );
   }
-
+  
   // return the dashboard rendering
   return (
     <div className="content-container" id="dashboard-container">
@@ -200,7 +200,7 @@ export default function Dashboard() {
           src={state.pauseLogs ? "./unpause.png" : "./pause.png"}
         />
       </div>
-      <LazyLog enableSearch={true} id="lazy-log" text={state.logs.replace("\n", "")} />
+      <LazyLog enableSearch={true} id="lazy-log" text={state.logs.replace("\n", "")}/>
       <Container id="charts-container">
         {[
           [

--- a/cmd/rpc/web/wallet/components/governance.jsx
+++ b/cmd/rpc/web/wallet/components/governance.jsx
@@ -1,6 +1,8 @@
 import React, {useEffect, useState, useContext} from "react";
 import Truncate from "react-truncate-inside";
 import JsonView from "@uiw/react-json-view";
+import { lightTheme } from '@uiw/react-json-view/light';
+import { darkTheme } from '@uiw/react-json-view/dark';
 import {Bar} from "react-chartjs-2";
 import {Chart as ChartJS, BarElement, CategoryScale, LinearScale, Tooltip, Legend} from "chart.js";
 import {Accordion, Button, Carousel, Container, Form, InputGroup, Modal, Spinner, Table} from "react-bootstrap";
@@ -58,6 +60,7 @@ export default function Governance({keygroup, account: accountWithTxs, validator
     const [primaryColor, setPrimaryColor] = useState('');
     const [secondaryColor, setSecondaryColor] = useState('');
     const [buttonVariant, setButtonVariant] = useState('outline-dark');
+    const [JsonViewVariant, setJsonViewVariant] = useState('darkTheme');
 
     // Using a standalone useEffect here to isolate the color states
     useEffect(() => {
@@ -66,8 +69,10 @@ export default function Governance({keygroup, account: accountWithTxs, validator
 
       if (currentTheme === 'dark') {
         setButtonVariant('outline-light');
+        setJsonViewVariant('lightTheme');
       } else {
         setButtonVariant('outline-dark');
+        setJsonViewVariant('darkTheme');
       }
     }, []);
 
@@ -395,7 +400,12 @@ export default function Governance({keygroup, account: accountWithTxs, validator
                             onFieldChange={onFormChange}
                         />
                         {!objEmpty(state.txResult) && (
-                            <JsonView value={state.txResult} shortenTextAfterLength={100} displayDataTypes={false}/>
+                            <JsonView
+                              value={state.txResult}
+                              shortenTextAfterLength={100}
+                              displayDataTypes={false}
+                              theme={JsonViewVariant}
+                            />
                         )}
                     </Modal.Body>
                     <Modal.Footer>

--- a/cmd/rpc/web/wallet/styles/globals.css
+++ b/cmd/rpc/web/wallet/styles/globals.css
@@ -549,7 +549,6 @@ th {
   height: 300px !important;
   margin-bottom: 50px;
   border: 2px solid #222222;
-  filter: grayscale(100%);
 }
 
 .content-dark .react-lazylog-searchbar {
@@ -585,8 +584,7 @@ th {
   height: 300px!important;
   margin-bottom: 50px;
   border: 0;
-  filter: grayscale(100%);
-  background: #eee;
+  background: #fff;
 }
 
 #charts-container {


### PR DESCRIPTION
## Description
Implements theme-switching for JsonView component

## Related Issues
Closes: #78 

## Changes Made
- Sets JsonViewVariant value based on current bs-data-theme

## Checklist
- [x] I have tested the changes locally and verified they work as intended.
- [x] I have appropriately titled my branch `issue-#<issue-number>`.
- [x] I have run re-built the web-wallet and/or block explorer (if applicable).
- [ ] I have updated documentation (if applicable).
- [ ] I have included tests for the changes (if applicable).

## Additional Notes
The JsonView component is only called at the end of a transaction, in a modal where the theme can't be toggled. This fix patches initial state, but there may be circumstances where it's possible to be out of sync with the parent. Styles will be readable either way.