### PR TITLE
Fix local transaction gossip issue

### DIFF
--- a/controller/p2p.go
+++ b/controller/p2p.go
@@ -98,12 +98,9 @@ func (c *Controller) Sync() {
 func (c *Controller) SendTxMsg(tx []byte) lib.ErrorI {
 	// create a transaction message object using the tx bytes and the chain id
 	msg := &lib.TxMessage{ChainId: c.Config.ChainId, Tx: tx}
-	// send it to self for de-duplication and awareness of self originated transactions
-	if err := c.P2P.SelfSend(c.PublicKey, Tx, msg); err != nil {
-		return err
-	}
-	// gossip to all the peers for the chain
-	return c.P2P.SendToPeers(Tx, msg)
+
+	// send transaction to controller for processing and gossip
+	return c.P2P.SelfSend(c.PublicKey, Tx, msg)
 }
 
 // SendCertificateResultsTx() originates and auto-sends a CertificateResultsTx after successfully leading a Consensus height


### PR DESCRIPTION


## Description
This fixes a bug where for every locally sent transaction, invalid transactions would still be sent and valid transactions would be sent twice.

## Related Issues
Closes: #92

## Changes Made
- Removed call to `P2P.SendToPeers()` from `Controller.SendTxMsg`

## Checklist
- [x] I have tested the changes locally and verified they work as intended.
- [x] I have appropriately titled my branch `issue-#<issue-number>`.
- [ ] I have run re-built the web-wallet and/or block explorer (if applicable).
- [ ] I have updated documentation (if applicable).
- [ ] I have included tests for the changes (if applicable).

## Additional Notes