### PR TITLE
Exploratory no-timer implementation for issue #102

### DIFF
--- a/p2p/conn.go
+++ b/p2p/conn.go
@@ -83,7 +83,7 @@ func (p *P2P) NewConnection(conn net.Conn) (*MultiConn, lib.ErrorI) {
 		quitReceiving: make(chan struct{}, maxChanSize),
 		sendPong:      make(chan struct{}, maxChanSize),
 		receivedPong:  make(chan struct{}, maxChanSize),
-		packetOut:     make(chan *Packet, maxQueueSize),
+		packetOut:     make(chan *Packet, 0),
 		onError:       p.OnPeerError,
 		error:         sync.Once{},
 		p2p:           p,

--- a/p2p/conn.go
+++ b/p2p/conn.go
@@ -341,7 +341,7 @@ func (c *MultiConn) streamFanIn() {
 type Stream struct {
 	topic        lib.Topic                    // the subject and priority of the stream
 	sendQueue    chan []byte                  // a queue of incoming messages
-	packetOut    chan *Packet                 // a queue of outoing packets
+	packetOut    chan *Packet                 // a queue of outgoing packets
 	upNextToSend []byte                       // a buffer holding unsent portions of the next message
 	msgAssembler []byte                       // collects and adds incoming packets until the entire message is received (EOF signal)
 	inbox        chan *lib.MessageAndMetadata // the channel where fully received messages are held for other parts of the app to read

--- a/p2p/conn.go
+++ b/p2p/conn.go
@@ -356,7 +356,7 @@ func (s *Stream) sendController() {
 			// Send the next packet; it may be chunked if needed.
 			// This will block until the send service reads it
 			s.packetOut <- s.nextPacket()
-			// nextPacket() will re-populate s.upNextToSend, restart loop to check again
+			// nextPacket() will re-populate s.upNextToSend, continue loop to check again
 			continue
 		}
 

--- a/p2p/p2p.go
+++ b/p2p/p2p.go
@@ -312,6 +312,7 @@ func (p *P2P) NewStreams() (streams map[lib.Topic]*Stream) {
 			topic:        i,
 			msgAssembler: make([]byte, 0, maxMessageSize),
 			sendQueue:    make(chan []byte, maxQueueSize),
+			packetOut:    make(chan *Packet, 1),
 			inbox:        p.Inbox(i),
 			logger:       p.log,
 		}

--- a/p2p/p2p.go
+++ b/p2p/p2p.go
@@ -316,6 +316,7 @@ func (p *P2P) NewStreams() (streams map[lib.Topic]*Stream) {
 			inbox:        p.Inbox(i),
 			logger:       p.log,
 		}
+		go streams[i].sendController()
 	}
 	return
 }

--- a/p2p/p2p.go
+++ b/p2p/p2p.go
@@ -312,7 +312,7 @@ func (p *P2P) NewStreams() (streams map[lib.Topic]*Stream) {
 			topic:        i,
 			msgAssembler: make([]byte, 0, maxMessageSize),
 			sendQueue:    make(chan []byte, maxQueueSize),
-			packetOut:    make(chan *Packet, 1),
+			packetOut:    make(chan *Packet, 0),
 			inbox:        p.Inbox(i),
 			logger:       p.log,
 		}


### PR DESCRIPTION
Expanding on Pablo's ideas with channels I tried this approach:

There are two new goroutines:

- Each stream has its own goroutine `sendController` that processes incoming messages and queues up the next packet it wants to send, making it available for when `MultiConn` is ready to send it.
- `MultiConn` now has a goroutine called `streamFanIn` whose job is to send the next queued packet for each stream to the `send service` via a common channel.

This approach has several benefits:

- No semaphores or locks. 
- No need for a write queue as the for loop in `send service` manages concurrent access to the socket
- Data flow between components is clear
- Required logic is consolidated into fewer places
- All queues are channels which we can easy both control their capacity and query their current size for monitoring purposes
- Uses standard go paradigms - for-select loops, channels and goroutines

This video from one of the creators of go was very enlightening. Both for the theory behind why these go features were made and how they were built to solve problems such as this one.

https://www.youtube.com/watch?v=f6kdp27TYZs

One game changer: "share memory by communicating, don't communicate by sharing memory"

`time.Sleep` was used as an idling mechanism solely to prevent CPU use when there's no data to send. A larger refactor might let us eliminate it, other than that there doesn't seem to be a way to do that without resorting to `reflect` like Pablo noted. We could implement a dynamic backoff for the sleep time.