### PR TITLE
feat: add back ping pong

### DIFF
--- a/bft/mock_test.go
+++ b/bft/mock_test.go
@@ -34,8 +34,11 @@ func newTestConsensus(t *testing.T, phase Phase, numValidators int) (tc *testCon
 		sendToProposerChan: make(chan lib.Signable),
 		sendToReplicasChan: make(chan lib.Signable),
 	}
+	// Disable VDF service for testing
+	config := lib.DefaultConfig()
+	config.RunVDF = false
 	// create the bft object using the mocks
-	tc.bft, err = New(lib.DefaultConfig(), tc.valKeys[0], 1, 1, tc.cont, false, lib.NewDefaultLogger())
+	tc.bft, err = New(config, tc.valKeys[0], 1, 1, tc.cont, config.RunVDF, lib.NewDefaultLogger())
 	tc.bft.ValidatorSet = tc.valSet
 	require.NoError(t, err)
 	// set the bft phase

--- a/lib/.proto/p2p.proto
+++ b/lib/.proto/p2p.proto
@@ -38,6 +38,12 @@ message Packet {
   bytes bytes = 3;
 }
 
+// Ping is a message sent by a node to check the availability or responsiveness of another peer
+message Ping {}
+
+// Pong is a response message sent back to acknowledge receipt of a Ping message, confirming the peer is active
+message Pong {}
+
 // PeerBookRequest is a peer exchange request message that enables new peer discovery via swapping
 message PeerBookRequestMessage{}
 

--- a/p2p/conn.go
+++ b/p2p/conn.go
@@ -16,6 +16,8 @@ import (
 )
 
 const (
+	pingInterval           = 30 * time.Second        // how often a ping is to be sent
+	pongTimeoutDuration    = 20 * time.Second        // how long the sender of a ping waits for a pong before throwing an error
 	maxDataChunkSize       = 1024 - packetHeaderSize // maximum size of the chunk of bytes in a packet
 	maxPacketSize          = 1024                    // maximum size of the full packet
 	packetHeaderSize       = 47                      // the overhead of the protobuf packet header
@@ -65,6 +67,8 @@ type MultiConn struct {
 	streams       map[lib.Topic]*Stream       // multiple independent bi-directional communication channels
 	quitSending   chan struct{}               // signal to quit
 	quitReceiving chan struct{}               // signal to quit
+	sendPong      chan struct{}               // signal to send keep alive message
+	receivedPong  chan struct{}               // signal that received keep alive message
 	onError       func(error, []byte, string) // callback to call if peer errors
 	error         sync.Once                   // thread safety to ensure MultiConn.onError is only called once
 	p2p           *P2P                        // a pointer reference to the P2P module
@@ -84,6 +88,8 @@ func (p *P2P) NewConnection(conn net.Conn) (*MultiConn, lib.ErrorI) {
 		streams:       p.NewStreams(),
 		quitSending:   make(chan struct{}, maxChanSize),
 		quitReceiving: make(chan struct{}, maxChanSize),
+		sendPong:      make(chan struct{}, maxChanSize),
+		receivedPong:  make(chan struct{}, maxChanSize),
 		onError:       p.OnPeerError,
 		error:         sync.Once{},
 		p2p:           p,
@@ -143,21 +149,64 @@ func (c *MultiConn) Send(topic lib.Topic, msg *Envelope) (ok bool) {
 func (c *MultiConn) startSendService() {
 	defer lib.CatchPanic(c.log)
 	m := limiter.New(0, 0)
+	ping, err := time.NewTicker(pingInterval), lib.ErrorI(nil)
+	pongTimer := time.NewTimer(pongTimeoutDuration)
 	var packet *Packet
-	defer func() { m.Done() }()
+	defer func() { lib.StopTimer(pongTimer); ping.Stop(); m.Done() }()
 	for {
 		// select statement ensures the sequential coordination of the concurrent processes
 		select {
 		case packet = <-c.streams[lib.Topic_CONSENSUS].sendQueue:
+			c.sendPacket(packet, m)
 		case packet = <-c.streams[lib.Topic_BLOCK].sendQueue:
+			c.sendPacket(packet, m)
 		case packet = <-c.streams[lib.Topic_BLOCK_REQUEST].sendQueue:
+			c.sendPacket(packet, m)
 		case packet = <-c.streams[lib.Topic_TX].sendQueue:
+			c.sendPacket(packet, m)
 		case packet = <-c.streams[lib.Topic_PEERS_RESPONSE].sendQueue:
+			c.sendPacket(packet, m)
 		case packet = <-c.streams[lib.Topic_PEERS_REQUEST].sendQueue:
+			c.sendPacket(packet, m)
+		case <-ping.C: // fires every 'pingInterval'
+			c.log.Debugf("Send Ping to: %s", lib.BytesToTruncatedString(c.Address.PublicKey))
+			// send a ping to the peer
+			if err = c.sendWireBytes(new(Ping), m); err != nil {
+				break
+			}
+			// reset the pong timer
+			lib.StopTimer(pongTimer)
+			// set the pong timer to execute an Error function if the timer expires before receiving a pong
+			pongTimer = time.AfterFunc(pongTimeoutDuration, func() {
+				if e := ErrPongTimeout(); e != nil {
+					c.Error(e, NoPongSlash)
+				}
+			})
+		case _, open := <-c.sendPong: // fires when receive service got a 'ping' message
+			// if the channel was closed
+			if !open {
+				// log the close
+				c.log.Debugf("Pong channel closed, stopping")
+				// exit
+				return
+			}
+			// log the pong sending
+			c.log.Debugf("Send Pong to: %s", lib.BytesToTruncatedString(c.Address.PublicKey))
+			// send a pong
+			c.sendWireBytes(new(Pong), m)
+		case _, open := <-c.receivedPong: // fires when receive service got a 'pong' message
+			// if the channel was closed
+			if !open {
+				// log the close
+				c.log.Debugf("Receive pong channel closed, stopping")
+				// exit
+				return
+			}
+			// reset the pong timer
+			lib.StopTimer(pongTimer)
 		case <-c.quitSending: // fires when Stop() is called
 			return
 		}
-		c.sendPacket(packet, m)
 	}
 }
 
@@ -167,7 +216,7 @@ func (c *MultiConn) startSendService() {
 func (c *MultiConn) startReceiveService() {
 	defer lib.CatchPanic(c.log)
 	m := limiter.New(0, 0)
-	defer func() { m.Done() }()
+	defer func() { close(c.sendPong); close(c.receivedPong); m.Done() }()
 	for {
 		select {
 		default: // fires unless quit was signaled
@@ -198,6 +247,12 @@ func (c *MultiConn) startReceiveService() {
 					c.Error(er, slash)
 					return
 				}
+			case *Ping: // receive ping message notifies the "send" service to respond with a 'pong' message
+				c.log.Debugf("Received ping from %s", lib.BytesToTruncatedString(c.Address.PublicKey))
+				c.sendPong <- struct{}{}
+			case *Pong: // receive pong message notifies the "send" service to disable the 'pong timer exit'
+				c.log.Debugf("Received pong from %s", lib.BytesToTruncatedString(c.Address.PublicKey))
+				c.receivedPong <- struct{}{}
 			default: // unknown type results in slash and exiting the service
 				c.Error(ErrUnknownP2PMsg(x), UnknownMessageSlash)
 				return
@@ -246,8 +301,18 @@ func (c *MultiConn) sendPacket(packet *Packet, m *limiter.Monitor) (err lib.Erro
 		packet.Eof,
 		crypto.ShortHashString(packet.Bytes),
 	)
+	// send packet as message over the wire
+	err = c.sendWireBytes(packet, m)
+	return
+}
+
+// sendWireBytes() a rate limited writer of outbound bytes to the wire
+// wraps a proto.Message into a universal Envelope, then converts to bytes and
+// sends them across the wire without violating the data flow rate limits
+// message may be a Packet, a Ping or a Pong
+func (c *MultiConn) sendWireBytes(message proto.Message, m *limiter.Monitor) (err lib.ErrorI) {
 	// convert the proto.Message into a proto.Any
-	a, err := lib.NewAny(packet)
+	a, err := lib.NewAny(message)
 	if err != nil {
 		return err
 	}

--- a/p2p/p2p.pb.go
+++ b/p2p/p2p.pb.go
@@ -155,6 +155,84 @@ func (x *Packet) GetBytes() []byte {
 	return nil
 }
 
+// Ping is a message sent by a node to check the availability or responsiveness of another peer
+type Ping struct {
+	state         protoimpl.MessageState
+	sizeCache     protoimpl.SizeCache
+	unknownFields protoimpl.UnknownFields
+}
+
+func (x *Ping) Reset() {
+	*x = Ping{}
+	if protoimpl.UnsafeEnabled {
+		mi := &file_p2p_proto_msgTypes[2]
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		ms.StoreMessageInfo(mi)
+	}
+}
+
+func (x *Ping) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*Ping) ProtoMessage() {}
+
+func (x *Ping) ProtoReflect() protoreflect.Message {
+	mi := &file_p2p_proto_msgTypes[2]
+	if protoimpl.UnsafeEnabled && x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use Ping.ProtoReflect.Descriptor instead.
+func (*Ping) Descriptor() ([]byte, []int) {
+	return file_p2p_proto_rawDescGZIP(), []int{2}
+}
+
+// Pong is a response message sent back to acknowledge receipt of a Ping message, confirming the peer is active
+type Pong struct {
+	state         protoimpl.MessageState
+	sizeCache     protoimpl.SizeCache
+	unknownFields protoimpl.UnknownFields
+}
+
+func (x *Pong) Reset() {
+	*x = Pong{}
+	if protoimpl.UnsafeEnabled {
+		mi := &file_p2p_proto_msgTypes[3]
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		ms.StoreMessageInfo(mi)
+	}
+}
+
+func (x *Pong) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*Pong) ProtoMessage() {}
+
+func (x *Pong) ProtoReflect() protoreflect.Message {
+	mi := &file_p2p_proto_msgTypes[3]
+	if protoimpl.UnsafeEnabled && x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use Pong.ProtoReflect.Descriptor instead.
+func (*Pong) Descriptor() ([]byte, []int) {
+	return file_p2p_proto_rawDescGZIP(), []int{3}
+}
+
 // PeerBookRequest is a peer exchange request message that enables new peer discovery via swapping
 type PeerBookRequestMessage struct {
 	state         protoimpl.MessageState
@@ -165,7 +243,7 @@ type PeerBookRequestMessage struct {
 func (x *PeerBookRequestMessage) Reset() {
 	*x = PeerBookRequestMessage{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_p2p_proto_msgTypes[2]
+		mi := &file_p2p_proto_msgTypes[4]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -178,7 +256,7 @@ func (x *PeerBookRequestMessage) String() string {
 func (*PeerBookRequestMessage) ProtoMessage() {}
 
 func (x *PeerBookRequestMessage) ProtoReflect() protoreflect.Message {
-	mi := &file_p2p_proto_msgTypes[2]
+	mi := &file_p2p_proto_msgTypes[4]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -191,7 +269,7 @@ func (x *PeerBookRequestMessage) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PeerBookRequestMessage.ProtoReflect.Descriptor instead.
 func (*PeerBookRequestMessage) Descriptor() ([]byte, []int) {
-	return file_p2p_proto_rawDescGZIP(), []int{2}
+	return file_p2p_proto_rawDescGZIP(), []int{4}
 }
 
 // PeerBookResponseMessage is a peer exchange response message sent back after receiving a PeerBookRequestMessage
@@ -208,7 +286,7 @@ type PeerBookResponseMessage struct {
 func (x *PeerBookResponseMessage) Reset() {
 	*x = PeerBookResponseMessage{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_p2p_proto_msgTypes[3]
+		mi := &file_p2p_proto_msgTypes[5]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -221,7 +299,7 @@ func (x *PeerBookResponseMessage) String() string {
 func (*PeerBookResponseMessage) ProtoMessage() {}
 
 func (x *PeerBookResponseMessage) ProtoReflect() protoreflect.Message {
-	mi := &file_p2p_proto_msgTypes[3]
+	mi := &file_p2p_proto_msgTypes[5]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -234,7 +312,7 @@ func (x *PeerBookResponseMessage) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PeerBookResponseMessage.ProtoReflect.Descriptor instead.
 func (*PeerBookResponseMessage) Descriptor() ([]byte, []int) {
-	return file_p2p_proto_rawDescGZIP(), []int{3}
+	return file_p2p_proto_rawDescGZIP(), []int{5}
 }
 
 func (x *PeerBookResponseMessage) GetBook() []*BookPeer {
@@ -262,7 +340,7 @@ type BookPeer struct {
 func (x *BookPeer) Reset() {
 	*x = BookPeer{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_p2p_proto_msgTypes[4]
+		mi := &file_p2p_proto_msgTypes[6]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -275,7 +353,7 @@ func (x *BookPeer) String() string {
 func (*BookPeer) ProtoMessage() {}
 
 func (x *BookPeer) ProtoReflect() protoreflect.Message {
-	mi := &file_p2p_proto_msgTypes[4]
+	mi := &file_p2p_proto_msgTypes[6]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -288,7 +366,7 @@ func (x *BookPeer) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use BookPeer.ProtoReflect.Descriptor instead.
 func (*BookPeer) Descriptor() ([]byte, []int) {
-	return file_p2p_proto_rawDescGZIP(), []int{4}
+	return file_p2p_proto_rawDescGZIP(), []int{6}
 }
 
 func (x *BookPeer) GetAddress() *lib.PeerAddress {
@@ -321,7 +399,8 @@ var file_p2p_proto_rawDesc = []byte{
 	0x52, 0x08, 0x73, 0x74, 0x72, 0x65, 0x61, 0x6d, 0x49, 0x64, 0x12, 0x10, 0x0a, 0x03, 0x65, 0x6f,
 	0x66, 0x18, 0x02, 0x20, 0x01, 0x28, 0x08, 0x52, 0x03, 0x65, 0x6f, 0x66, 0x12, 0x14, 0x0a, 0x05,
 	0x62, 0x79, 0x74, 0x65, 0x73, 0x18, 0x03, 0x20, 0x01, 0x28, 0x0c, 0x52, 0x05, 0x62, 0x79, 0x74,
-	0x65, 0x73, 0x22, 0x18, 0x0a, 0x16, 0x50, 0x65, 0x65, 0x72, 0x42, 0x6f, 0x6f, 0x6b, 0x52, 0x65,
+	0x65, 0x73, 0x22, 0x06, 0x0a, 0x04, 0x50, 0x69, 0x6e, 0x67, 0x22, 0x06, 0x0a, 0x04, 0x50, 0x6f,
+	0x6e, 0x67, 0x22, 0x18, 0x0a, 0x16, 0x50, 0x65, 0x65, 0x72, 0x42, 0x6f, 0x6f, 0x6b, 0x52, 0x65,
 	0x71, 0x75, 0x65, 0x73, 0x74, 0x4d, 0x65, 0x73, 0x73, 0x61, 0x67, 0x65, 0x22, 0x3e, 0x0a, 0x17,
 	0x50, 0x65, 0x65, 0x72, 0x42, 0x6f, 0x6f, 0x6b, 0x52, 0x65, 0x73, 0x70, 0x6f, 0x6e, 0x73, 0x65,
 	0x4d, 0x65, 0x73, 0x73, 0x61, 0x67, 0x65, 0x12, 0x23, 0x0a, 0x04, 0x62, 0x6f, 0x6f, 0x6b, 0x18,
@@ -351,22 +430,24 @@ func file_p2p_proto_rawDescGZIP() []byte {
 	return file_p2p_proto_rawDescData
 }
 
-var file_p2p_proto_msgTypes = make([]protoimpl.MessageInfo, 5)
+var file_p2p_proto_msgTypes = make([]protoimpl.MessageInfo, 7)
 var file_p2p_proto_goTypes = []interface{}{
 	(*Envelope)(nil),                // 0: types.Envelope
 	(*Packet)(nil),                  // 1: types.Packet
-	(*PeerBookRequestMessage)(nil),  // 2: types.PeerBookRequestMessage
-	(*PeerBookResponseMessage)(nil), // 3: types.PeerBookResponseMessage
-	(*BookPeer)(nil),                // 4: types.BookPeer
-	(*anypb.Any)(nil),               // 5: google.protobuf.Any
-	(lib.Topic)(0),                  // 6: types.Topic
-	(*lib.PeerAddress)(nil),         // 7: types.PeerAddress
+	(*Ping)(nil),                    // 2: types.Ping
+	(*Pong)(nil),                    // 3: types.Pong
+	(*PeerBookRequestMessage)(nil),  // 4: types.PeerBookRequestMessage
+	(*PeerBookResponseMessage)(nil), // 5: types.PeerBookResponseMessage
+	(*BookPeer)(nil),                // 6: types.BookPeer
+	(*anypb.Any)(nil),               // 7: google.protobuf.Any
+	(lib.Topic)(0),                  // 8: types.Topic
+	(*lib.PeerAddress)(nil),         // 9: types.PeerAddress
 }
 var file_p2p_proto_depIdxs = []int32{
-	5, // 0: types.Envelope.payload:type_name -> google.protobuf.Any
-	6, // 1: types.Packet.stream_id:type_name -> types.Topic
-	4, // 2: types.PeerBookResponseMessage.book:type_name -> types.BookPeer
-	7, // 3: types.BookPeer.Address:type_name -> types.PeerAddress
+	7, // 0: types.Envelope.payload:type_name -> google.protobuf.Any
+	8, // 1: types.Packet.stream_id:type_name -> types.Topic
+	6, // 2: types.PeerBookResponseMessage.book:type_name -> types.BookPeer
+	9, // 3: types.BookPeer.Address:type_name -> types.PeerAddress
 	4, // [4:4] is the sub-list for method output_type
 	4, // [4:4] is the sub-list for method input_type
 	4, // [4:4] is the sub-list for extension type_name
@@ -405,7 +486,7 @@ func file_p2p_proto_init() {
 			}
 		}
 		file_p2p_proto_msgTypes[2].Exporter = func(v interface{}, i int) interface{} {
-			switch v := v.(*PeerBookRequestMessage); i {
+			switch v := v.(*Ping); i {
 			case 0:
 				return &v.state
 			case 1:
@@ -417,7 +498,7 @@ func file_p2p_proto_init() {
 			}
 		}
 		file_p2p_proto_msgTypes[3].Exporter = func(v interface{}, i int) interface{} {
-			switch v := v.(*PeerBookResponseMessage); i {
+			switch v := v.(*Pong); i {
 			case 0:
 				return &v.state
 			case 1:
@@ -429,6 +510,30 @@ func file_p2p_proto_init() {
 			}
 		}
 		file_p2p_proto_msgTypes[4].Exporter = func(v interface{}, i int) interface{} {
+			switch v := v.(*PeerBookRequestMessage); i {
+			case 0:
+				return &v.state
+			case 1:
+				return &v.sizeCache
+			case 2:
+				return &v.unknownFields
+			default:
+				return nil
+			}
+		}
+		file_p2p_proto_msgTypes[5].Exporter = func(v interface{}, i int) interface{} {
+			switch v := v.(*PeerBookResponseMessage); i {
+			case 0:
+				return &v.state
+			case 1:
+				return &v.sizeCache
+			case 2:
+				return &v.unknownFields
+			default:
+				return nil
+			}
+		}
+		file_p2p_proto_msgTypes[6].Exporter = func(v interface{}, i int) interface{} {
 			switch v := v.(*BookPeer); i {
 			case 0:
 				return &v.state
@@ -447,7 +552,7 @@ func file_p2p_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: file_p2p_proto_rawDesc,
 			NumEnums:      0,
-			NumMessages:   5,
+			NumMessages:   7,
 			NumExtensions: 0,
 			NumServices:   0,
 		},


### PR DESCRIPTION
Add back old ping pong implementation using new `sendProtoMsg` func

Dependency: https://github.com/canopy-network/canopy/pull/144 for unit test fix