### PR TITLE
Renaming Buy Orders to Lock Orders

### DIFF
--- a/.docker/volumes/node_1/genesis.json
+++ b/.docker/volumes/node_1/genesis.json
@@ -60,7 +60,7 @@
       "maxSlashPerCommittee": 15,
       "delegateRewardPercentage": 10,
       "buyDeadlineBlocks": 15,
-      "buyOrderFeeMultiplier": 2
+      "lockOrderFeeMultiplier": 2
     },
     "fee": {
       "sendFee": 10000,

--- a/.docker/volumes/node_2/genesis.json
+++ b/.docker/volumes/node_2/genesis.json
@@ -50,7 +50,7 @@
       "maxSlashPerCommittee": 15,
       "delegateRewardPercentage": 10,
       "buyDeadlineBlocks": 15,
-      "buyOrderFeeMultiplier": 2
+      "lockOrderFeeMultiplier": 2
     },
     "fee": {
       "sendFee": 10000,

--- a/.docker/volumes/node_3/genesis.json
+++ b/.docker/volumes/node_3/genesis.json
@@ -50,7 +50,7 @@
       "maxSlashPerCommittee": 15,
       "delegateRewardPercentage": 10,
       "buyDeadlineBlocks": 15,
-      "buyOrderFeeMultiplier": 2
+      "lockOrderFeeMultiplier": 2
     },
     "fee": {
       "sendFee": 10000,

--- a/cmd/cli/admin.go
+++ b/cmd/cli/admin.go
@@ -53,7 +53,7 @@ func init() {
 	adminCmd.AddCommand(txCreateOrderCmd)
 	adminCmd.AddCommand(txEditOrderCmd)
 	adminCmd.AddCommand(txDeleteOrderCmd)
-	adminCmd.AddCommand(txBuyOrderCmd)
+	adminCmd.AddCommand(txLockOrderCmd)
 	adminCmd.AddCommand(txStartPollCmd)
 	adminCmd.AddCommand(approveTxVotePoll)
 	adminCmd.AddCommand(rejectTxVotePoll)
@@ -241,12 +241,12 @@ var (
 		},
 	}
 
-	txBuyOrderCmd = &cobra.Command{
-		Use:   "tx-buy-order <address or nickname> <canopy-receive-address> <order-id> --fee=10000 --simulate=true",
-		Short: "buy an existing sell order - use the simulate flag to generate json only",
+	txLockOrderCmd = &cobra.Command{
+		Use:   "tx-lock-order <address or nickname> <canopy-receive-address> <order-id> --fee=10000 --simulate=true",
+		Short: "lock an existing sell order - use the simulate flag to generate json only",
 		Args:  cobra.MinimumNArgs(3),
 		Run: func(cmd *cobra.Command, args []string) {
-			writeTxResultToConsole(client.TxBuyOrder(argGetAddrOrNickname(args[0]), argGetAddr(args[1]), uint64(argToInt(args[2])), getPassword(), !sim, fee))
+			writeTxResultToConsole(client.TxLockOrder(argGetAddrOrNickname(args[0]), argGetAddr(args[1]), uint64(argToInt(args[2])), getPassword(), !sim, fee))
 		},
 	}
 

--- a/cmd/rpc/client.go
+++ b/cmd/rpc/client.go
@@ -629,7 +629,7 @@ func (c *Client) TxDeleteOrder(from AddrOrNickname, orderId, chainId uint64,
 	return c.transactionRequest(TxDeleteOrderRouteName, txReq)
 }
 
-func (c *Client) TxBuyOrder(from AddrOrNickname, receiveAddress string, orderId uint64,
+func (c *Client) TxLockOrder(from AddrOrNickname, receiveAddress string, orderId uint64,
 	pwd string, submit bool, optFee uint64) (hash *string, tx json.RawMessage, e lib.ErrorI) {
 	receiveHex, err := lib.NewHexBytesFromString(receiveAddress)
 	if err != nil {
@@ -646,7 +646,7 @@ func (c *Client) TxBuyOrder(from AddrOrNickname, receiveAddress string, orderId 
 	if err != nil {
 		return nil, nil, err
 	}
-	return c.transactionRequest(TxBuyOrderRouteName, txReq)
+	return c.transactionRequest(TxLockOrderRouteName, txReq)
 }
 
 func (c *Client) TxStartPoll(from AddrOrNickname, pollJSON json.RawMessage,

--- a/cmd/rpc/web/wallet/components/account.jsx
+++ b/cmd/rpc/web/wallet/components/account.jsx
@@ -2,7 +2,7 @@ import {
     KeystoreGet,
     KeystoreImport,
     KeystoreNew,
-    TxBuyOrder,
+    TxLockOrder,
     TxCreateOrder,
     TxDeleteOrder,
     TxEditOrder,
@@ -30,7 +30,7 @@ import {
 } from "@/components/util";
 import { KeystoreContext } from "@/pages";
 import {
-    BuyIcon,
+    LockIcon,
     CopyIcon,
     EditOrderIcon,
     EditStakeIcon,
@@ -62,7 +62,7 @@ const transactionButtons = [
     { title: "PAUSE", name: "pause", src: PauseIcon },
     { title: "PLAY", name: "unpause", src: UnpauseIcon },
     { title: "SWAP", name: "create_order", src: SwapIcon },
-    { title: "LOCK", name: "buy_order", src: BuyIcon },
+    { title: "LOCK", name: "lock_order", src: LockIcon },
     { title: "REPRICE", name: "edit_order", src: EditOrderIcon },
     { title: "VOID", name: "delete_order", src: DeleteOrderIcon },
 ];
@@ -294,8 +294,8 @@ export default function Accounts({ keygroup, account, validator, setActiveKey })
                         r.password,
                         submit,
                     ),
-                buy_order: () =>
-                    TxBuyOrder(r.sender, r.receiveAddress, numberFromCommas(r.orderId), fee, r.password, submit),
+                lock_order: () =>
+                    TxLockOrder(r.sender, r.receiveAddress, numberFromCommas(r.orderId), fee, r.password, submit),
                 edit_order: () =>
                     TxEditOrder(
                         r.sender,

--- a/cmd/rpc/web/wallet/components/api.js
+++ b/cmd/rpc/web/wallet/components/api.js
@@ -33,7 +33,7 @@ const txUnpausePath = "/v1/admin/tx-unpause";
 const txChangeParamPath = "/v1/admin/tx-change-param";
 const txDaoTransfer = "/v1/admin/tx-dao-transfer";
 const txCreateOrder = "/v1/admin/tx-create-order";
-const txBuyOrder = "/v1/admin/tx-buy-order";
+const txLockOrder = "/v1/admin/tx-lock-order";
 const txEditOrder = "/v1/admin/tx-edit-order";
 const txDeleteOrder = "/v1/admin/tx-delete-order";
 const txStartPoll = "/v1/admin/tx-start-poll";
@@ -187,7 +187,7 @@ function newSellOrderTxRequest(
   });
 }
 
-function newBuyOrderTxRequest(address, receiveAddress, orderId, fee, submit, password) {
+function newLockOrderTxRequest(address, receiveAddress, orderId, fee, submit, password) {
   return JSON.stringify({
     address: address,
     receiveAddress: receiveAddress,
@@ -517,11 +517,11 @@ export async function TxCreateOrder(
   );
 }
 
-export async function TxBuyOrder(address, receiveAddress, orderId, fee, password, submit) {
+export async function TxLockOrder(address, receiveAddress, orderId, fee, password, submit) {
   return POST(
     adminRPCURL,
-    txBuyOrder,
-    newBuyOrderTxRequest(address, receiveAddress, Number(orderId), Number(fee), submit, password),
+    txLockOrder,
+    newLockOrderTxRequest(address, receiveAddress, Number(orderId), Number(fee), submit, password),
   );
 }
 

--- a/cmd/rpc/web/wallet/components/svg_icons.jsx
+++ b/cmd/rpc/web/wallet/components/svg_icons.jsx
@@ -1,6 +1,6 @@
 // SVG map so that components are reusable
 
-const BuyIcon = () => {
+const LockIcon = () => {
     return (
         <svg xmlns="http://www.w3.org/2000/svg" width="80" height="80" className="bi bi-check-circle" viewBox="0 0 16 16">
             <path d="M8 15A7 7 0 1 1 8 1a7 7 0 0 1 0 14m0 1A8 8 0 1 0 8 0a8 8 0 0 0 0 16"/>
@@ -278,7 +278,7 @@ const WalletLogoIcon = () => {
 }
 
 export {
-    BuyIcon,
+    LockIcon,
     CopyIcon,
     DeleteOrderIcon,
     DiscordIcon,

--- a/cmd/rpc/web/wallet/components/util.js
+++ b/cmd/rpc/web/wallet/components/util.js
@@ -315,7 +315,7 @@ export function getFormInputs(type, keyGroup, account, validator, keyStore) {
             ];
         case "create_order":
             return [a.account, a.chainId, a.amount, a.receiveAmount, a.receiveAddress, a.memo, a.fee, a.password];
-        case "buy_order":
+        case "lock_order":
             return [a.account, a.buyersReceiveAddress, a.orderId, a.fee, a.password];
         case "edit_order":
             return [

--- a/controller/result.go
+++ b/controller/result.go
@@ -2,10 +2,11 @@ package controller
 
 import (
 	"bytes"
+	"slices"
+
 	"github.com/canopy-network/canopy/bft"
 	"github.com/canopy-network/canopy/fsm/types"
 	"github.com/canopy-network/canopy/lib"
-	"slices"
 )
 
 /* This file implements the 'Certificate Result' logic which ensures the */
@@ -173,8 +174,8 @@ func (c *Controller) addPaymentPercent(toAdd *lib.LotteryWinner, results *lib.Ce
 
 // HandleSwaps() handles the 'buy' side of the sell orders
 func (c *Controller) HandleSwaps(blockResult *lib.BlockResult, results *lib.CertificateResult, rootChainHeight uint64) {
-	// parse the last block for 'buy orders'
-	buyOrders := c.FSM.ParseBuyOrders(blockResult)
+	// parse the last block for 'lock orders'
+	lockOrders := c.FSM.ParseLockOrders(blockResult)
 	// get orders from the root-Chain
 	orders, err := c.LoadRootChainOrderBook(rootChainHeight)
 	// if an error occurred while loading the orders
@@ -186,7 +187,7 @@ func (c *Controller) HandleSwaps(blockResult *lib.BlockResult, results *lib.Cert
 	closeOrders, resetOrders := c.FSM.ProcessRootChainOrderBook(orders, blockResult)
 	// add the orders to the certificate result - truncating the 'lock orders' for defensive spam protection
 	results.Orders = &lib.Orders{
-		BuyOrders:   lib.TruncateSlice(buyOrders, 1000),
+		LockOrders:  lib.TruncateSlice(lockOrders, 1000),
 		ResetOrders: resetOrders,
 		CloseOrders: closeOrders,
 	}

--- a/fsm/message_test.go
+++ b/fsm/message_test.go
@@ -1872,7 +1872,7 @@ func TestHandleMessageCertificateResults(t *testing.T) {
 			},
 		},
 		Orders: &lib.Orders{
-			BuyOrders: []*lib.BuyOrder{{
+			LockOrders: []*lib.LockOrder{{
 				OrderId:             0,
 				BuyerSendAddress:    newTestAddressBytes(t),
 				BuyerReceiveAddress: newTestAddressBytes(t),
@@ -2057,16 +2057,16 @@ func TestHandleMessageCertificateResults(t *testing.T) {
 				require.ErrorContains(t, err, test.error)
 				return
 			}
-			// 1) validate the 'buy order'
+			// 1) validate the 'lock order'
 			func() {
 				order, e := sm.GetOrder(0, lib.CanopyChainId+1)
 				require.NoError(t, e)
-				// convenience variable for buy order
-				buyOrder := test.msg.Qc.Results.Orders.BuyOrders[0]
+				// convenience variable for lock order
+				lockOrder := test.msg.Qc.Results.Orders.LockOrders[0]
 				// validate the receipt address was set
-				require.Equal(t, buyOrder.BuyerReceiveAddress, order.BuyerReceiveAddress)
+				require.Equal(t, lockOrder.BuyerReceiveAddress, order.BuyerReceiveAddress)
 				// validate the deadline was set
-				require.Equal(t, buyOrder.BuyerChainDeadline, order.BuyerChainDeadline)
+				require.Equal(t, lockOrder.BuyerChainDeadline, order.BuyerChainDeadline)
 			}()
 			// 2) validate the 'reset order'
 			func() {

--- a/fsm/swap_test.go
+++ b/fsm/swap_test.go
@@ -19,8 +19,8 @@ func TestHandleCommitteeSwaps(t *testing.T) {
 		notFound        bool
 	}{
 		{
-			name:   "buy order already accepted",
-			detail: "the buy order cannot be claimed as its already reserved",
+			name:   "lock order already accepted",
+			detail: "the lock order cannot be claimed as its already reserved",
 			preset: []*lib.SellOrder{
 				{
 					Committee:           lib.CanopyChainId,
@@ -31,7 +31,7 @@ func TestHandleCommitteeSwaps(t *testing.T) {
 				},
 			},
 			orders: &lib.Orders{
-				BuyOrders: []*lib.BuyOrder{
+				LockOrders: []*lib.LockOrder{
 					{
 						OrderId:             0,
 						BuyerReceiveAddress: newTestAddressBytes(t, 1),
@@ -100,7 +100,7 @@ func TestHandleCommitteeSwaps(t *testing.T) {
 				},
 			},
 			orders: &lib.Orders{
-				BuyOrders: []*lib.BuyOrder{
+				LockOrders: []*lib.LockOrder{
 					{
 						OrderId:             0,
 						BuyerReceiveAddress: newTestAddressBytes(t, 1),
@@ -127,18 +127,18 @@ func TestHandleCommitteeSwaps(t *testing.T) {
 			}
 			// execute the function call
 			sm.HandleCommitteeSwaps(test.orders, lib.CanopyChainId)
-			// validate the buy orders
-			for _, buyOrder := range test.orders.BuyOrders {
+			// validate the lock orders
+			for _, lockOrder := range test.orders.LockOrders {
 				// get the order
-				order, e := sm.GetOrder(buyOrder.OrderId, lib.CanopyChainId)
+				order, e := sm.GetOrder(lockOrder.OrderId, lib.CanopyChainId)
 				require.NoError(t, e)
-				// if the buy order is already accepted
+				// if the lock order is already accepted
 				if test.alreadyAccepted {
-					require.NotEqual(t, buyOrder.BuyerReceiveAddress, order.BuyerReceiveAddress)
+					require.NotEqual(t, lockOrder.BuyerReceiveAddress, order.BuyerReceiveAddress)
 				} else {
 					// validate the update of the 'buy' fields
-					require.Equal(t, buyOrder.BuyerReceiveAddress, order.BuyerReceiveAddress)
-					require.Equal(t, buyOrder.BuyerChainDeadline, order.BuyerChainDeadline)
+					require.Equal(t, lockOrder.BuyerReceiveAddress, order.BuyerReceiveAddress)
+					require.Equal(t, lockOrder.BuyerChainDeadline, order.BuyerChainDeadline)
 				}
 			}
 			// validate the reset orders
@@ -347,18 +347,18 @@ func TestEditOrder(t *testing.T) {
 	}
 }
 
-func TestBuyOrder(t *testing.T) {
+func TestLockOrder(t *testing.T) {
 	tests := []struct {
 		name   string
 		detail string
 		preset *lib.SellOrder
-		order  *lib.BuyOrder
+		order  *lib.LockOrder
 		error  string
 	}{
 		{
-			name:   "buy order not found",
-			detail: "the buy order cannot be found",
-			order: &lib.BuyOrder{
+			name:   "lock order not found",
+			detail: "the lock order cannot be found",
+			order: &lib.LockOrder{
 
 				OrderId:             0,
 				BuyerReceiveAddress: newTestAddressBytes(t, 1),
@@ -367,8 +367,8 @@ func TestBuyOrder(t *testing.T) {
 			error: "not found",
 		},
 		{
-			name:   "buy order already accepted",
-			detail: "the buy order cannot be claimed as its already reserved",
+			name:   "lock order already accepted",
+			detail: "the lock order cannot be claimed as its already reserved",
 			preset: &lib.SellOrder{
 				Committee:           lib.CanopyChainId,
 				AmountForSale:       100,
@@ -376,7 +376,7 @@ func TestBuyOrder(t *testing.T) {
 				BuyerReceiveAddress: newTestAddressBytes(t),
 				SellersSendAddress:  newTestAddressBytes(t),
 			},
-			order: &lib.BuyOrder{
+			order: &lib.LockOrder{
 
 				OrderId:             0,
 				BuyerReceiveAddress: newTestAddressBytes(t, 1),
@@ -385,15 +385,15 @@ func TestBuyOrder(t *testing.T) {
 			error: "order already accepted",
 		},
 		{
-			name:   "buy order",
-			detail: "successful buy order without error",
+			name:   "lock order",
+			detail: "successful lock order without error",
 			preset: &lib.SellOrder{
 				Committee:          lib.CanopyChainId,
 				AmountForSale:      100,
 				RequestedAmount:    100,
 				SellersSendAddress: newTestAddressBytes(t),
 			},
-			order: &lib.BuyOrder{
+			order: &lib.LockOrder{
 				OrderId:             0,
 				BuyerReceiveAddress: newTestAddressBytes(t, 1),
 				BuyerChainDeadline:  100,
@@ -410,7 +410,7 @@ func TestBuyOrder(t *testing.T) {
 				require.NoError(t, err)
 			}
 			// execute the function call
-			err := sm.BuyOrder(test.order, lib.CanopyChainId)
+			err := sm.LockOrder(test.order, lib.CanopyChainId)
 			// validate the expected error
 			require.Equal(t, test.error != "", err != nil, err)
 			if err != nil {
@@ -499,7 +499,7 @@ func TestCloseOrder(t *testing.T) {
 				SellersSendAddress: newTestAddressBytes(t),
 			},
 			order: 0,
-			error: "buy order invalid",
+			error: "lock order invalid",
 		},
 		{
 			name:   "close order",

--- a/fsm/types/error.go
+++ b/fsm/types/error.go
@@ -272,8 +272,8 @@ func ErrInvalidOrders() lib.ErrorI {
 	return lib.NewError(lib.CodeInvalidOrders, lib.StateMachineModule, "orders are invalid")
 }
 
-func ErrInvalidBuyOrder() lib.ErrorI {
-	return lib.NewError(lib.CodeInvalidBuyOrder, lib.StateMachineModule, "buy order invalid")
+func ErrInvalidLockOrder() lib.ErrorI {
+	return lib.NewError(lib.CodeInvalidLockOrder, lib.StateMachineModule, "lock order invalid")
 }
 
 func InvalidSellOrder() lib.ErrorI {
@@ -288,12 +288,12 @@ func ErrInvalidResetOrder() lib.ErrorI {
 	return lib.NewError(lib.CodeInvalidResetOrder, lib.StateMachineModule, "reset order invalid")
 }
 
-func ErrDuplicateBuyOrder() lib.ErrorI {
-	return lib.NewError(lib.CodeDuplicateBuyOrder, lib.StateMachineModule, "buy order is a duplicate")
+func ErrDuplicateLockOrder() lib.ErrorI {
+	return lib.NewError(lib.CodeDuplicateLockOrder, lib.StateMachineModule, "lock order is a duplicate")
 }
 
 func ErrInvalidBuyerDeadline() lib.ErrorI {
-	return lib.NewError(lib.CodeInvalidBuyerDeadline, lib.StateMachineModule, "buy order deadline height is invalid")
+	return lib.NewError(lib.CodeInvalidBuyerDeadline, lib.StateMachineModule, "lock order deadline height is invalid")
 }
 
 func ErrInvalidCheckpoint() lib.ErrorI {

--- a/fsm/types/gov.go
+++ b/fsm/types/gov.go
@@ -69,7 +69,7 @@ func DefaultParams() *Params {
 			MaxSlashPerCommittee:               15,
 			DelegateRewardPercentage:           10,
 			BuyDeadlineBlocks:                  15,
-			BuyOrderFeeMultiplier:              2,
+			LockOrderFeeMultiplier:              2,
 		},
 		Fee: &FeeParams{
 			SendFee:               10000,
@@ -228,7 +228,7 @@ const (
 	ParamMaxSlashPerCommittee               = "maxSlashPerCommittee"               // the maximum validator slash per committee per block
 	ParamDelegateRewardPercentage           = "delegateRewardPercentage"           // the percentage of the block reward that is awarded to the delegates
 	ParamBuyDeadlineBlocks                  = "buyDeadlineBlocks"                  // the amount of blocks a 'buyer' has to complete an order they reserved
-	ParamBuyOrderFeeMultiplier              = "buyOrderFeeMultiplier"              // the fee multiplier of the 'send' fee that is required to execute a buy order
+	ParamLockOrderFeeMultiplier              = "lockOrderFeeMultiplier"              // the fee multiplier of the 'send' fee that is required to execute a lock order
 )
 
 // Check() validates the Validator params
@@ -275,8 +275,8 @@ func (x *ValidatorParams) Check() lib.ErrorI {
 	if x.BuyDeadlineBlocks == 0 {
 		return ErrInvalidParam(ParamBuyDeadlineBlocks)
 	}
-	if x.BuyOrderFeeMultiplier == 0 {
-		return ErrInvalidParam(ParamBuyOrderFeeMultiplier)
+	if x.LockOrderFeeMultiplier == 0 {
+		return ErrInvalidParam(ParamLockOrderFeeMultiplier)
 	}
 	return nil
 }
@@ -314,8 +314,8 @@ func (x *ValidatorParams) SetUint64(paramName string, value uint64) lib.ErrorI {
 		x.DelegateRewardPercentage = value
 	case ParamBuyDeadlineBlocks:
 		x.BuyDeadlineBlocks = value
-	case ParamBuyOrderFeeMultiplier:
-		x.BuyOrderFeeMultiplier = value
+	case ParamLockOrderFeeMultiplier:
+		x.LockOrderFeeMultiplier = value
 	default:
 		return ErrUnknownParam()
 	}

--- a/fsm/types/gov.pb.go
+++ b/fsm/types/gov.pb.go
@@ -360,8 +360,8 @@ type ValidatorParams struct {
 	DelegateRewardPercentage uint64 `protobuf:"varint,14,opt,name=delegate_reward_percentage,json=delegateRewardPercentage,proto3" json:"delegateRewardPercentage"` // @gotags: json:"delegateRewardPercentage"
 	// buy_deadline_blocks: amount of blocks a 'buyer' has to complete an order they 'reserved'
 	BuyDeadlineBlocks uint64 `protobuf:"varint,15,opt,name=buy_deadline_blocks,json=buyDeadlineBlocks,proto3" json:"buyDeadlineBlocks"` // @gotags: json:"buyDeadlineBlocks"
-	// buy_order_fee_multiplier: the fee multiplier of the 'send' fee that is required to execute a buy order
-	BuyOrderFeeMultiplier uint64 `protobuf:"varint,16,opt,name=buy_order_fee_multiplier,json=buyOrderFeeMultiplier,proto3" json:"buyOrderFeeMultiplier"` // @gotags: json:"buyOrderFeeMultiplier"
+	// lock_order_fee_multiplier: the fee multiplier of the 'send' fee that is required to execute a lock order
+	LockOrderFeeMultiplier uint64 `protobuf:"varint,16,opt,name=lock_order_fee_multiplier,json=lockOrderFeeMultiplier,proto3" json:"lockOrderFeeMultiplier"` // @gotags: json:"lockOrderFeeMultiplier"
 }
 
 func (x *ValidatorParams) Reset() {
@@ -501,9 +501,9 @@ func (x *ValidatorParams) GetBuyDeadlineBlocks() uint64 {
 	return 0
 }
 
-func (x *ValidatorParams) GetBuyOrderFeeMultiplier() uint64 {
+func (x *ValidatorParams) GetLockOrderFeeMultiplier() uint64 {
 	if x != nil {
-		return x.BuyOrderFeeMultiplier
+		return x.LockOrderFeeMultiplier
 	}
 	return 0
 }

--- a/fsm/types/message.go
+++ b/fsm/types/message.go
@@ -782,17 +782,17 @@ func checkStartEndHeight(proposal GovProposal) lib.ErrorI {
 func checkOrders(orders *lib.Orders) lib.ErrorI {
 	if orders != nil {
 		deDupe := lib.NewDeDuplicator[uint64]()
-		for _, buyOrder := range orders.BuyOrders {
-			if buyOrder == nil {
-				return ErrInvalidBuyOrder()
+		for _, lockOrder := range orders.LockOrders {
+			if lockOrder == nil {
+				return ErrInvalidLockOrder()
 			}
-			if found := deDupe.Found(buyOrder.OrderId); found {
-				return ErrDuplicateBuyOrder()
+			if found := deDupe.Found(lockOrder.OrderId); found {
+				return ErrDuplicateLockOrder()
 			}
-			if err := checkAddress(buyOrder.BuyerReceiveAddress); err != nil {
+			if err := checkAddress(lockOrder.BuyerReceiveAddress); err != nil {
 				return err
 			}
-			if buyOrder.BuyerChainDeadline == 0 {
+			if lockOrder.BuyerChainDeadline == 0 {
 				return ErrInvalidBuyerDeadline()
 			}
 		}

--- a/fsm/types/transaction.go
+++ b/fsm/types/transaction.go
@@ -142,8 +142,8 @@ func NewDeleteOrderTx(from crypto.PrivateKeyI, orderId, committeeId uint64, netw
 	}, networkId, chainId, fee, height, memo)
 }
 
-// NewBuyOrderTx() reserves a sell order using a send-tx and the memo field
-func NewBuyOrderTx(from crypto.PrivateKeyI, order lib.BuyOrder, networkId, chainId, fee, height uint64) (lib.TransactionI, lib.ErrorI) {
+// NewLockOrderTx() reserves a sell order using a send-tx and the memo field
+func NewLockOrderTx(from crypto.PrivateKeyI, order lib.LockOrder, networkId, chainId, fee, height uint64) (lib.TransactionI, lib.ErrorI) {
 	jsonBytes, err := lib.MarshalJSON(order)
 	if err != nil {
 		return nil, err

--- a/lib/.proto/certificate.proto
+++ b/lib/.proto/certificate.proto
@@ -79,9 +79,9 @@ message SlashRecipients {
 // The committee monitors the 3rd party chain for actions such as intent to buy, funds sent,
 // and funds not sent, and communicates these states to the Canopy chain
 message Orders {
-  // buy_orders: a list of actions where a buyer expresses an intent to purchase an order,
+  // lock_orders: a list of actions where a buyer expresses an intent to purchase an order,
   // often referred to as 'claiming' the order
-  repeated BuyOrder buy_orders = 1; // @gotags: json:"buyOrders"
+  repeated LockOrder lock_orders = 1; // @gotags: json:"buyOrders"
   // reset_orders: a list of orders where no funds were sent before the deadline,
   // signaling to Canopy to 'un-claim' the order
   repeated uint64 reset_orders = 2; // @gotags: json:"resetOrders"
@@ -90,8 +90,8 @@ message Orders {
   repeated uint64 close_orders = 3; // @gotags: json:"closeOrders"
 }
 
-// BuyOrder is a buyer expressing an intent to purchase an order, often referred to as 'claiming' the order
-message BuyOrder {
+// LockOrder is a buyer expressing an intent to purchase an order, often referred to as 'claiming' the order
+message LockOrder {
   // order_id: is the number id that is unique to this committee to identify the order
   uint64 order_id = 1; // @gotags: json:"orderID"
   // buyer_receive_address: the Canopy address where the tokens may be received

--- a/lib/.proto/certificate.proto
+++ b/lib/.proto/certificate.proto
@@ -81,7 +81,7 @@ message SlashRecipients {
 message Orders {
   // lock_orders: a list of actions where a buyer expresses an intent to purchase an order,
   // often referred to as 'claiming' the order
-  repeated LockOrder lock_orders = 1; // @gotags: json:"buyOrders"
+  repeated LockOrder lock_orders = 1; // @gotags: json:"lockOrders"
   // reset_orders: a list of orders where no funds were sent before the deadline,
   // signaling to Canopy to 'un-claim' the order
   repeated uint64 reset_orders = 2; // @gotags: json:"resetOrders"

--- a/lib/.proto/gov.proto
+++ b/lib/.proto/gov.proto
@@ -118,8 +118,8 @@ message ValidatorParams {
   uint64 delegate_reward_percentage = 14; // @gotags: json:"delegateRewardPercentage"
   // buy_deadline_blocks: amount of blocks a 'buyer' has to complete an order they 'reserved'
   uint64 buy_deadline_blocks = 15; // @gotags: json:"buyDeadlineBlocks"
-  // buy_order_fee_multiplier: the fee multiplier of the 'send' fee that is required to execute a buy order
-  uint64 buy_order_fee_multiplier = 16; // @gotags: json:"buyOrderFeeMultiplier"
+  // lock_order_fee_multiplier: the fee multiplier of the 'send' fee that is required to execute a lock order
+  uint64 lock_order_fee_multiplier = 16; // @gotags: json:"lockOrderFeeMultiplier"
 }
 
 // FeeParams is the parameter space that defines various amounts for transaction fees

--- a/lib/certificate.go
+++ b/lib/certificate.go
@@ -697,7 +697,7 @@ func (x *LockOrder) Equals(y *LockOrder) bool {
 		// exit with 'equal'
 		return true
 	}
-	// if either of the buy orders are empty
+	// if either of the lock orders are empty
 	if x == nil || y == nil {
 		// exit with 'unequal'
 		return false
@@ -745,7 +745,7 @@ func (x LockOrder) MarshalJSON() ([]byte, error) {
 	})
 }
 
-// UnmarshalJSON() implements the json.Unmarshaler interface for BuyOrder
+// UnmarshalJSON() implements the json.Unmarshaler interface for LockOrder
 func (x *LockOrder) UnmarshalJSON(jsonBytes []byte) (err error) {
 	// create a new json object reference to ensure a non nil result
 	j := new(lockOrderJSON)

--- a/lib/certificate.go
+++ b/lib/certificate.go
@@ -609,20 +609,20 @@ func (x *Orders) CheckBasic() (err ErrorI) {
 		// exit with no error
 		return
 	}
-	// for each buy order
-	for _, buy := range x.BuyOrders {
-		// if the buy order is empty
-		if buy == nil {
+	// for each lock order
+	for _, lock := range x.LockOrders {
+		// if the lock order is empty
+		if lock == nil {
 			// exit with empty error
-			return ErrNilBuyOrder()
+			return ErrNilLockOrder()
 		}
 		// ensure the sending address actually has some bytes
-		if len(buy.BuyerSendAddress) == 0 {
+		if len(lock.BuyerSendAddress) == 0 {
 			// exit with address error
 			return ErrInvalidBuyerSendAddress()
 		}
 		// ensure the receive address is exactly 20 bytes
-		if len(buy.BuyerReceiveAddress) != crypto.AddressSize {
+		if len(lock.BuyerReceiveAddress) != crypto.AddressSize {
 			// exit with address error
 			return ErrInvalidBuyerReceiveAddress()
 		}
@@ -673,15 +673,15 @@ func (x *Orders) Equals(y *Orders) bool {
 		// exit with 'unequal'
 		return false
 	}
-	// if the buy orders lists are not equal size
-	if len(x.BuyOrders) != len(y.BuyOrders) {
+	// if the lock orders lists are not equal size
+	if len(x.LockOrders) != len(y.LockOrders) {
 		// exit with 'unequal'
 		return false
 	}
-	// for each buy order
-	for i, buyOrder := range x.BuyOrders {
-		// if the individual buy orders are unequal
-		if !buyOrder.Equals(y.BuyOrders[i]) {
+	// for each lock order
+	for i, lockOrder := range x.LockOrders {
+		// if the individual lock orders are unequal
+		if !lockOrder.Equals(y.LockOrders[i]) {
 			// exit with 'unequal'
 			return false
 		}
@@ -690,9 +690,9 @@ func (x *Orders) Equals(y *Orders) bool {
 	return true
 }
 
-// Equals() compares two BuyOrders for equality
-func (x *BuyOrder) Equals(y *BuyOrder) bool {
-	// if both the buy orders are empty
+// Equals() compares two LockOrders for equality
+func (x *LockOrder) Equals(y *LockOrder) bool {
+	// if both the lock orders are empty
 	if x == nil && y == nil {
 		// exit with 'equal'
 		return true
@@ -721,8 +721,8 @@ func (x *BuyOrder) Equals(y *BuyOrder) bool {
 	return x.BuyerChainDeadline == y.BuyerChainDeadline
 }
 
-// buyOrderJSON implements the json.Marshaller & json.Unmarshaler interfaces for BuyOrder
-type buyOrderJSON struct {
+// lockOrderJSON implements the json.Marshaller & json.Unmarshaler interfaces for LockOrder
+type lockOrderJSON struct {
 	// order_id: is the number id that is unique to this committee to identify the order
 	OrderId uint64 `json:"order_id,omitempty"`
 	// buyers_send_address: the Canopy address where the tokens may be received
@@ -734,10 +734,10 @@ type buyOrderJSON struct {
 	BuyerChainDeadline uint64 `json:"buyer_chain_deadline,omitempty"`
 }
 
-// MarshalJSON() implements the json.Marshaller interface for BuyOrder
-func (x BuyOrder) MarshalJSON() ([]byte, error) {
-	// convert the buy order to json bytes using the json object
-	return json.Marshal(&buyOrderJSON{
+// MarshalJSON() implements the json.Marshaller interface for LockOrder
+func (x LockOrder) MarshalJSON() ([]byte, error) {
+	// convert the lock order to json bytes using the json object
+	return json.Marshal(&lockOrderJSON{
 		OrderId:             x.OrderId,
 		BuyersSendAddress:   x.BuyerSendAddress,
 		BuyerReceiveAddress: x.BuyerReceiveAddress,
@@ -746,16 +746,16 @@ func (x BuyOrder) MarshalJSON() ([]byte, error) {
 }
 
 // UnmarshalJSON() implements the json.Unmarshaler interface for BuyOrder
-func (x *BuyOrder) UnmarshalJSON(jsonBytes []byte) (err error) {
+func (x *LockOrder) UnmarshalJSON(jsonBytes []byte) (err error) {
 	// create a new json object reference to ensure a non nil result
-	j := new(buyOrderJSON)
+	j := new(lockOrderJSON)
 	// populate the json object ref with json bytes
 	if err = json.Unmarshal(jsonBytes, j); err != nil {
 		// exit with error
 		return
 	}
 	// populate the underlying structure using the json object
-	*x = BuyOrder{
+	*x = LockOrder{
 		OrderId:             j.OrderId,
 		BuyerReceiveAddress: j.BuyerReceiveAddress,
 		BuyerSendAddress:    j.BuyersSendAddress,

--- a/lib/certificate.pb.go
+++ b/lib/certificate.pb.go
@@ -348,9 +348,9 @@ type Orders struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	// buy_orders: a list of actions where a buyer expresses an intent to purchase an order,
+	// lock_orders: a list of actions where a buyer expresses an intent to purchase an order,
 	// often referred to as 'claiming' the order
-	BuyOrders []*BuyOrder `protobuf:"bytes,1,rep,name=buy_orders,json=buyOrders,proto3" json:"buyOrders"` // @gotags: json:"buyOrders"
+	LockOrders []*LockOrder `protobuf:"bytes,1,rep,name=lock_orders,json=lockOrders,proto3" json:"lockOrders"` // @gotags: json:"lockOrders"
 	// reset_orders: a list of orders where no funds were sent before the deadline,
 	// signaling to Canopy to 'un-claim' the order
 	ResetOrders []uint64 `protobuf:"varint,2,rep,packed,name=reset_orders,json=resetOrders,proto3" json:"resetOrders"` // @gotags: json:"resetOrders"
@@ -391,9 +391,9 @@ func (*Orders) Descriptor() ([]byte, []int) {
 	return file_certificate_proto_rawDescGZIP(), []int{4}
 }
 
-func (x *Orders) GetBuyOrders() []*BuyOrder {
+func (x *Orders) GetLockOrders() []*LockOrder {
 	if x != nil {
-		return x.BuyOrders
+		return x.LockOrders
 	}
 	return nil
 }
@@ -412,8 +412,8 @@ func (x *Orders) GetCloseOrders() []uint64 {
 	return nil
 }
 
-// BuyOrder is a buyer expressing an intent to purchase an order, often referred to as 'claiming' the order
-type BuyOrder struct {
+// LockOrder is a buyer expressing an intent to purchase an order, often referred to as 'claiming' the order
+type LockOrder struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
@@ -429,8 +429,8 @@ type BuyOrder struct {
 	BuyerChainDeadline uint64 `protobuf:"varint,4,opt,name=buyer_chain_deadline,json=buyerChainDeadline,proto3" json:"buyerChainDeadline"` // @gotags: json:"buyerChainDeadline"
 }
 
-func (x *BuyOrder) Reset() {
-	*x = BuyOrder{}
+func (x *LockOrder) Reset() {
+	*x = LockOrder{}
 	if protoimpl.UnsafeEnabled {
 		mi := &file_certificate_proto_msgTypes[5]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
@@ -438,13 +438,13 @@ func (x *BuyOrder) Reset() {
 	}
 }
 
-func (x *BuyOrder) String() string {
+func (x *LockOrder) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
-func (*BuyOrder) ProtoMessage() {}
+func (*LockOrder) ProtoMessage() {}
 
-func (x *BuyOrder) ProtoReflect() protoreflect.Message {
+func (x *LockOrder) ProtoReflect() protoreflect.Message {
 	mi := &file_certificate_proto_msgTypes[5]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
@@ -456,33 +456,33 @@ func (x *BuyOrder) ProtoReflect() protoreflect.Message {
 	return mi.MessageOf(x)
 }
 
-// Deprecated: Use BuyOrder.ProtoReflect.Descriptor instead.
-func (*BuyOrder) Descriptor() ([]byte, []int) {
+// Deprecated: Use LockOrder.ProtoReflect.Descriptor instead.
+func (*LockOrder) Descriptor() ([]byte, []int) {
 	return file_certificate_proto_rawDescGZIP(), []int{5}
 }
 
-func (x *BuyOrder) GetOrderId() uint64 {
+func (x *LockOrder) GetOrderId() uint64 {
 	if x != nil {
 		return x.OrderId
 	}
 	return 0
 }
 
-func (x *BuyOrder) GetBuyerReceiveAddress() []byte {
+func (x *LockOrder) GetBuyerReceiveAddress() []byte {
 	if x != nil {
 		return x.BuyerReceiveAddress
 	}
 	return nil
 }
 
-func (x *BuyOrder) GetBuyerSendAddress() []byte {
+func (x *LockOrder) GetBuyerSendAddress() []byte {
 	if x != nil {
 		return x.BuyerSendAddress
 	}
 	return nil
 }
 
-func (x *BuyOrder) GetBuyerChainDeadline() uint64 {
+func (x *LockOrder) GetBuyerChainDeadline() uint64 {
 	if x != nil {
 		return x.BuyerChainDeadline
 	}
@@ -949,7 +949,7 @@ var file_certificate_proto_goTypes = []interface{}{
 	(*RewardRecipients)(nil),   // 2: types.RewardRecipients
 	(*SlashRecipients)(nil),    // 3: types.SlashRecipients
 	(*Orders)(nil),             // 4: types.Orders
-	(*BuyOrder)(nil),           // 5: types.BuyOrder
+	(*LockOrder)(nil),           // 5: types.LockOrder
 	(*Checkpoint)(nil),         // 6: types.Checkpoint
 	(*PaymentPercents)(nil),    // 7: types.PaymentPercents
 	(*DoubleSigner)(nil),       // 8: types.DoubleSigner
@@ -968,7 +968,7 @@ var file_certificate_proto_depIdxs = []int32{
 	6,  // 6: types.CertificateResult.checkpoint:type_name -> types.Checkpoint
 	7,  // 7: types.RewardRecipients.payment_percents:type_name -> types.PaymentPercents
 	8,  // 8: types.SlashRecipients.double_signers:type_name -> types.DoubleSigner
-	5,  // 9: types.Orders.buy_orders:type_name -> types.BuyOrder
+	5,  // 9: types.Orders.lock_orders:type_name -> types.LockOrder
 	10, // 10: types.CommitteesData.list:type_name -> types.CommitteeData
 	7,  // 11: types.CommitteeData.payment_percents:type_name -> types.PaymentPercents
 	12, // [12:12] is the sub-list for method output_type
@@ -1046,7 +1046,7 @@ func file_certificate_proto_init() {
 			}
 		}
 		file_certificate_proto_msgTypes[5].Exporter = func(v interface{}, i int) interface{} {
-			switch v := v.(*BuyOrder); i {
+			switch v := v.(*LockOrder); i {
 			case 0:
 				return &v.state
 			case 1:

--- a/lib/certificate_test.go
+++ b/lib/certificate_test.go
@@ -3,9 +3,10 @@ package lib
 import (
 	"bytes"
 	"encoding/json"
+	"testing"
+
 	"github.com/canopy-network/canopy/lib/crypto"
 	"github.com/stretchr/testify/require"
-	"testing"
 )
 
 func TestCertificateCheckBasic(t *testing.T) {
@@ -289,8 +290,8 @@ func TestCertificateResultsCheckBasic(t *testing.T) {
 			error: "double signer is invalid",
 		},
 		{
-			name:   "nil buy order",
-			detail: "a buy order cannot be nil",
+			name:   "nil lock order",
+			detail: "a lock order cannot be nil",
 			result: &CertificateResult{
 				RewardRecipients: &RewardRecipients{
 					PaymentPercents: []*PaymentPercents{{
@@ -300,16 +301,16 @@ func TestCertificateResultsCheckBasic(t *testing.T) {
 					}},
 				},
 				Orders: &Orders{
-					BuyOrders: []*BuyOrder{
+					LockOrders: []*LockOrder{
 						nil,
 					},
 				},
 			},
-			error: "buy order is nil",
+			error: "lock order is nil",
 		},
 		{
-			name:   "invalid buy order",
-			detail: "a buy order send address is invalid",
+			name:   "invalid lock order",
+			detail: "a lock order send address is invalid",
 			result: &CertificateResult{
 				RewardRecipients: &RewardRecipients{
 					PaymentPercents: []*PaymentPercents{{
@@ -319,7 +320,7 @@ func TestCertificateResultsCheckBasic(t *testing.T) {
 					}},
 				},
 				Orders: &Orders{
-					BuyOrders: []*BuyOrder{
+					LockOrders: []*LockOrder{
 						{
 							OrderId:             0,
 							BuyerSendAddress:    nil,
@@ -343,7 +344,7 @@ func TestCertificateResultsCheckBasic(t *testing.T) {
 					}},
 				},
 				Orders: &Orders{
-					BuyOrders: []*BuyOrder{
+					LockOrders: []*LockOrder{
 						{
 							OrderId:             0,
 							BuyerSendAddress:    newTestAddressBytes(t),
@@ -398,7 +399,7 @@ func TestCheckpointHash(t *testing.T) {
 			}},
 		},
 		Orders: &Orders{
-			BuyOrders: []*BuyOrder{
+			LockOrders: []*LockOrder{
 				{
 					OrderId:             0,
 					BuyerReceiveAddress: newTestAddressBytes(t),

--- a/lib/certificate_test.go
+++ b/lib/certificate_test.go
@@ -333,8 +333,8 @@ func TestCertificateResultsCheckBasic(t *testing.T) {
 			error: "invalid buyer send address",
 		},
 		{
-			name:   "invalid buy order",
-			detail: "a buy order receive address is invalid",
+			name:   "invalid lock order",
+			detail: "a lock order receive address is invalid",
 			result: &CertificateResult{
 				RewardRecipients: &RewardRecipients{
 					PaymentPercents: []*PaymentPercents{{

--- a/lib/error.go
+++ b/lib/error.go
@@ -139,7 +139,7 @@ const (
 	CodeNonNilCertResults               ErrorCode = 40
 	CodeInvalidMemo                     ErrorCode = 41
 	CodeNilCertResult                   ErrorCode = 42
-	CodeNilBuyOrder                     ErrorCode = 43
+	CodeNilLockOrder                     ErrorCode = 43
 	CodeInvalidBuyerReceiveAddress      ErrorCode = 44
 	CodeEmptyTransaction                ErrorCode = 45
 	CodeHashSize                        ErrorCode = 46
@@ -241,8 +241,8 @@ const (
 	CodeUnauthorizedOrderChange           ErrorCode = 75
 	CodeMinimumOrderSize                  ErrorCode = 76
 	CodeOrderAlreadyAccepted              ErrorCode = 77
-	CodeInvalidBuyOrder                   ErrorCode = 78
-	CodeDuplicateBuyOrder                 ErrorCode = 79
+	CodeInvalidLockOrder                   ErrorCode = 78
+	CodeDuplicateLockOrder                 ErrorCode = 79
 	CodeInvalidBuyerDeadline              ErrorCode = 80
 	CodeInvalidCloseOrder                 ErrorCode = 81
 	CodeInvalidResetOrder                 ErrorCode = 82
@@ -683,8 +683,8 @@ func ErrNonNilCertResults() ErrorI {
 	return NewError(CodeNonNilCertResults, MainModule, "the certificate results is not empty")
 }
 
-func ErrNilBuyOrder() ErrorI {
-	return NewError(CodeNilBuyOrder, MainModule, "buy order is nil")
+func ErrNilLockOrder() ErrorI {
+	return NewError(CodeNilLockOrder, MainModule, "lock order is nil")
 }
 
 func ErrInvalidBuyerReceiveAddress() ErrorI {

--- a/lib/swap.go
+++ b/lib/swap.go
@@ -22,8 +22,8 @@ func (x *OrderBook) AddOrder(order *SellOrder) (id uint64) {
 	return
 }
 
-// BuyOrder() adds a recipient address and deadline height to the order to 'claim' the order and prevent others from 'claiming it'
-func (x *OrderBook) BuyOrder(orderId int, buyersReceiveAddress, buyersSendAddress []byte, buyerChainDeadlineHeight uint64) ErrorI {
+// LockOrder() adds a recipient address and deadline height to the order to 'claim' the order and prevent others from 'claiming it'
+func (x *OrderBook) LockOrder(orderId int, buyersReceiveAddress, buyersSendAddress []byte, buyerChainDeadlineHeight uint64) ErrorI {
 	order, err := x.GetOrder(orderId)
 	if err != nil {
 		return err

--- a/lib/swap_test.go
+++ b/lib/swap_test.go
@@ -64,7 +64,7 @@ func TestAddOrder(t *testing.T) {
 	}
 }
 
-func TestBuyOrder(t *testing.T) {
+func TestLockOrder(t *testing.T) {
 	tests := []struct {
 		name                     string
 		initialOrders            []*SellOrder
@@ -124,7 +124,7 @@ func TestBuyOrder(t *testing.T) {
 			// init the OrderBook
 			orderBook := &OrderBook{Orders: test.initialOrders}
 			// execute the function call
-			err := orderBook.BuyOrder(
+			err := orderBook.LockOrder(
 				test.orderId,
 				test.buyersReceiveAddress,
 				test.buyersSendAddress,


### PR DESCRIPTION
## Description
Renames "Buy Orders" to "Lock Orders".

## Related Issues
Closes: #96

## Changes Made
- Renamed Buy Orders to Lock orders throughout the codebase.

## Checklist
- [x] I have tested the changes locally and verified they work as intended.
- [x] I have appropriately titled my branch `issue-#<issue-number>`.
- [x] I have run re-built the web-wallet and/or block explorer (if applicable).
- [ ] I have updated documentation (if applicable).
- [ ] I have included tests for the changes (if applicable).

## Additional Notes