### PR TITLE
Fix for #78 and logging control button tweak

### DIFF
--- a/cmd/rpc/web/wallet/.gitignore
+++ b/cmd/rpc/web/wallet/.gitignore
@@ -27,6 +27,10 @@ yarn-error.log*
 # local env files
 .env*.local
 
+# Docker environment
+.docker/.env
+.docker/volumes
+
 # vercel
 .vercel
 

--- a/cmd/rpc/web/wallet/components/account.jsx
+++ b/cmd/rpc/web/wallet/components/account.jsx
@@ -94,19 +94,19 @@ export default function Accounts({keygroup, account, validator, setActiveKey}) {
 
   const stateRef = useRef(state);
   const [buttonVariant, setButtonVariant] = useState('outline-dark');
-  const [JsonViewVariant, setJsonViewVariant] = useState(darkTheme);
+  const [JsonViewVariant, setJsonViewVariant] = useState('darkTheme');
 
   // Using a standalone useEffect here to isolate the color states 
   useEffect(() => {
     // Check data-bs-theme on mount
     const currentTheme = document.documentElement.getAttribute('data-bs-theme');
-
+    
     if (currentTheme === 'dark') {
       setButtonVariant('outline-light');
-      setJsonViewVariant(lightTheme);
+      setJsonViewVariant('lightTheme');
     } else {
       setButtonVariant('outline-dark');
-      setJsonViewVariant(darkTheme);
+      setJsonViewVariant('darkTheme');
     }
   }, []);
 
@@ -341,6 +341,7 @@ export default function Accounts({keygroup, account, validator, setActiveKey}) {
                 state={state}
                 closeOnClick={resetState}
                 keystore={ks}
+                JsonViewVariant={JsonViewVariant}
             />
         );
     }
@@ -493,7 +494,7 @@ function JSONViewer({state, setState, JsonViewVariant}) {
             value={isEmptyPK ? {result: state.txResult} : {result: state.pk}}
             shortenTextAfterLength={100}
             displayDataTypes={false}
-            style={JsonViewVariant}
+            theme={JsonViewVariant}
         />
     );
 }

--- a/cmd/rpc/web/wallet/components/dashboard.jsx
+++ b/cmd/rpc/web/wallet/components/dashboard.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useState, memo } from "react";
 import Truncate from "react-truncate-inside";
 import { getRatio, formatNumber } from "@/components/util";
 import Container from "react-bootstrap/Container";
@@ -18,6 +18,15 @@ import {
   peerInfoPath,
   Resource,
 } from "@/components/api";
+
+// Memoized log controller button
+const RenderControlButton = memo(({ state, setState }) => { 
+  return (
+    <div onClick={() => setState({ ...state, pauseLogs: !state.pauseLogs })} className="logs-button-container">
+      {state.pauseLogs ? <UnpauseIcon className="icon-button" /> : <PauseIcon className="icon-button" />}
+    </div>
+  );
+});
 
 // Dashboard() is the main component of this file
 export default function Dashboard() {
@@ -130,7 +139,7 @@ export default function Dashboard() {
         ],
       },
     ];
-
+  
   // renderButtonCarouselItem() generates the button for the carousel
   function renderButtonCarouselItem(props) {
     return (
@@ -259,12 +268,8 @@ export default function Dashboard() {
       </Container>
       <h2 className="dashboard-label">Transaction Log</h2>
       <Container id="log-container" fluid>
-        <div onClick={() => setState({ ...state, pauseLogs: !state.pauseLogs })} className="logs-button-container">
-          <img
-            className="logs-button"
-            alt="play-pause-btn"
-            src={state.pauseLogs ? "./unpause.png" : "./pause.png"}
-          />
+        <div className="logs-button-container">
+          <RenderControlButton state={state} setState={setState} />
         </div>
         <CanaLog text={state.logs} />
       </Container>

--- a/cmd/rpc/web/wallet/components/governance.jsx
+++ b/cmd/rpc/web/wallet/components/governance.jsx
@@ -356,7 +356,7 @@ export default function Governance({keygroup, account: accountWithTxs, validator
             </Button>
             <br/>
             <br/>
-            <Modal show={state.showPropModal} size="lg" onHide={handlePropClose}>
+            <Modal show={state.showPropModal} size="lg" onHide={handlePropClose} JsonViewVariant={JsonViewVariant}>
                 <Form onSubmit={onPropSubmit}>
                     <Modal.Header closeButton>
                         <Modal.Title>{state.txPropType === 0 ? "Change Parameter" : "Treasury Subsidy"}</Modal.Title>

--- a/cmd/rpc/web/wallet/styles/globals.css
+++ b/cmd/rpc/web/wallet/styles/globals.css
@@ -518,27 +518,25 @@ div#log-container {
 }
 
 .logs-button-container {
-  alignment: left;
-  width: 20px;
-  height: 20px;
+  height: 30px;
+  width: 30px;
   position: relative;
-  top: 27px;
-  left: 42px;
+  top: 8px;
+  left: 18px;
   cursor: pointer;
-  transition: ease-in-out 0.2s;
+  transition: .2s ease-in-out;
 }
 
 .logs-button-container:hover {
-  scale: 1.2;
+  scale: 1.05;
 }
 
-.logs-button {
-  width: 25px;
-  height: 25px;
+.logs-button-container svg {
+    max-width: 30px;
 }
 
-.content-dark .logs-button {
-  filter: invert(1);
+.logs-button-container svg path {
+    fill: var(--primary-color);
 }
 
 .canalog-container {


### PR DESCRIPTION
## Description
Applied the weird approach that works on the Governance component to the Accounts component (passing style prop as a string to 'theme' prop, which is the opposite of how that is supposed to work). Also includes a tweak to the dashboard logging control to replace with SVG. 

## Related Issues
#78 #86 

Closes: #78 

## Changes Made
- Passes style prop as a string value to theme prop of JsonView
- Creates a memoized control button for CanaLog with styled SVGs
- Added supporting styles for the control button
- Added .docker/volumes to .gitignore so that node json files are not suggested as part of commits

## Checklist
- [x] I have tested the changes locally and verified they work as intended.
- [x] I have appropriately titled my branch `issue-#<issue-number>`.
- [x] I have run re-built the web-wallet and/or block explorer (if applicable).
- [ ] I have updated documentation (if applicable).
- [ ] I have included tests for the changes (if applicable).

## Additional Notes
The JsonView styles are updating as expected in my testing, but to be honest, the provided styles are ugly and still hard to read. Will likely come back to this and swap out for locally declared styles that match the aesthetic of the interface. But, fixed for now.