### PR TITLE
Node Sync Fixes

### DIFF
--- a/controller/consensus.go
+++ b/controller/consensus.go
@@ -112,8 +112,6 @@ func (c *Controller) Sync() {
 			for _, peer := range peers {
 				syncingPeers = append(syncingPeers, lib.BytesToString(peer.Address.PublicKey))
 			}
-			// Remove requests that have timed out
-			c.applyTimeouts(queue)
 			// Calculate the height to stop at when updating queue
 			stopHeight := min(fsmHeight+blockSyncQueueSize, maxHeight)
 			// Send block requests for any missing heights in the queue
@@ -141,6 +139,8 @@ func (c *Controller) Sync() {
 				maxHeight, minVDFIterations = m, v
 				c.log.Debugf("Updated chain %d with max height: %d and iterations %d", c.Config.ChainId, maxHeight, minVDFIterations)
 			}
+			// Remove any block requests that have timed out
+			c.applyTimeouts(queue)
 		}
 	}
 	// Syncing complete

--- a/controller/consensus.go
+++ b/controller/consensus.go
@@ -183,8 +183,6 @@ func (c *Controller) processQueue(startHeight, stopHeight uint64, queue map[uint
 			c.P2P.ChangeReputation(req.message.Sender.Address.PublicKey, p2p.InvalidBlockRep)
 			break
 		}
-		// unlock controller
-		c.Unlock()
 		// calculate and log the elapsed time
 		elapsed := time.Since(start)
 		c.log.Infof("Block %d sync complete. HandlePeerBlock took %s", height, elapsed)

--- a/controller/consensus.go
+++ b/controller/consensus.go
@@ -229,6 +229,7 @@ func (c *Controller) sendBlockRequests(start, stop uint64, queue map[uint64]bloc
 
 		// Add new request to queue
 		queue[height] = blockSyncRequest{
+			timestamp:     time.Now(),
 			height:        height,
 			peerPublicKey: peerPublicKey,
 		}


### PR DESCRIPTION
This PR addresses the following:

- blockRequest timestamp initialization
- Panic due to missing lock around `HandlePeerBlock`
- One sufficiently long `processQueue` times, block requests could timeout when they shouldn't