### PR TITLE
feat: add consensus duration logic

### DIFF
--- a/cmd/rpc/web/explorer/components/api.js
+++ b/cmd/rpc/web/explorer/components/api.js
@@ -1,4 +1,5 @@
 let rpcURL = "http://localhost:50002"; // default value for the RPC URL
+let adminRPCURL = "http://localhost:50003"; // default Admin RPC URL
 let chainId = 1; // default chain id
 
 if (typeof window !== "undefined") {
@@ -30,11 +31,12 @@ const validatorPath = "/v1/query/validator";
 const paramsPath = "/v1/query/params";
 const supplyPath = "/v1/query/supply";
 const ordersPath = "/v1/query/orders";
+const configPath = "/v1/admin/config";
 
 // POST
 
-export async function POST(request, path) {
-  return fetch(rpcURL + path, {
+export async function POST(url, request, path) {
+  return fetch(url + path, {
     method: "POST",
     body: request,
   })
@@ -49,6 +51,23 @@ export async function POST(request, path) {
       return Promise.reject(rejected);
     });
 }
+
+export async function GET(url, path) {
+  return fetch(url + path, {
+    method: "GET",
+  })
+    .then(async (response) => {
+      if (!response.ok) {
+        return Promise.reject(response);
+      }
+      return response.json();
+    })
+    .catch((rejected) => {
+      console.log(rejected);
+      return Promise.reject(rejected);
+    });
+}
+
 
 // REQUEST OBJECTS BELOW
 
@@ -83,31 +102,31 @@ function validatorsReq(page, height, committee) {
 // API CALLS BELOW
 
 export function Blocks(page, _) {
-  return POST(pageHeightReq(page, 0), blocksPath);
+  return POST(rpcURL, pageHeightReq(page, 0), blocksPath);
 }
 
 export function Transactions(page, height) {
-  return POST(pageHeightReq(page, height), txsByHeightPath);
+  return POST(rpcURL, pageHeightReq(page, height), txsByHeightPath);
 }
 
 export function Accounts(page, _) {
-  return POST(pageHeightReq(page, 0), accountsPath);
+  return POST(rpcURL, pageHeightReq(page, 0), accountsPath);
 }
 
 export function Validators(page, _) {
-  return POST(pageHeightReq(page, 0), validatorsPath);
+  return POST(rpcURL, pageHeightReq(page, 0), validatorsPath);
 }
 
 export function Committee(page, chain_id) {
-  return POST(validatorsReq(page, 0, chain_id), validatorsPath);
+  return POST(rpcURL, validatorsReq(page, 0, chain_id), validatorsPath);
 }
 
 export function DAO(height, _) {
-  return POST(heightAndIDRequest(height, 4294967296), poolPath);
+  return POST(rpcURL, heightAndIDRequest(height, 4294967296), poolPath);
 }
 
 export function Account(height, address) {
-  return POST(heightAndAddrRequest(height, address), accountPath);
+  return POST(rpcURL, heightAndAddrRequest(height, address), accountPath);
 }
 
 export async function AccountWithTxs(height, address, page) {
@@ -119,43 +138,47 @@ export async function AccountWithTxs(height, address, page) {
 }
 
 export function Params(height, _) {
-  return POST(heightRequest(height), paramsPath);
+  return POST(rpcURL, heightRequest(height), paramsPath);
 }
 
 export function Supply(height, _) {
-  return POST(heightRequest(height), supplyPath);
+  return POST(rpcURL, heightRequest(height), supplyPath);
 }
 
 export function Validator(height, address) {
-  return POST(heightAndAddrRequest(height, address), validatorPath);
+  return POST(rpcURL, heightAndAddrRequest(height, address), validatorPath);
 }
 
 export function BlockByHeight(height) {
-  return POST(heightRequest(height), blockByHeightPath);
+  return POST(rpcURL, heightRequest(height), blockByHeightPath);
 }
 
 export function BlockByHash(hash) {
-  return POST(hashRequest(hash), blockByHashPath);
+  return POST(rpcURL, hashRequest(hash), blockByHashPath);
 }
 
 export function TxByHash(hash) {
-  return POST(hashRequest(hash), txByHashPath);
+  return POST(rpcURL, hashRequest(hash), txByHashPath);
 }
 
 export function TransactionsBySender(page, sender) {
-  return POST(pageAddrReq(page, sender), txsBySender);
+  return POST(rpcURL, pageAddrReq(page, sender), txsBySender);
 }
 
 export function TransactionsByRec(page, rec) {
-  return POST(pageAddrReq(page, rec), txsByRec);
+  return POST(rpcURL, pageAddrReq(page, rec), txsByRec);
 }
 
 export function Pending(page, _) {
-  return POST(pageAddrReq(page, ""), pendingPath);
+  return POST(rpcURL, pageAddrReq(page, ""), pendingPath);
 }
 
 export function Orders(chain_id) {
-  return POST(heightAndIDRequest(0, chain_id), ordersPath);
+  return POST(rpcURL, heightAndIDRequest(0, chain_id), ordersPath);
+}
+
+export function Config() {
+  return GET(adminRPCURL, configPath)
 }
 
 // COMPONENT SPECIFIC API CALLS BELOW

--- a/cmd/rpc/web/explorer/components/cards.jsx
+++ b/cmd/rpc/web/explorer/components/cards.jsx
@@ -80,14 +80,14 @@ function getCardHeader(props, idx) {
 }
 
 // getCardSubHeader() returns the sub header of the card (right below the header)
-function getCardSubHeader(props, idx) {
+function getCardSubHeader(props, consensusDuration, idx) {
   const v = props.blocks;
   if (v.results.length === 0) {
     return "Loading";
   }
   switch (idx) {
     case 0:
-      return convertTime(v.results[0].block_header.time);
+      return convertTime(v.results[0].block_header.time-consensusDuration);
     case 1:
       return convertNumber(Number(props.supply.total) - Number(props.supply.staked), 1000, true) + " liquid";
     case 2:
@@ -144,14 +144,14 @@ function getCardNote(props, idx) {
 }
 
 // getCardFooter() returns the data for the footer of the card
-function getCardFooter(props, idx) {
+function getCardFooter(props, consensusDuration, idx) {
   const v = props.blocks;
   if (v.results.length === 0) {
     return "Loading";
   }
   switch (idx) {
     case 0:
-      return "Next block: " + addDate(v.results[0].block_header.time, v.results[0].meta.took);
+      return "Next block: " + addDate(v.results[0].block_header.time, consensusDuration);
     case 1:
       let s = "DAO pool supply: ";
       if (props.pool != null) {
@@ -200,6 +200,7 @@ function getCardOnClick(props, index) {
 // Cards() returns the main component
 export default function Cards(props) {
   const cardData = props.state.cardData;
+  const consensusDuration = props.state.consensusDuration;
   return (
     <Row sm={1} md={2} lg={4} className="g-4">
       {Array.from({ length: 4 }, (_, idx) => {
@@ -211,11 +212,11 @@ export default function Cards(props) {
                 <Card.Title className="card-title">{cardTitles[idx]}</Card.Title>
                 <h5>{getCardHeader(cardData, idx)}</h5>
                 <div className="d-flex justify-content-between mb-1">
-                  <Card.Text className="card-info-2 mb-2">{getCardSubHeader(cardData, idx)}</Card.Text>
+                  <Card.Text className="card-info-2 mb-2">{getCardSubHeader(cardData, consensusDuration, idx)}</Card.Text>
                   <Card.Text className="card-info-3">{getCardRightAligned(cardData, idx)}</Card.Text>
                 </div>
                 <div className="card-info-4 mb-3">{getCardNote(cardData, idx)}</div>
-                <Card.Footer className="card-footer">{getCardFooter(cardData, idx)}</Card.Footer>
+                <Card.Footer className="card-footer">{getCardFooter(cardData, consensusDuration, idx)}</Card.Footer>
               </Card.Body>
             </Card>
           </Col>

--- a/cmd/rpc/web/explorer/pages/index.js
+++ b/cmd/rpc/web/explorer/pages/index.js
@@ -5,7 +5,7 @@ import DetailModal from "@/components/modal";
 import Cards from "@/components/cards";
 import { useEffect, useState } from "react";
 import { Spinner, Toast, ToastContainer } from "react-bootstrap";
-import { getCardData, getTableData, getModalData } from "@/components/api";
+import { getCardData, getTableData, getModalData, Config } from "@/components/api";
 
 export default function Home() {
   const [state, setState] = useState({
@@ -15,6 +15,7 @@ export default function Home() {
     tablePage: 0,
     tableData: {},
     showToast: false,
+    consensusDuration: 0,
 
     sortColumn: null,
     sortDirection: "asc",
@@ -31,7 +32,7 @@ export default function Home() {
   });
 
   function getCardAndTableData(setLoading) {
-    Promise.allSettled([getTableData(state.tablePage, state.category, state.committee), getCardData()]).then(
+    Promise.allSettled([getTableData(state.tablePage, state.category, state.committee), getCardData(), Config()]).then(
       (values) => {
         let settledValues = [];
         for (const v of values) {
@@ -42,10 +43,14 @@ export default function Home() {
           settledValues.push(v.value);
         }
 
+        const consensusDuration = settledValues[2].ElectionTimeoutMS + settledValues[2].ElectionVoteTimeoutMS 
+          + settledValues[2].ProposeTimeoutMS + settledValues[2].ProposeVoteTimeoutMS + settledValues[2].PrecommitTimeoutMS 
+          + settledValues[2].PrecommitVoteTimeoutMS + settledValues[2].CommitTimeoutMS + settledValues[2].CommitProcessMS + settledValues[2].RoundInterruptTimeoutMS;
+
         if (setLoading) {
-          return setState({ ...state, loading: false, tableData: settledValues[0], cardData: settledValues[1] });
+          return setState({ ...state, loading: false, tableData: settledValues[0], cardData: settledValues[1], consensusDuration: consensusDuration });
         }
-        return setState({ ...state, tableData: settledValues[0], cardData: settledValues[1] });
+        return setState({ ...state, tableData: settledValues[0], cardData: settledValues[1], consensusDuration: consensusDuration });
       },
     );
   }


### PR DESCRIPTION
## Description
Fixes bug that Next Block Time shows when consensus starts and not when it ends

## Related Issues

Closes: #31  

## Changes Made
- Add possibility to do config requests in the explorer
- Add consensus duration as state for main page
- Add it to the time for next block time
- Substract it of block time

## Checklist
- [x] I have tested the changes locally and verified they work as intended.
- [x] I have appropriately titled my branch `issue-#<issue-number>`.
- [x] I have run re-built the web-wallet and/or block explorer (if applicable).
- [ ] I have updated documentation (if applicable).
- [ ] I have included tests for the changes (if applicable).

