### PR TITLE
Partition DB Design

### DIFF
--- a/cmd/cli/main.go
+++ b/cmd/cli/main.go
@@ -268,6 +268,7 @@ func WriteDefaultGenesisFile(validatorPrivateKey crypto.PrivateKeyI, genesisFile
 			NetAddress:   "tcp://localhost",
 			StakedAmount: 1000000000000,
 			Output:       addr.Bytes(),
+			Compound:     true,
 		}},
 		Params: fsm.DefaultParams(),
 	}

--- a/controller/block.go
+++ b/controller/block.go
@@ -270,6 +270,16 @@ func (c *Controller) CommitCertificate(qc *lib.QuorumCertificate, block *lib.Blo
 		// exit with error
 		return
 	}
+	// check if the store should partition
+	if storeI.ShouldPartition() {
+		// if syncing, run the partition synchronously
+		if c.isSyncing.Load() {
+			storeI.Partition() // TODO: make async design during syncing; worried this may create a temporary P2P deadlock in the future
+		} else {
+			// execute the partition as a background process to not interrupt consensus
+			go storeI.Partition()
+		}
+	}
 	// log to signal finishing the commit
 	c.log.Infof("Committed block %s at H:%d 🔒", lib.BytesToTruncatedString(qc.BlockHash), block.BlockHeader.Height)
 	// set up the finite state machine for the next height

--- a/fsm/committee.go
+++ b/fsm/committee.go
@@ -349,7 +349,7 @@ func (s *StateMachine) DeleteCommittees(address crypto.AddressI, totalStake uint
 
 // SetCommitteeMember() sets the address as a 'member' of the committee in the state
 func (s *StateMachine) SetCommitteeMember(address crypto.AddressI, chainId, stakeForCommittee uint64) lib.ErrorI {
-	return s.Set(KeyForCommittee(chainId, address, stakeForCommittee), bytes.Repeat([]byte("F"), 1000000))
+	return s.Set(KeyForCommittee(chainId, address, stakeForCommittee), nil)
 }
 
 // DeleteCommitteeMember() removes the address from being a 'member' of the committee in the state

--- a/fsm/committee.go
+++ b/fsm/committee.go
@@ -349,7 +349,7 @@ func (s *StateMachine) DeleteCommittees(address crypto.AddressI, totalStake uint
 
 // SetCommitteeMember() sets the address as a 'member' of the committee in the state
 func (s *StateMachine) SetCommitteeMember(address crypto.AddressI, chainId, stakeForCommittee uint64) lib.ErrorI {
-	return s.Set(KeyForCommittee(chainId, address, stakeForCommittee), nil)
+	return s.Set(KeyForCommittee(chainId, address, stakeForCommittee), bytes.Repeat([]byte("F"), 1000000))
 }
 
 // DeleteCommitteeMember() removes the address from being a 'member' of the committee in the state

--- a/lib/crypto/hash.go
+++ b/lib/crypto/hash.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"crypto/sha256"
 	"encoding/hex"
+	"github.com/canopy-network/canopy/lib"
 	"hash"
 )
 
@@ -66,7 +67,7 @@ func MerkleTree(items [][]byte) (root []byte, store [][]byte, err error) {
 		switch {
 		// normal case, parent = hash(concat(left, right))
 		default:
-			store[offset] = Hash(append(store[i], store[i+1]...))
+			store[offset] = Hash(lib.Append(store[i], store[i+1]))
 
 		// no left or right child, so the parent is going to be nil
 		case store[i] == nil:
@@ -74,7 +75,7 @@ func MerkleTree(items [][]byte) (root []byte, store [][]byte, err error) {
 
 		// no right child, parent = hash(concat(left, left))
 		case store[i+1] == nil:
-			store[offset] = Hash(append(store[i], store[i]...))
+			store[offset] = Hash(lib.Append(store[i], store[i]))
 		}
 		offset++
 	}

--- a/lib/crypto/hash.go
+++ b/lib/crypto/hash.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"crypto/sha256"
 	"encoding/hex"
-	"github.com/canopy-network/canopy/lib"
 	"hash"
 )
 
@@ -65,17 +64,17 @@ func MerkleTree(items [][]byte) (root []byte, store [][]byte, err error) {
 	// offset index = after the last transaction and adjusted to the next power of two.
 	for i := 0; i < size-1; i += 2 {
 		switch {
-		// normal case, parent = hash(concat(left, right))
+		// normal case, parent = hash(Concat(left, right))
 		default:
-			store[offset] = Hash(lib.Append(store[i], store[i+1]))
+			store[offset] = Hash(concat(store[i], store[i+1]))
 
 		// no left or right child, so the parent is going to be nil
 		case store[i] == nil:
 			store[offset] = nil
 
-		// no right child, parent = hash(concat(left, left))
+		// no right child, parent = hash(Concat(left, left))
 		case store[i+1] == nil:
-			store[offset] = Hash(lib.Append(store[i], store[i]))
+			store[offset] = Hash(concat(store[i], store[i]))
 		}
 		offset++
 	}
@@ -92,4 +91,12 @@ func nextPowerOfTwo(v int) int {
 	v |= v >> 16
 	v++
 	return v
+}
+
+// concat() concatenates two byte slices
+func concat(a, b []byte) []byte {
+	out := make([]byte, len(a)+len(b))
+	copy(out, a)
+	copy(out[len(a):], b)
+	return out
 }

--- a/lib/error.go
+++ b/lib/error.go
@@ -305,7 +305,7 @@ const (
 	CodeInvalidMerkleTree      ErrorCode   = 10
 	CodeInvalidMerkleTreeProof ErrorCode   = 11
 	CodeGarbageCollectDB       ErrorCode   = 12
-	CodeSetBatch               ErrorCode   = 13
+	CodeSetEntry               ErrorCode   = 13
 
 	RPCModule             ErrorModule = "rpc"
 	CodeRPCTimeout        ErrorCode   = 1

--- a/lib/error.go
+++ b/lib/error.go
@@ -304,6 +304,7 @@ const (
 	CodeReserveKeyWrite        ErrorCode   = 9
 	CodeInvalidMerkleTree      ErrorCode   = 10
 	CodeInvalidMerkleTreeProof ErrorCode   = 11
+	CodeGarbageCollectDB       ErrorCode   = 12
 
 	RPCModule             ErrorModule = "rpc"
 	CodeRPCTimeout        ErrorCode   = 1

--- a/lib/error.go
+++ b/lib/error.go
@@ -299,12 +299,13 @@ const (
 	CodeStoreGet               ErrorCode   = 4
 	CodeStoreDelete            ErrorCode   = 5
 	CodeCommitDB               ErrorCode   = 6
-	CodeCompactProof           ErrorCode   = 7
+	CodeFlushBatch             ErrorCode   = 7
 	CodeInvalidKey             ErrorCode   = 8
 	CodeReserveKeyWrite        ErrorCode   = 9
 	CodeInvalidMerkleTree      ErrorCode   = 10
 	CodeInvalidMerkleTreeProof ErrorCode   = 11
 	CodeGarbageCollectDB       ErrorCode   = 12
+	CodeDeleteBatch            ErrorCode   = 13
 
 	RPCModule             ErrorModule = "rpc"
 	CodeRPCTimeout        ErrorCode   = 1

--- a/lib/error.go
+++ b/lib/error.go
@@ -305,7 +305,7 @@ const (
 	CodeInvalidMerkleTree      ErrorCode   = 10
 	CodeInvalidMerkleTreeProof ErrorCode   = 11
 	CodeGarbageCollectDB       ErrorCode   = 12
-	CodeDeleteBatch            ErrorCode   = 13
+	CodeSetBatch               ErrorCode   = 13
 
 	RPCModule             ErrorModule = "rpc"
 	CodeRPCTimeout        ErrorCode   = 1

--- a/lib/store.go
+++ b/lib/store.go
@@ -21,6 +21,8 @@ type StoreI interface {
 	Commit() (root []byte, err ErrorI)           // save the store and increment the height
 	Discard()                                    // discard the underlying writer
 	Reset()                                      // reset the underlying writer
+	ShouldPartition() bool                       // check if should partition or not
+	Partition()                                  // move keys from the latest partition to the historical partition
 	Close() ErrorI                               // gracefully stop the database
 }
 

--- a/lib/util.go
+++ b/lib/util.go
@@ -748,3 +748,11 @@ func PrintStackTrace() {
 		}
 	}
 }
+
+// Append() is a 'safe append' when the caller wants to re-use the 'a' slice
+func Append(a, b []byte) []byte {
+	out := make([]byte, len(a)+len(b))
+	copy(out, a)
+	copy(out[len(a):], b)
+	return out
+}

--- a/store/error.go
+++ b/store/error.go
@@ -22,8 +22,8 @@ func ErrGarbageCollectDB(err error) lib.ErrorI {
 	return lib.NewError(lib.CodeGarbageCollectDB, lib.StorageModule, fmt.Sprintf("garbageCollectDB() failed with err: %s", err.Error()))
 }
 
-func ErrSetBatch(err error) lib.ErrorI {
-	return lib.NewError(lib.CodeSetBatch, lib.StorageModule, fmt.Sprintf("setBatch() failed with err: %s", err.Error()))
+func ErrSetEntry(err error) lib.ErrorI {
+	return lib.NewError(lib.CodeSetEntry, lib.StorageModule, fmt.Sprintf("setEntry() failed with err: %s", err.Error()))
 }
 
 func ErrStoreSet(err error) lib.ErrorI {

--- a/store/error.go
+++ b/store/error.go
@@ -22,6 +22,10 @@ func ErrGarbageCollectDB(err error) lib.ErrorI {
 	return lib.NewError(lib.CodeGarbageCollectDB, lib.StorageModule, fmt.Sprintf("garbageCollectDB() failed with err: %s", err.Error()))
 }
 
+func ErrDeleteBatch(err error) lib.ErrorI {
+	return lib.NewError(lib.CodeDeleteBatch, lib.StorageModule, fmt.Sprintf("deleteBatchAt() failed with err: %s", err.Error()))
+}
+
 func ErrStoreSet(err error) lib.ErrorI {
 	return lib.NewError(lib.CodeStoreSet, lib.StorageModule, fmt.Sprintf("store.set() failed with err: %s", err.Error()))
 }
@@ -34,8 +38,8 @@ func ErrStoreGet(err error) lib.ErrorI {
 	return lib.NewError(lib.CodeStoreGet, lib.StorageModule, fmt.Sprintf("store.get() failed with err: %s", err.Error()))
 }
 
-func ErrCompactProof(err error) lib.ErrorI {
-	return lib.NewError(lib.CodeCompactProof, lib.StorageModule, fmt.Sprintf("compactProof() failed with err: %s", err.Error()))
+func ErrFlushBatch(err error) lib.ErrorI {
+	return lib.NewError(lib.CodeFlushBatch, lib.StorageModule, fmt.Sprintf("flushBatch() failed with err: %s", err.Error()))
 }
 
 func ErrInvalidKey() lib.ErrorI {

--- a/store/error.go
+++ b/store/error.go
@@ -22,8 +22,8 @@ func ErrGarbageCollectDB(err error) lib.ErrorI {
 	return lib.NewError(lib.CodeGarbageCollectDB, lib.StorageModule, fmt.Sprintf("garbageCollectDB() failed with err: %s", err.Error()))
 }
 
-func ErrDeleteBatch(err error) lib.ErrorI {
-	return lib.NewError(lib.CodeDeleteBatch, lib.StorageModule, fmt.Sprintf("deleteBatchAt() failed with err: %s", err.Error()))
+func ErrSetBatch(err error) lib.ErrorI {
+	return lib.NewError(lib.CodeSetBatch, lib.StorageModule, fmt.Sprintf("setBatch() failed with err: %s", err.Error()))
 }
 
 func ErrStoreSet(err error) lib.ErrorI {

--- a/store/error.go
+++ b/store/error.go
@@ -18,6 +18,10 @@ func ErrCommitDB(err error) lib.ErrorI {
 	return lib.NewError(lib.CodeCommitDB, lib.StorageModule, fmt.Sprintf("commitDB() failed with err: %s", err.Error()))
 }
 
+func ErrGarbageCollectDB(err error) lib.ErrorI {
+	return lib.NewError(lib.CodeGarbageCollectDB, lib.StorageModule, fmt.Sprintf("garbageCollectDB() failed with err: %s", err.Error()))
+}
+
 func ErrStoreSet(err error) lib.ErrorI {
 	return lib.NewError(lib.CodeStoreSet, lib.StorageModule, fmt.Sprintf("store.set() failed with err: %s", err.Error()))
 }

--- a/store/fuzz_test.go
+++ b/store/fuzz_test.go
@@ -31,7 +31,7 @@ func TestFuzz(t *testing.T) {
 	defer cleanup()
 	defer db.Close()
 	keys := make([]string, 0)
-	compareStore := NewTxnWrapper(db.NewTransactionAt(1, true), lib.NewDefaultLogger(), latestStatePrefix)
+	compareStore := NewTxnWrapper(db.NewTransactionAt(1, true), lib.NewDefaultLogger(), []byte(latestStatePrefix))
 	for i := 0; i < 1000; i++ {
 		doRandomOperation(t, store, compareStore, &keys)
 	}
@@ -43,7 +43,7 @@ func TestFuzzTxn(t *testing.T) {
 	require.NoError(t, err)
 	store, err := NewStoreInMemory(lib.NewDefaultLogger())
 	keys := make([]string, 0)
-	compareStore := NewTxnWrapper(db.NewTransactionAt(1, true), lib.NewDefaultLogger(), latestStatePrefix)
+	compareStore := NewTxnWrapper(db.NewTransactionAt(1, true), lib.NewDefaultLogger(), []byte(latestStatePrefix))
 	for i := 0; i < 1000; i++ {
 		doRandomOperation(t, store, compareStore, &keys)
 	}

--- a/store/fuzz_test.go
+++ b/store/fuzz_test.go
@@ -31,7 +31,7 @@ func TestFuzz(t *testing.T) {
 	defer cleanup()
 	defer db.Close()
 	keys := make([]string, 0)
-	compareStore := NewTxnWrapper(db.NewTransactionAt(1, true), lib.NewDefaultLogger(), stateStorePrefix)
+	compareStore := NewTxnWrapper(db.NewTransactionAt(1, true), lib.NewDefaultLogger(), latestStatePrefix)
 	for i := 0; i < 1000; i++ {
 		doRandomOperation(t, store, compareStore, &keys)
 	}
@@ -43,7 +43,7 @@ func TestFuzzTxn(t *testing.T) {
 	require.NoError(t, err)
 	store, err := NewStoreInMemory(lib.NewDefaultLogger())
 	keys := make([]string, 0)
-	compareStore := NewTxnWrapper(db.NewTransactionAt(1, true), lib.NewDefaultLogger(), stateStorePrefix)
+	compareStore := NewTxnWrapper(db.NewTransactionAt(1, true), lib.NewDefaultLogger(), latestStatePrefix)
 	for i := 0; i < 1000; i++ {
 		doRandomOperation(t, store, compareStore, &keys)
 	}

--- a/store/indexer.go
+++ b/store/indexer.go
@@ -265,11 +265,15 @@ func (t *Indexer) GetDoubleSigners() (ds []*lib.DoubleSigner, err lib.ErrorI) {
 		// key split should be dsPrefix / height / address
 		address, height := segments[1], t.decodeBigEndian(segments[2])
 		// add to results
-		results[string(address)] = append(results[string(address)], height)
+		results[lib.BytesToString(address)] = append(results[lib.BytesToString(address)], height)
 	}
 	for address, heights := range results {
+		addr, e := lib.StringToBytes(address)
+		if e != nil {
+			return nil, e
+		}
 		ds = append(ds, &lib.DoubleSigner{
-			Id:      []byte(address),
+			Id:      addr,
 			Heights: heights,
 		})
 	}

--- a/store/smt_test.go
+++ b/store/smt_test.go
@@ -2171,7 +2171,7 @@ func NewTestSMT(t *testing.T, preset *NodeList, root []byte, keyBitSize int) (*S
 	require.NoError(t, err)
 	// make a writable tx that reads from the last height
 	tx := db.NewTransactionAt(1, true)
-	memStore := NewTxnWrapper(tx, lib.NewDefaultLogger(), stateCommitmentPrefix)
+	memStore := NewTxnWrapper(tx, lib.NewDefaultLogger(), []byte(stateCommitmentPrefix))
 	// if there's no preset - use the default 3 nodes
 	if preset == nil {
 		if root != nil {

--- a/store/store.go
+++ b/store/store.go
@@ -231,14 +231,14 @@ func (s *Store) Partition() {
 	if err = func() lib.ErrorI {
 		// calculate the partition height
 		snapshotHeight := partitionHeight(sc.Version())
+		// generate the historical partition prefix
+		partitionPrefix := historicalPrefix(snapshotHeight)
 		// create a reader at the partition height
 		reader := sc.db.NewTransactionAt(snapshotHeight, false)
 		defer reader.Discard()
 		// create a managed batch to do the 'writing'
 		writer := sc.db.NewWriteBatchAt(snapshotHeight)
 		defer writer.Cancel()
-		// generate the historical partition prefix
-		partitionPrefix := historicalPrefix(snapshotHeight)
 		// get the latest store in a transaction wrapper
 		lss := NewTxnWrapper(reader, sc.log, []byte(latestStatePrefix))
 		// create an iterator that traverses the entire latest state store at the partition height

--- a/store/store.go
+++ b/store/store.go
@@ -13,15 +13,15 @@ import (
 )
 
 const (
-	stateStorePrefix      = "s/"          // prefix designated for the LatestStateStore where the most recent blobs of state data are held
-	historicStatePrefix   = "h/"          // prefix designated for the HistoricalStateStore where the historical blobs of state data are held
-	stateCommitmentPrefix = "c/"          // prefix designated for the StateCommitmentStore (immutable, tree DB) built of hashes of state store data
-	indexerPrefix         = "i/"          // prefix designated for indexer (transactions, blocks, and quorum certificates)
-	stateCommitIDPrefix   = "x/"          // prefix designated for the commit ID (height and state merkle root)
-	lastCommitIDPrefix    = "a/"          // prefix designated for the latest commit ID for easy access (latest height and latest state merkle root)
-	partitionExistsKey    = "e/"          // to check if partition exists
-	partitionFrequency    = uint64(10000) // blocks
-	maxKeyBytes           = 256           // maximum size of a key
+	stateStorePrefix      = "s/"       // prefix designated for the LatestStateStore where the most recent blobs of state data are held
+	historicStatePrefix   = "h/"       // prefix designated for the HistoricalStateStore where the historical blobs of state data are held
+	stateCommitmentPrefix = "c/"       // prefix designated for the StateCommitmentStore (immutable, tree DB) built of hashes of state store data
+	indexerPrefix         = "i/"       // prefix designated for indexer (transactions, blocks, and quorum certificates)
+	stateCommitIDPrefix   = "x/"       // prefix designated for the commit ID (height and state merkle root)
+	lastCommitIDPrefix    = "a/"       // prefix designated for the latest commit ID for easy access (latest height and latest state merkle root)
+	partitionExistsKey    = "e/"       // to check if partition exists
+	partitionFrequency    = uint64(10) // blocks
+	maxKeyBytes           = 256        // maximum size of a key
 )
 
 var _ lib.StoreI = &Store{} // enforce the Store interface
@@ -203,7 +203,7 @@ func (s *Store) ShouldPartition() bool {
 		return false
 	}
 	// check if the value is set <key is the value>
-	return bytes.Equal(value, []byte(partitionExistsKey))
+	return !bytes.Equal(value, []byte(partitionExistsKey))
 }
 
 // Partition()
@@ -217,7 +217,6 @@ func (s *Store) Partition() {
 		partHeight := partitionHeight(s.version)
 		// create a writer at the partition height
 		reader := s.db.NewTransactionAt(partHeight, false)
-		// discard the writer when complete
 		defer reader.Discard()
 		// create a managed batch to do the 'writing'
 		writer := s.db.NewManagedWriteBatch()

--- a/store/store.go
+++ b/store/store.go
@@ -191,8 +191,8 @@ func (s *Store) Commit() (root []byte, err lib.ErrorI) {
 
 // ShouldPartition() determines if it is time to partition
 func (s *Store) ShouldPartition() (timeToPartition bool) {
-	// check if it's time to partition every 10 blocks
-	if (s.version-partitionHeight(s.version))%10 != 1 {
+	// check if it's time to partition (1001, 2001, 3001...)
+	if (s.version-partitionHeight(s.version))%(partitionFrequency/10) != 1 {
 		return false
 	}
 	// get the partition exists value from the store at a particular historical partition prefix

--- a/store/store.go
+++ b/store/store.go
@@ -191,10 +191,8 @@ func (s *Store) Commit() (root []byte, err lib.ErrorI) {
 
 // ShouldPartition() determines if it is time to partition
 func (s *Store) ShouldPartition() bool {
-	// check 10 times per partition range (in case there's a failure)
-	checkFrequency := partitionFrequency / 10
-	// check if it's time to partition
-	if s.version%checkFrequency != 1 {
+	// check if it's time to partition (1001, 2001, 3001...)
+	if (s.version-partitionHeight(s.version))%10 != 1 {
 		return false
 	}
 	// get the partition exists value from the store at a particular historical partition prefix

--- a/store/store.go
+++ b/store/store.go
@@ -227,15 +227,14 @@ func (s *Store) Partition() {
 		// 1. ------------------------------------------------------------------------
 		// create vars for the latest store <source> and historical store <destination>
 		lss := NewTxnWrapper(reader, s.log, stateStorePrefix)
-		hss := NewTxnWrapper(reader, s.log, partitionPrefix)
-		// set a signal the partition was successfully created <only written if batch succeeds>
-		if err := hss.Set([]byte(partitionExistsKey), []byte(partitionExistsKey)); err != nil {
-			return err
-		}
 		// create an iterator that traverses the entire state at the partition height
 		it, err := lss.Iterator(nil)
 		if err != nil {
 			return err
+		}
+		// set a signal the partition was successfully created <only written if batch succeeds>
+		if e := writer.Set([]byte(partitionPrefix+partitionExistsKey), []byte(partitionExistsKey)); e != nil {
+			return ErrSetBatch(e)
 		}
 		// for each key in the state at the partition height
 		for ; it.Valid(); it.Next() {

--- a/store/store.go
+++ b/store/store.go
@@ -13,15 +13,15 @@ import (
 )
 
 const (
-	latestStatePrefix     = "s/"      // prefix designated for the LatestStateStore where the most recent blobs of state data are held
-	historicStatePrefix   = "h/"      // prefix designated for the HistoricalStateStore where the historical blobs of state data are held
-	stateCommitmentPrefix = "c/"      // prefix designated for the StateCommitmentStore (immutable, tree DB) built of hashes of state store data
-	indexerPrefix         = "i/"      // prefix designated for indexer (transactions, blocks, and quorum certificates)
-	stateCommitIDPrefix   = "x/"      // prefix designated for the commit ID (height and state merkle root)
-	lastCommitIDPrefix    = "a/"      // prefix designated for the latest commit ID for easy access (latest height and latest state merkle root)
-	partitionExistsKey    = "e/"      // to check if partition exists
-	partitionFrequency    = uint64(5) // blocks
-	maxKeyBytes           = 256       // maximum size of a key
+	latestStatePrefix     = "s/"          // prefix designated for the LatestStateStore where the most recent blobs of state data are held
+	historicStatePrefix   = "h/"          // prefix designated for the HistoricalStateStore where the historical blobs of state data are held
+	stateCommitmentPrefix = "c/"          // prefix designated for the StateCommitmentStore (immutable, tree DB) built of hashes of state store data
+	indexerPrefix         = "i/"          // prefix designated for indexer (transactions, blocks, and quorum certificates)
+	stateCommitIDPrefix   = "x/"          // prefix designated for the commit ID (height and state merkle root)
+	lastCommitIDPrefix    = "a/"          // prefix designated for the latest commit ID for easy access (latest height and latest state merkle root)
+	partitionExistsKey    = "e/"          // to check if partition exists
+	partitionFrequency    = uint64(10000) // blocks
+	maxKeyBytes           = 256           // maximum size of a key
 )
 
 var _ lib.StoreI = &Store{} // enforce the Store interface
@@ -86,8 +86,8 @@ func NewStore(path string, log lib.LoggerI) (lib.StoreI, lib.ErrorI) {
 	// memTableSize is set to 1.28GB (max) to allow 128MB (10%) of writes in a
 	// single batch. It is seemingly unknown why the 10% limit is set
 	// https://discuss.dgraph.io/t/discussion-badgerdb-should-offer-arbitrarily-sized-atomic-transactions/8736
-	db, err := badger.OpenManaged(badger.DefaultOptions(path).WithNumVersionsToKeep(math.MaxInt).WithLoggingLevel(badger.ERROR).
-		WithMemTableSize(int64(100 * units.Kilobyte)).WithValueThreshold(0).WithValueLogFileSize(int64(2 * units.Megabyte)))
+	db, err := badger.OpenManaged(badger.DefaultOptions(path).WithNumVersionsToKeep(math.MaxInt64).
+		WithLoggingLevel(badger.ERROR).WithMemTableSize(int64(1*units.GB + 280*units.MB)))
 	if err != nil {
 		return nil, ErrOpenDB(err)
 	}
@@ -130,7 +130,7 @@ func (s *Store) NewReadOnly(queryVersion uint64) (lib.StoreI, lib.ErrorI) {
 	var useHistorical bool
 	// if the query version is older than the partition frequency
 	if queryVersion+1 < partitionHeight(s.version) {
-		useHistorical = true // REMOVE THIS
+		useHistorical = true
 	}
 	// make a reader for the specified version
 	reader := s.db.NewTransactionAt(queryVersion, false)
@@ -192,10 +192,7 @@ func (s *Store) Commit() (root []byte, err lib.ErrorI) {
 // ShouldPartition() determines if it is time to partition
 func (s *Store) ShouldPartition() (timeToPartition bool) {
 	// check if it's time to partition (1001, 2001, 3001...)
-	//if (s.version-partitionHeight(s.version))%(partitionFrequency/10) != 1 {
-	//	return false
-	//}
-	if s.version%2 != 1 {
+	if (s.version-partitionHeight(s.version))%(partitionFrequency/10) != 1 {
 		return false
 	}
 	// get the partition exists value from the store at a particular historical partition prefix
@@ -219,7 +216,7 @@ func (s *Store) ShouldPartition() (timeToPartition bool) {
 //  1. SNAPSHOT: for each key in the state store, copy them in the new historical partition to ensure
 //     each partition has a complete version of the state at the border -- allowing older partitions to
 //     safely be pruned
-//  2. PRUNE: Drop all versions in the LSS older than the latest @ partition height
+//  2. PRUNE: Drop all versions in the LSS older than the latest keys @ partition height
 func (s *Store) Partition() {
 	// create a copy of the store for multi-thread safety
 	sCopy, err := s.Copy()

--- a/store/store.go
+++ b/store/store.go
@@ -234,14 +234,14 @@ func (s *Store) Partition() {
 	if err = func() lib.ErrorI {
 		// calculate the partition height
 		snapshotHeight := partitionHeight(sc.Version())
-		// generate the historical partition prefix
-		partitionPrefix := historicalPrefix(snapshotHeight)
 		// create a reader at the partition height
 		reader := sc.db.NewTransactionAt(snapshotHeight, false)
 		defer reader.Discard()
 		// create a managed batch to do the 'writing'
 		writer := sc.db.NewWriteBatchAt(snapshotHeight)
 		defer writer.Cancel()
+		// generate the historical partition prefix
+		partitionPrefix := historicalPrefix(snapshotHeight)
 		// get the latest store in a transaction wrapper
 		lss := NewTxnWrapper(reader, sc.log, []byte(latestStatePrefix))
 		// create an iterator that traverses the entire latest state store at the partition height

--- a/store/txn_test.go
+++ b/store/txn_test.go
@@ -266,7 +266,7 @@ func TestTxnIterate(t *testing.T) {
 	db, err := badger.OpenManaged(badger.DefaultOptions("").WithInMemory(true).WithLoggingLevel(badger.ERROR))
 	require.NoError(t, err)
 	parent, err := NewStoreInMemory(lib.NewDefaultLogger())
-	compare := NewTxnWrapper(db.NewTransactionAt(1, true), lib.NewDefaultLogger(), stateStorePrefix)
+	compare := NewTxnWrapper(db.NewTransactionAt(1, true), lib.NewDefaultLogger(), latestStatePrefix)
 	test := NewTxn(parent)
 	defer func() { parent.Close(); compare.Close(); db.Close(); test.Discard() }()
 	require.NoError(t, test.Set([]byte("a"), []byte("a")))

--- a/store/txn_test.go
+++ b/store/txn_test.go
@@ -266,7 +266,7 @@ func TestTxnIterate(t *testing.T) {
 	db, err := badger.OpenManaged(badger.DefaultOptions("").WithInMemory(true).WithLoggingLevel(badger.ERROR))
 	require.NoError(t, err)
 	parent, err := NewStoreInMemory(lib.NewDefaultLogger())
-	compare := NewTxnWrapper(db.NewTransactionAt(1, true), lib.NewDefaultLogger(), latestStatePrefix)
+	compare := NewTxnWrapper(db.NewTransactionAt(1, true), lib.NewDefaultLogger(), []byte(latestStatePrefix))
 	test := NewTxn(parent)
 	defer func() { parent.Close(); compare.Close(); db.Close(); test.Discard() }()
 	require.NoError(t, test.Set([]byte("a"), []byte("a")))

--- a/store/wrapper_txn.go
+++ b/store/wrapper_txn.go
@@ -9,11 +9,22 @@ import (
 )
 
 const (
-	badgerMetaFieldName               = "meta"    // badgerDB Entry 'meta' field name
-	badgerDiscardEarlierVersions byte = 1 << 2    // badgerDB 'discard earlier versions' flag
-	badgerDeleteBit              byte = 1 << 0    // badgerDB 'tombstoned' flag
-	badgerNoDiscardBit           byte = 1 << 3    // badgerDB 'never discard'  bit
-	badgerGCRatio                     = .00000001 // the ratio when badgerDB will run the garbage collector
+	// BadgerDB garbage collector behavior is not well documented leading to many open issues in their repository
+	// However, here is our current understanding based on experimentation
+	// ----------------------------------------------------------------------------------------------------------
+	// BadgerDB Garbage Collection Rules listed by priority
+	// 1. MergeOp Bit prevents garbage collection of a key regardless
+	// 2. Nothing above DiscardTs will be garbage collected
+	// 3. Deleting, expiring, and setting ‘Discard earlier versions’ signals the removal of older versions of a key
+	// 4. Deleting or expiring a key makes it eligible for GC
+	// 5. If KeepNumVersions is set to max int it will prevent automatic GC of older versions
+	// ------------------------------------------------------------------------------
+	// Bits source: https://github.com/hypermodeinc/badger/blob/85389e88bf308c1dc271383b77b67f4ef4a85194/value.go#L37
+	badgerMetaFieldName               = "meta" // badgerDB Entry 'meta' field name
+	badgerDiscardEarlierVersions byte = 1 << 2 // badgerDB 'discard earlier versions' flag
+	badgerDeleteBit              byte = 1 << 0 // badgerDB 'tombstoned' flag
+	badgerNoDiscardBit           byte = 1 << 3 // badgerDB 'never discard'  bit
+	badgerGCRatio                     = .15    // the ratio when badgerDB will run the garbage collector
 )
 
 // RWStoreI interface enforcement

--- a/store/wrapper_txn.go
+++ b/store/wrapper_txn.go
@@ -89,20 +89,6 @@ func (t *TxnWrapper) RevIterator(prefix []byte) (lib.IteratorI, lib.ErrorI) {
 	}, nil
 }
 
-// ArchiveIterator() creates a new iterator for all versions under the given prefix in the BadgerDB transaction
-func (t *TxnWrapper) ArchiveIterator(prefix []byte) (lib.IteratorI, lib.ErrorI) {
-	parent := t.db.NewIterator(badger.IteratorOptions{
-		Prefix:      append([]byte(t.prefix), prefix...),
-		AllVersions: true,
-	})
-	parent.Rewind()
-	return &Iterator{
-		logger: t.logger,
-		parent: parent,
-		prefix: t.prefix,
-	}, nil
-}
-
 // seekLast() positions the iterator at the last key for the given prefix
 func seekLast(it *badger.Iterator, prefix []byte) {
 	it.Seek(prefixEnd(prefix))
@@ -119,10 +105,9 @@ type Iterator struct {
 	err    error
 }
 
-func (i *Iterator) Valid() bool     { return i.parent.Valid() }
-func (i *Iterator) Next()           { i.parent.Next() }
-func (i *Iterator) Close()          { i.parent.Close() }
-func (i *Iterator) Version() uint64 { return i.parent.Item().Version() }
+func (i *Iterator) Valid() bool { return i.parent.Valid() }
+func (i *Iterator) Next()       { i.parent.Next() }
+func (i *Iterator) Close()      { i.parent.Close() }
 func (i *Iterator) Key() (key []byte) {
 	// get the key from the parent
 	key = i.parent.Item().Key()

--- a/store/wrapper_txn.go
+++ b/store/wrapper_txn.go
@@ -37,7 +37,7 @@ func NewTxnWrapper(db *badger.Txn, logger lib.LoggerI, prefix []byte) *TxnWrappe
 
 // Get() retrieves the value associated with the key from the BadgerDB transaction
 func (t *TxnWrapper) Get(k []byte) ([]byte, lib.ErrorI) {
-	item, err := t.db.Get(append(t.prefix, k...))
+	item, err := t.db.Get(lib.Append(t.prefix, k))
 	if err != nil {
 		if err == badger.ErrKeyNotFound {
 			return nil, nil
@@ -53,7 +53,7 @@ func (t *TxnWrapper) Get(k []byte) ([]byte, lib.ErrorI) {
 
 // Set() stores the key-value pair in the BadgerDB transaction
 func (t *TxnWrapper) Set(k, v []byte) lib.ErrorI {
-	if err := t.db.Set(append(t.prefix, k...), v); err != nil {
+	if err := t.db.Set(lib.Append(t.prefix, k), v); err != nil {
 		return ErrStoreSet(err)
 	}
 	return nil
@@ -61,7 +61,7 @@ func (t *TxnWrapper) Set(k, v []byte) lib.ErrorI {
 
 // Delete() removes the key-value pair from the BadgerDB transaction
 func (t *TxnWrapper) Delete(k []byte) lib.ErrorI {
-	if err := t.db.Delete(append(t.prefix, k...)); err != nil {
+	if err := t.db.Delete(lib.Append(t.prefix, k)); err != nil {
 		return ErrStoreDelete(err)
 	}
 	return nil
@@ -70,7 +70,7 @@ func (t *TxnWrapper) Delete(k []byte) lib.ErrorI {
 // Set() stores the key-value pair in the BadgerDB transaction
 func (t *TxnWrapper) SetNonPruneable(k, v []byte) lib.ErrorI {
 	// set an entry with a bit that prevents it from being discarded
-	if err := t.db.SetEntry(newEntry(append(t.prefix, k...), v, badgerNoDiscardBit)); err != nil {
+	if err := t.db.SetEntry(newEntry(lib.Append(t.prefix, k), v, badgerNoDiscardBit)); err != nil {
 		return ErrStoreSet(err)
 	}
 	return nil
@@ -79,7 +79,7 @@ func (t *TxnWrapper) SetNonPruneable(k, v []byte) lib.ErrorI {
 // DeleteNonPrunable() removes the key-value pair from the BadgerDB transaction but prevents it from being garbage collected
 func (t *TxnWrapper) DeleteNonPrunable(k []byte) lib.ErrorI {
 	// set an entry with a bit that marks it as deleted and prevents it from being discarded
-	if err := t.db.SetEntry(newEntry(append(t.prefix, k...), nil, badgerDeleteBit|badgerNoDiscardBit)); err != nil {
+	if err := t.db.SetEntry(newEntry(lib.Append(t.prefix, k), nil, badgerDeleteBit|badgerNoDiscardBit)); err != nil {
 		return ErrStoreDelete(err)
 	}
 	return nil
@@ -92,7 +92,7 @@ func (t *TxnWrapper) setDB(p *badger.Txn) { t.db = p }
 // Iterator() creates a new iterator for the given prefix in the BadgerDB transaction
 func (t *TxnWrapper) Iterator(prefix []byte) (lib.IteratorI, lib.ErrorI) {
 	parent := t.db.NewIterator(badger.IteratorOptions{
-		Prefix: append(t.prefix, prefix...),
+		Prefix: lib.Append(t.prefix, prefix),
 	})
 	parent.Rewind()
 	return &Iterator{
@@ -104,7 +104,7 @@ func (t *TxnWrapper) Iterator(prefix []byte) (lib.IteratorI, lib.ErrorI) {
 
 // RevIterator() creates a new reverse iterator for the given prefix in the BadgerDB transaction
 func (t *TxnWrapper) RevIterator(prefix []byte) (lib.IteratorI, lib.ErrorI) {
-	newPrefix := append(t.prefix, prefix...)
+	newPrefix := lib.Append(t.prefix, prefix)
 	parent := t.db.NewIterator(badger.IteratorOptions{
 		Reverse: true,
 		Prefix:  newPrefix,
@@ -120,7 +120,7 @@ func (t *TxnWrapper) RevIterator(prefix []byte) (lib.IteratorI, lib.ErrorI) {
 // ArchiveIterator() creates a new iterator for all versions under the given prefix in the BadgerDB transaction
 func (t *TxnWrapper) ArchiveIterator(prefix []byte) (lib.IteratorI, lib.ErrorI) {
 	parent := t.db.NewIterator(badger.IteratorOptions{
-		Prefix:      append(t.prefix, prefix...),
+		Prefix:      lib.Append(t.prefix, prefix),
 		AllVersions: true,
 	})
 	parent.Rewind()
@@ -180,12 +180,12 @@ var (
 
 // prefixEnd() returns the end key for a given prefix by appending max possible bytes
 func prefixEnd(prefix []byte) []byte {
-	return append(prefix, endBytes...)
+	return lib.Append(prefix, endBytes)
 }
 
 // newEntry() creates a new badgerDB entry
 func newEntry(key, value []byte, meta byte) (e *badger.Entry) {
-	e = &badger.Entry{Key: append(key), Value: value}
+	e = &badger.Entry{Key: key, Value: value}
 	setMeta(e, meta)
 	return
 }

--- a/store/wrapper_txn_test.go
+++ b/store/wrapper_txn_test.go
@@ -65,7 +65,7 @@ func TestIteratorWithDelete(t *testing.T) {
 func newTestTxnWrapper(t *testing.T) (*badger.DB, *TxnWrapper, func()) {
 	db, err := badger.OpenManaged(badger.DefaultOptions("").WithInMemory(true).WithLoggingLevel(badger.ERROR))
 	require.NoError(t, err)
-	parent := NewTxnWrapper(db.NewTransactionAt(0, true), lib.NewDefaultLogger(), stateStorePrefix)
+	parent := NewTxnWrapper(db.NewTransactionAt(0, true), lib.NewDefaultLogger(), latestStatePrefix)
 	return db, parent, func() {
 		db.Close()
 		parent.Close()

--- a/store/wrapper_txn_test.go
+++ b/store/wrapper_txn_test.go
@@ -7,7 +7,9 @@ import (
 	"github.com/dgraph-io/badger/v4"
 	"github.com/stretchr/testify/require"
 	math "math/rand"
+	"reflect"
 	"testing"
+	"unsafe"
 )
 
 func TestGetSetDelete(t *testing.T) {
@@ -24,6 +26,52 @@ func TestGetSetDelete(t *testing.T) {
 	reader := db.NewTransactionAt(0, false)
 	_, er := reader.Get([]byte("a"))
 	require.Contains(t, er.Error(), badger.ErrKeyNotFound.Error())
+}
+
+func TestSetDeleteNonPruneable(t *testing.T) {
+	db, store, cleanup := newTestTxnWrapper(t)
+	defer cleanup()
+	// first set 'a' and 'b' at height 1
+	require.NoError(t, store.SetNonPruneable([]byte("a"), []byte("a")))
+	require.NoError(t, store.SetNonPruneable([]byte("b"), []byte("b")))
+	require.NoError(t, store.db.CommitAt(1, nil))
+	// delete 'b' at height 2
+	tx := db.NewTransactionAt(1, true)
+	nextStore := NewTxnWrapper(tx, lib.NewDefaultLogger(), []byte(latestStatePrefix))
+	require.NoError(t, nextStore.DeleteNonPrunable([]byte("b")))
+	require.NoError(t, nextStore.db.CommitAt(2, nil))
+	// read at height 2
+	tx2 := db.NewTransactionAt(2, true)
+	nextStore2 := NewTxnWrapper(tx2, lib.NewDefaultLogger(), []byte(latestStatePrefix))
+	defer nextStore2.Close()
+	// use an archive iterator
+	iterator, err := nextStore2.ArchiveIterator(nil)
+	require.NoError(t, err)
+	it := iterator.(*Iterator)
+	defer it.Close()
+	var count int
+	// check the expected values of each item of the archive iterator and the order
+	// including the pruning and delete bits
+	for ; it.Valid(); it.Next() {
+		require.True(t, getMeta(it.parent.Item())&badgerNoDiscardBit != 0)
+		switch count {
+		case 0:
+			require.Equal(t, it.Key(), []byte("a"))
+			require.Equal(t, it.Value(), []byte("a"))
+			require.False(t, getMeta(it.parent.Item())&badgerDeleteBit != 0)
+		case 1:
+			require.Equal(t, it.Key(), []byte("b"))
+			require.Equal(t, it.Value(), []byte(nil))
+			require.True(t, getMeta(it.parent.Item())&badgerDeleteBit != 0)
+		case 2:
+			require.Equal(t, it.Key(), []byte("b"))
+			require.Equal(t, it.Value(), []byte("b"))
+			require.False(t, getMeta(it.parent.Item())&badgerDeleteBit != 0)
+		}
+		count++
+	}
+	// ensure 3 keys
+	require.Equal(t, count, 3)
 }
 
 func TestIteratorBasic(t *testing.T) {
@@ -65,9 +113,16 @@ func TestIteratorWithDelete(t *testing.T) {
 func newTestTxnWrapper(t *testing.T) (*badger.DB, *TxnWrapper, func()) {
 	db, err := badger.OpenManaged(badger.DefaultOptions("").WithInMemory(true).WithLoggingLevel(badger.ERROR))
 	require.NoError(t, err)
-	parent := NewTxnWrapper(db.NewTransactionAt(0, true), lib.NewDefaultLogger(), []byte(latestStatePrefix))
+	parent := NewTxnWrapper(db.NewTransactionAt(1, true), lib.NewDefaultLogger(), []byte(latestStatePrefix))
 	return db, parent, func() {
 		db.Close()
 		parent.Close()
 	}
+}
+
+func getMeta(e *badger.Item) (value byte) {
+	v := reflect.ValueOf(e).Elem()
+	f := v.FieldByName(badgerMetaFieldName)
+	ptr := unsafe.Pointer(f.UnsafeAddr())
+	return *(*byte)(ptr)
 }

--- a/store/wrapper_txn_test.go
+++ b/store/wrapper_txn_test.go
@@ -65,7 +65,7 @@ func TestIteratorWithDelete(t *testing.T) {
 func newTestTxnWrapper(t *testing.T) (*badger.DB, *TxnWrapper, func()) {
 	db, err := badger.OpenManaged(badger.DefaultOptions("").WithInMemory(true).WithLoggingLevel(badger.ERROR))
 	require.NoError(t, err)
-	parent := NewTxnWrapper(db.NewTransactionAt(0, true), lib.NewDefaultLogger(), latestStatePrefix)
+	parent := NewTxnWrapper(db.NewTransactionAt(0, true), lib.NewDefaultLogger(), []byte(latestStatePrefix))
 	return db, parent, func() {
 		db.Close()
 		parent.Close()


### PR DESCRIPTION
## Historical State Partitioning (BadgerDB, Managed Mode)

Using BadgerDB in **managed mode**, we treat block heights as timestamps. This allows precise versioning of key/value pairs at each block.

### Prefixes

- `/State/` – latest state
- `/<PartitionPrefix>/` – historical snapshots (every N blocks)
- `N = 1000`
- `PartitionPrefix = (Height / N) * N` (e.g., 4787 → 4000)

---

### Step 1: Double Write on Set

On each new write at `LatestHeight`:

- `/State/<Key>` → `Value` @ `LatestHeight`
- `/<PartitionPrefix>/<Key>` → `Value` @ `LatestHeight`

---

### Step 2: Flatten Snapshot Boundary

If `LatestHeight % N == 1`:

- `LastHeight = LatestHeight - 1`
- For each key in `/State/` at version `LastHeight`:
  - Copy to `/<PartitionPrefix>/<Key>` at `LastHeight`
  - Delete all older `/State/<Key>` versions

This ensures snapshots are complete for each partition.

---

### Step 3: Historical Queries

To read key at `targetBlock`:

```go
txn := db.NewTransactionAt(targetBlock)

if LatestHeight - targetBlock < N:
    prefix = /State/
else:
    PartitionPrefix = (targetBlock / N) * N
    prefix = /<PartitionPrefix>/
    
txn.Get(prefix + key)
```

---

### Benefits

- Keeps `/State/` fast to iterate (few versions)
- Historical data is chunked → faster seeks & smaller iterator windows
- No reverse seeks needed due to managed timestamps