### PR TITLE
Issue-#137: `Makefile` improvements

### DIFF
--- a/.docker/Dockerfile
+++ b/.docker/Dockerfile
@@ -12,8 +12,8 @@ COPY . /go/src/github.com/canopy-network/canopy
 ENV EXPLORER_BASE_PATH=${EXPLORER_BASE_PATH}
 ENV WALLET_BASE_PATH=${WALLET_BASE_PATH}
 
-RUN make build-wallet
-RUN make build-explorer
+RUN make build/wallet
+RUN make build/explorer
 RUN go build -a -o bin ./${BUILD_PATH}/*.go
 
 FROM alpine:3.19

--- a/.docker/compose.yaml
+++ b/.docker/compose.yaml
@@ -1,5 +1,3 @@
-version: '3.1'
-
 services:
   node-1:
     container_name: node-1
@@ -8,8 +6,8 @@ services:
       dockerfile: .docker/Dockerfile
       args:
         BUILD_PATH: cmd/cli
-        EXPLORER_BASE_PATH: ''
-        WALLET_BASE_PATH: ''
+        EXPLORER_BASE_PATH: ""
+        WALLET_BASE_PATH: ""
     ports:
       - 50000:50000 # Wallet
       - 50001:50001 # Explorer
@@ -18,7 +16,7 @@ services:
       - 9001:9001 # TCP P2P
     networks:
       - canopy
-    command: [ "start" ]
+    command: ["start"]
     volumes:
       - ./volumes/node_1:/root/.canopy
     deploy:
@@ -34,8 +32,8 @@ services:
       dockerfile: .docker/Dockerfile
       args:
         BUILD_PATH: cmd/cli
-        EXPLORER_BASE_PATH: ''
-        WALLET_BASE_PATH: ''
+        EXPLORER_BASE_PATH: ""
+        WALLET_BASE_PATH: ""
     ports:
       - 40000:40000 # Wallet
       - 40001:40001 # Explorer
@@ -44,7 +42,7 @@ services:
       - 9002:9002 # TCP P2P
     networks:
       - canopy
-    command: [ "start" ]
+    command: ["start"]
     volumes:
       - ./volumes/node_2:/root/.canopy
     deploy:

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ help:
 	@sed -n 's/^##//p' ${MAKEFILE_LIST} | column -t -s ':' |  sed -e 's/^/ /'
 
 # Targets, this is a list of all available commands which can be executed using the make command.
-.PHONY: build/canopy build/wallet build/explorer test/all dev/deps docker/up \
+.PHONY: build/canopy build/canopy-full build/wallet build/explorer test/all dev/deps docker/up \
 	docker/down docker/up-fast docker/down docker/logs
 
 # ==================================================================================== #
@@ -24,13 +24,17 @@ help:
 # ==================================================================================== #
 
 ## build/canopy: build the canopy binary into the GO_BIN_DIR
-build/canopy: build/wallet build/explorer
+build/canopy:
 	go build -o $(GO_BIN_DIR)/canopy $(CLI_DIR)
+
+## build/canopy-full: build the canopy binary and its wallet and explorer altogether
+build/canopy-full: build/wallet build/explorer build/canopy
 
 ## build/wallet: build the canopy's wallet project
 build/wallet:
 	npm install --prefix $(WALLET_DIR) && npm run build --prefix $(WALLET_DIR)
 
+## build/explorer: build the canopy's explorer project
 build/explorer:
 	npm install --prefix $(EXPLORER_DIR) && npm run build --prefix $(EXPLORER_DIR)
 

--- a/Makefile
+++ b/Makefile
@@ -23,8 +23,8 @@ help:
 # BUILDING
 # ==================================================================================== #
 
-## build: build the canopy binary into the specified directory
-build/canopy: build-wallet build-explorer
+## build/canopy: build the canopy binary into the GO_BIN_DIR
+build/canopy: build/wallet build/explorer
 	go build -o $(GO_BIN_DIR)/canopy $(CLI_DIR)
 
 ## build/wallet: build the canopy's wallet project

--- a/Makefile
+++ b/Makefile
@@ -3,40 +3,82 @@ GO_BIN_DIR := ~/go/bin
 CLI_DIR := ./cmd/cli/...
 WALLET_DIR := ./cmd/rpc/web/wallet
 EXPLORER_DIR := ./cmd/rpc/web/explorer
-DOCKER_DIR := ./.docker
+DOCKER_DIR := ./.docker/compose.yaml
 
-# Targets
-.PHONY: build deps test build-wallet build-explorer docker-up docker-up-fast
+# ==================================================================================== #
+# HELPERS
+# ==================================================================================== #
 
-build: build-wallet build-explorer
+## help: print each command's help message
+.PHONY: help
+help:
+	@echo 'Usage:'
+	@sed -n 's/^##//p' ${MAKEFILE_LIST} | column -t -s ':' |  sed -e 's/^/ /'
+
+# Targets, this is a list of all available commands which can be executed using the make command.
+.PHONY: build/canopy build/wallet build/explorer test/all dev/deps docker/up \
+	docker/down docker/up-fast docker/down docker/logs
+
+# ==================================================================================== #
+# BUILDING
+# ==================================================================================== #
+
+## build: build the canopy binary into the specified directory
+build/canopy: build-wallet build-explorer
 	go build -o $(GO_BIN_DIR)/canopy $(CLI_DIR)
 
-deps:
-	go mod vendor
+## build/wallet: build the canopy's wallet project
+build/wallet:
+	npm install --prefix $(WALLET_DIR) && npm run build --prefix $(WALLET_DIR)
 
-test:
+build/explorer:
+	npm install --prefix $(EXPLORER_DIR) && npm run build --prefix $(EXPLORER_DIR)
+
+# ==================================================================================== #
+# TESTING
+# ==================================================================================== #
+
+## test/all: run all canopy tests
+test/all:
 	go test ./... -p=1
 
-# Golang currently does not support multiple fuzz targets, so each need to be called individually
-# For more information check the open issue: https://github.com/golang/go/issues/46312
-fuzz-test:
+## test/fuzz: run all canopy fuzz tests individually
+test/fuzz:
+	# Golang currently does not support multiple fuzz targets, so each need to be called individually
+	# For more information check the open issue: https://github.com/golang/go/issues/46312
 	go test -fuzz=FuzzKeyDecodeEncode ./store -fuzztime=5s
 	go test -fuzz=FuzzBytesToBits ./store -fuzztime=5s
 
-build-wallet:
-	cd $(WALLET_DIR) && npm install && npm run build
+# ==================================================================================== #
+# DEVELOPMENT
+# ==================================================================================== #
 
-build-explorer:
-	cd $(EXPLORER_DIR) && npm install && npm run build
+## dev/deps: install all dependencies on the project's directory
+dev/deps:
+	go mod vendor
 
-docker-up:
-	cd $(DOCKER_DIR) && docker-compose down && docker-compose up --build -d
+# Detect OS to run the docker compose command, this is because Docker for MacOS does not support the
+# modern docker compose command and still uses the legacy docker-compose
+ifeq ($(shell uname -s),Darwin)
+    DOCKER_COMPOSE_CMD = docker-compose
+else
+    DOCKER_COMPOSE_CMD = docker compose
+endif
 
-docker-down:
-	cd $(DOCKER_DIR) && docker-compose down
+## docker/up: build and start the compose containers in detached mode
+docker/up:
+	$(DOCKER_COMPOSE_CMD) -f $(DOCKER_DIR) down && \
+	$(DOCKER_COMPOSE_CMD) -f $(DOCKER_DIR) up --build -d
 
-docker-up-fast:
-	cd $(DOCKER_DIR) && docker-compose down && docker-compose up -d
-	
-docker-logs:
-	cd $(DOCKER_DIR) && docker-compose logs -f --tail=1000
+## docker/down: stop the compose containers
+docker/down:
+	$(DOCKER_COMPOSE_CMD) -f $(DOCKER_DIR) down
+
+## docker/up-fast: build and start the compose containers in detached mode without rebuilding
+docker/up-fast:
+	$(DOCKER_COMPOSE_CMD) -f $(DOCKER_DIR) down && \
+	$(DOCKER_COMPOSE_CMD) -f $(DOCKER_DIR) up -d
+
+## docker/logs: show the latest logs of the compose containers
+docker/logs:
+	$(DOCKER_COMPOSE_CMD) -f $(DOCKER_DIR) logs -f --tail=1000


### PR DESCRIPTION
## Description
Who said `Makefiles` can't be pretty? Add multiple miscellaneous enhancements to the `Makefile`

## Related Issues
Closes: #137

## Changes Made
- Restructured Makefile into logical sections pertaining to what the commands do
- Rename all commands with a prefix of their main purpose
- Add comments to all commands
- Add `help` command which list all the commands and their comments by just typing `make` or `make help`
- Add docker compose command detection for macOS and linux
- Changed the nomenclature off cd'ing to the folder to run the command to each command's native custom directory set

## Checklist
- [x] I have tested the changes locally and verified they work as intended.
- [x] I have appropriately titled my branch `issue-#<issue-number>`.

## Additional Notes
**IMPORTANT:** This "breaks" the current commands as their names changed, please do consult the name changes before anything

## Simulation of `make` or `make help` to display command information
```bash
$ make
Usage:
  help             print each command's help message
  build/canopy     build the canopy binary into the GO_BIN_DIR
  build/wallet     build the canopy's wallet project
  test/all         run all canopy tests
  test/fuzz        run all canopy fuzz tests individually
  dev/deps         install all dependencies on the project's directory
  docker/up        build and start the compose containers in detached mode
  docker/down      stop the compose containers
  docker/up-fast   build and start the compose containers in detached mode without rebuilding
  docker/logs      show the latest logs of the compose containers
```