### PR TITLE
feat: implent auto update

### DIFF
--- a/.docker/Dockerfile
+++ b/.docker/Dockerfile
@@ -2,7 +2,6 @@ FROM golang:1.23.9-alpine AS builder
 
 RUN apk update && apk add --no-cache make bash nodejs npm
 
-ARG BUILD_PATH
 ARG EXPLORER_BASE_PATH
 ARG WALLET_BASE_PATH
 
@@ -14,7 +13,7 @@ ENV WALLET_BASE_PATH=${WALLET_BASE_PATH}
 
 RUN make build/wallet
 RUN make build/explorer
-RUN go build -a -o bin ./${BUILD_PATH}/*.go
+RUN go build -a -o bin ./cmd/main/...
 
 FROM alpine:3.19
 WORKDIR /app

--- a/.docker/compose.yaml
+++ b/.docker/compose.yaml
@@ -5,7 +5,6 @@ services:
       context: ..
       dockerfile: .docker/Dockerfile
       args:
-        BUILD_PATH: cmd/cli
         EXPLORER_BASE_PATH: ""
         WALLET_BASE_PATH: ""
     ports:
@@ -31,7 +30,6 @@ services:
       context: ..
       dockerfile: .docker/Dockerfile
       args:
-        BUILD_PATH: cmd/cli
         EXPLORER_BASE_PATH: ""
         WALLET_BASE_PATH: ""
     ports:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,44 @@
+name: Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Tag for the release (e.g. v1.0.0)'
+        required: true
+
+jobs:
+  release:
+    name: Build and Release
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.22' # Change this to match your Go version
+
+      - name: Build binaries
+        run: |
+          make build/wallet
+          make build/explorer
+          mkdir -p dist
+
+          # AMD64 build
+          GOARCH=amd64 CGO_ENABLED=0 GOOS=linux go build -a -o dist/cli-linux-amd64 ./cmd/main/...
+
+          # ARM64 build
+          GOARCH=arm64 CGO_ENABLED=0 GOOS=linux go build -a -o dist/cli-linux-arm64 ./cmd/main/...
+
+      - name: Create GitHub release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ github.event.inputs.tag }}
+          files: |
+            dist/cli-linux-amd64
+            dist/cli-linux-arm64
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,7 @@ vendor
 # Environment
 .docker/.env
 .docker/volumes/
+.env
 
 .docs/TIMELOG.md
 .docs/WISHLIST.md

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,9 +2,9 @@ FROM golang:1.23.9-alpine AS builder
 
 RUN apk update && apk add --no-cache make bash nodejs npm
 
-ARG BUILD_PATH
 ARG EXPLORER_BASE_PATH
 ARG WALLET_BASE_PATH
+ARG BIN_PATH
 
 WORKDIR /go/src/github.com/canopy-network/canopy
 COPY . /go/src/github.com/canopy-network/canopy
@@ -15,12 +15,21 @@ ENV WALLET_BASE_PATH=${WALLET_BASE_PATH}
 RUN make build/wallet
 RUN make build/explorer
 RUN CGO_ENABLED=0 GOOS=linux go build -a -o bin ./auto-update/.
-RUN CGO_ENABLED=0 GOOS=linux go build -a -o cli ./cmd/main/...
 
+# Only build if the file at ${BIN_PATH} doesn't already exist
+RUN if [ ! -f "${BIN_PATH}" ]; then \
+    echo "File ${BIN_PATH} not found. Building it..."; \
+    CGO_ENABLED=0 GOOS=linux go build -a -o "${BIN_PATH}" ./cmd/main/...; \
+  else \
+    echo "File ${BIN_PATH} already exists. Skipping build."; \
+  fi
 
 FROM alpine:3.19
+
+ARG BIN_PATH
+
 WORKDIR /app
 COPY --from=builder /go/src/github.com/canopy-network/canopy/bin ./
-COPY --from=builder /go/src/github.com/canopy-network/canopy/cli ./cli
-RUN chmod +x ./cli
+COPY --from=builder /go/src/github.com/canopy-network/canopy/${BIN_PATH} ${BIN_PATH}
+RUN chmod +x ${BIN_PATH}
 ENTRYPOINT ["/app/bin"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,7 @@ COPY . /go/src/github.com/canopy-network/canopy
 # RUN make build/wallet
 # RUN make build/explorer
 RUN CGO_ENABLED=0 GOOS=linux go build -a -o bin ./auto-update/.
+RUN CGO_ENABLED=0 GOOS=linux go build -a -o cli ./cmd/main/...
 
 
 FROM alpine:3.19

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,19 +1,19 @@
 FROM golang:1.23.9-alpine AS builder
 
-# RUN apk update && apk add --no-cache make bash nodejs npm
+RUN apk update && apk add --no-cache make bash nodejs npm
 
-# ARG BUILD_PATH
-# ARG EXPLORER_BASE_PATH
-# ARG WALLET_BASE_PATH
+ARG BUILD_PATH
+ARG EXPLORER_BASE_PATH
+ARG WALLET_BASE_PATH
 
 WORKDIR /go/src/github.com/canopy-network/canopy
 COPY . /go/src/github.com/canopy-network/canopy
 
-# ENV EXPLORER_BASE_PATH=${EXPLORER_BASE_PATH}
-# ENV WALLET_BASE_PATH=${WALLET_BASE_PATH}
+ENV EXPLORER_BASE_PATH=${EXPLORER_BASE_PATH}
+ENV WALLET_BASE_PATH=${WALLET_BASE_PATH}
 
-# RUN make build/wallet
-# RUN make build/explorer
+RUN make build/wallet
+RUN make build/explorer
 RUN CGO_ENABLED=0 GOOS=linux go build -a -o bin ./auto-update/.
 RUN CGO_ENABLED=0 GOOS=linux go build -a -o cli ./cmd/main/...
 

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # Variables
 GO_BIN_DIR := ~/go/bin
-CLI_DIR := ./cmd/cli/...
+CLI_DIR := ./cmd/main/...
 WALLET_DIR := ./cmd/rpc/web/wallet
 EXPLORER_DIR := ./cmd/rpc/web/explorer
 DOCKER_DIR := ./.docker/compose.yaml

--- a/auto-update/Dockerfile
+++ b/auto-update/Dockerfile
@@ -1,0 +1,25 @@
+FROM golang:1.23.9-alpine AS builder
+
+# RUN apk update && apk add --no-cache make bash nodejs npm
+
+# ARG BUILD_PATH
+# ARG EXPLORER_BASE_PATH
+# ARG WALLET_BASE_PATH
+
+WORKDIR /go/src/github.com/canopy-network/canopy
+COPY . /go/src/github.com/canopy-network/canopy
+
+# ENV EXPLORER_BASE_PATH=${EXPLORER_BASE_PATH}
+# ENV WALLET_BASE_PATH=${WALLET_BASE_PATH}
+
+# RUN make build/wallet
+# RUN make build/explorer
+RUN CGO_ENABLED=0 GOOS=linux go build -a -o bin ./auto-update/.
+
+
+FROM alpine:3.19
+WORKDIR /app
+COPY --from=builder /go/src/github.com/canopy-network/canopy/bin ./
+COPY --from=builder /go/src/github.com/canopy-network/canopy/cli ./cli
+RUN chmod +x ./cli
+ENTRYPOINT ["/app/bin"]

--- a/auto-update/README.md
+++ b/auto-update/README.md
@@ -1,0 +1,117 @@
+# Canopy Auto-Update Package
+
+This package implements an automatic update mechanism for the Canopy CLI application. It periodically checks for new releases and automatically updates the binary when available, ensuring users always have the latest version of the software.
+
+## Overview
+
+The auto-update package provides a robust mechanism to:
+- Check for new releases on GitHub
+- Download and install updates automatically
+- Manage the running CLI process
+- Handle graceful updates without disrupting the user experience
+
+## Architecture
+
+### Flow of Operation
+
+1. **Initialization and Configuration**
+   - The system starts by checking if auto-update is enabled in the configuration
+   - Sets up necessary data directories and binary paths
+   - Initializes thread-safe state management mechanisms
+   - Creates communication channels for process coordination
+
+2. **Version Check and Update Detection**
+   - Every 30 minutes, the system queries GitHub's API for the latest release
+   - Compares the current version with the latest release
+   - If a new version is found, sets a flag to prevent concurrent updates
+   - The system identifies the appropriate platform-specific binary for the current OS/architecture
+
+3. **Update Process**
+   - When a new version is detected, the system:
+     1. Downloads the new binary while maintaining exclusive access
+     2. Replaces the existing binary with proper permissions
+     3. Adds a random delay (1-30 minutes) to prevent update storms
+     4. Sets an update-in-progress flag to manage the update state
+
+4. **Process Management**
+   - The system maintains two main goroutines:
+     1. Process Manager: Handles the CLI process lifecycle
+     2. Update Checker: Periodically checks for new versions
+   - When an update is ready:
+     1. Sends termination signal to the current process
+     2. Waits for process termination
+     3. Starts the new version
+     4. Maintains process state and handles errors
+
+5. **Thread Safety and Coordination**
+   - Uses atomic flags for state management:
+     - Update-in-progress flag: Prevents process exit during updates
+     - Update-detection flag: Prevents concurrent update handling
+   - Implements mutex for binary file access
+   - Uses buffered channels for process coordination:
+     - Start signal channel: Signals process start
+     - End signal channel: Signals process end
+
+## How It Works
+
+1. **Initialization**
+   - Creates necessary data directories
+   - Loads configuration
+   - Sets up binary path
+
+2. **Update Check Loop**
+   - Runs every 30 minutes
+   - Fetches latest release from GitHub
+   - Compares versions
+   - Triggers update if needed
+
+3. **Update Process**
+   - Downloads new binary
+   - Adds random delay (1-30 minutes)
+   - Gracefully terminates current process
+   - Starts new version
+   - Maintains process state
+
+4. **Error Handling**
+   - Manages download failures
+   - Handles process termination errors
+   - Recovers from failed updates
+   - Logs error conditions
+
+## Configuration
+
+The auto-update mechanism can be enabled/disabled through the Canopy configuration:
+
+```json
+{
+    "autoUpdate": true
+}
+```
+
+## Environment Variables
+
+- `BIN_PATH`: Specifies the path to the CLI binary (defaults to "./cli")
+
+## Dependencies
+
+- Go standard library
+- GitHub API for release information
+- Canopy core packages
+
+## Usage
+
+For deployment examples, refer to the `Dockerfile` in the root of the repository. The Dockerfile demonstrates:
+- How to build the auto-update enabled binary
+- Proper environment setup
+- Required permissions
+- Volume mounting for persistence
+- Process management in a containerized environment
+
+Example Dockerfile usage:
+```bash
+# Build the image
+docker build --build-arg BIN_PATH=./cli -t canopy .
+
+# Run the container
+docker run -it --env-file=.env -p 50000:50000 -p 50001:50001 -p 50002:50002 -p 50003:50003 -p 9001:9001 --name canopy canopy
+```

--- a/auto-update/main.go
+++ b/auto-update/main.go
@@ -11,7 +11,6 @@ import (
 	"os/exec"
 	"path/filepath"
 	"runtime"
-	"strconv"
 	"sync"
 	"sync/atomic"
 	"syscall"
@@ -23,19 +22,18 @@ import (
 )
 
 const (
-	repoOwner = "pablocampogo"
+	repoOwner = "canopy-network"
 	repoName  = "canopy"
-	binPath   = "./cli"
 )
 
 var (
-	autoUpdate    bool
-	rawAutoUpdate = os.Getenv("AUTO_UPDATE")
+	binPath = os.Getenv("BIN_PATH")
 )
 
 func init() {
-	// is safe to ignore the error and assume false
-	autoUpdate, _ = strconv.ParseBool(rawAutoUpdate)
+	if binPath == "" {
+		binPath = "./cli"
+	}
 }
 
 type Release struct {
@@ -115,7 +113,6 @@ type Release struct {
 }
 
 func getLatestRelease() (string, string, error) {
-	// return "v0.0.5", "https://github.com/pablocampogo/canopy/releases/download/v0.0.5/cli", nil
 	apiURL := "https://api.github.com/repos/" + repoOwner + "/" + repoName + "/releases/latest"
 	resp, err := http.Get(apiURL)
 	if err != nil {

--- a/auto-update/main.go
+++ b/auto-update/main.go
@@ -368,6 +368,12 @@ func runAutoUpdate() {
 // main is the entry point of the application
 // It handles both manual and auto-update modes based on configuration
 func main() {
+	// check if start was called or just waken up for setup
+	if len(os.Args) < 2 || os.Args[1] != "start" {
+		log.Println("Set up complete! Now you can start!")
+		return
+	}
+
 	// Initialize data directory and configuration
 	err := os.MkdirAll(cli.DataDir, os.ModePerm)
 	if err != nil {

--- a/auto-update/main.go
+++ b/auto-update/main.go
@@ -228,7 +228,7 @@ func main() {
 				<-notifyStartRun
 
 				downloadLock.Lock()
-				log.Printf("Starting %s...\n", binPath)
+				log.Printf("Starting version: %s in %s...\n", curRelease, binPath)
 				cmd, err = runBinary()
 				if err != nil {
 					log.Printf("Failed to run binary: %v", err)

--- a/auto-update/main.go
+++ b/auto-update/main.go
@@ -25,19 +25,22 @@ import (
 
 // Constants defining the GitHub repository information
 const (
-	repoOwner = "canopy-network"
-	repoName  = "canopy"
+	repoName = "canopy"
 )
 
 // Global variable for the binary path
 var (
-	binPath = os.Getenv("BIN_PATH")
+	binPath   = os.Getenv("BIN_PATH")
+	repoOwner = os.Getenv("REPO_OWNER")
 )
 
 // init initializes the binary path if not set in environment variables
 func init() {
 	if binPath == "" {
 		binPath = "./cli"
+	}
+	if repoOwner == "" {
+		repoOwner = "canopy-network"
 	}
 }
 

--- a/auto-update/main.go
+++ b/auto-update/main.go
@@ -306,8 +306,8 @@ func main() {
 					}
 				}
 
-				log.Println("Checking for upgrade in 5s...")
-				time.Sleep(5 * time.Second)
+				log.Println("Checking for upgrade in 30m...")
+				time.Sleep(30 * time.Minute)
 			}
 		}()
 		_, err = os.Stat(binPath)

--- a/auto-update/main.go
+++ b/auto-update/main.go
@@ -1,0 +1,258 @@
+package main
+
+import (
+	"encoding/json"
+	"errors"
+	"io"
+	"log"
+	"net/http"
+	"os"
+	"os/exec"
+	"strconv"
+	"sync"
+	"syscall"
+	"time"
+
+	"github.com/canopy-network/canopy/cmd/cli"
+	"github.com/canopy-network/canopy/cmd/rpc"
+)
+
+const (
+	repoOwner = "pablocampogo"
+	repoName  = "canopy"
+	binPath   = "./cli"
+)
+
+var (
+	autoUpdate    bool
+	rawAutoUpdate = os.Getenv("AUTO_UPDATE")
+)
+
+func init() {
+	// is safe to ignore the error and assume false
+	autoUpdate, _ = strconv.ParseBool(rawAutoUpdate)
+}
+
+type Release struct {
+	URL       string `json:"url"`
+	AssetsURL string `json:"assets_url"`
+	UploadURL string `json:"upload_url"`
+	HTMLURL   string `json:"html_url"`
+	ID        int    `json:"id"`
+	Author    struct {
+		Login             string `json:"login"`
+		ID                int    `json:"id"`
+		NodeID            string `json:"node_id"`
+		AvatarURL         string `json:"avatar_url"`
+		GravatarID        string `json:"gravatar_id"`
+		URL               string `json:"url"`
+		HTMLURL           string `json:"html_url"`
+		FollowersURL      string `json:"followers_url"`
+		FollowingURL      string `json:"following_url"`
+		GistsURL          string `json:"gists_url"`
+		StarredURL        string `json:"starred_url"`
+		SubscriptionsURL  string `json:"subscriptions_url"`
+		OrganizationsURL  string `json:"organizations_url"`
+		ReposURL          string `json:"repos_url"`
+		EventsURL         string `json:"events_url"`
+		ReceivedEventsURL string `json:"received_events_url"`
+		Type              string `json:"type"`
+		UserViewType      string `json:"user_view_type"`
+		SiteAdmin         bool   `json:"site_admin"`
+	} `json:"author"`
+	NodeID          string    `json:"node_id"`
+	TagName         string    `json:"tag_name"`
+	TargetCommitish string    `json:"target_commitish"`
+	Name            string    `json:"name"`
+	Draft           bool      `json:"draft"`
+	Prerelease      bool      `json:"prerelease"`
+	CreatedAt       time.Time `json:"created_at"`
+	PublishedAt     time.Time `json:"published_at"`
+	Assets          []struct {
+		URL      string      `json:"url"`
+		ID       int         `json:"id"`
+		NodeID   string      `json:"node_id"`
+		Name     string      `json:"name"`
+		Label    interface{} `json:"label"`
+		Uploader struct {
+			Login             string `json:"login"`
+			ID                int    `json:"id"`
+			NodeID            string `json:"node_id"`
+			AvatarURL         string `json:"avatar_url"`
+			GravatarID        string `json:"gravatar_id"`
+			URL               string `json:"url"`
+			HTMLURL           string `json:"html_url"`
+			FollowersURL      string `json:"followers_url"`
+			FollowingURL      string `json:"following_url"`
+			GistsURL          string `json:"gists_url"`
+			StarredURL        string `json:"starred_url"`
+			SubscriptionsURL  string `json:"subscriptions_url"`
+			OrganizationsURL  string `json:"organizations_url"`
+			ReposURL          string `json:"repos_url"`
+			EventsURL         string `json:"events_url"`
+			ReceivedEventsURL string `json:"received_events_url"`
+			Type              string `json:"type"`
+			UserViewType      string `json:"user_view_type"`
+			SiteAdmin         bool   `json:"site_admin"`
+		} `json:"uploader"`
+		ContentType        string      `json:"content_type"`
+		State              string      `json:"state"`
+		Size               int         `json:"size"`
+		Digest             interface{} `json:"digest"`
+		DownloadCount      int         `json:"download_count"`
+		CreatedAt          time.Time   `json:"created_at"`
+		UpdatedAt          time.Time   `json:"updated_at"`
+		BrowserDownloadURL string      `json:"browser_download_url"`
+	} `json:"assets"`
+	TarballURL string `json:"tarball_url"`
+	ZipballURL string `json:"zipball_url"`
+	Body       string `json:"body"`
+}
+
+func getLatestRelease() (string, string, error) {
+	// return "v0.0.5", "https://github.com/pablocampogo/canopy/releases/download/v0.0.5/cli", nil
+	apiURL := "https://api.github.com/repos/" + repoOwner + "/" + repoName + "/releases/latest"
+	resp, err := http.Get(apiURL)
+	if err != nil {
+		return "", "", err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == 200 {
+		var rel Release
+		if err := json.NewDecoder(resp.Body).Decode(&rel); err != nil {
+			return "", "", err
+		}
+
+		return rel.TagName, rel.Assets[0].BrowserDownloadURL, nil
+	}
+
+	return "", "", errors.New("NON 200 OK")
+
+	// // Find asset matching OS and ARCH
+	// targetName := repoName + "-" + runtime.GOOS + "-" + runtime.GOARCH
+	// for _, asset := range rel.Assets {
+	// 	if asset.Name == targetName {
+	// 		return rel.TagName, asset.BrowserDownloadURL, nil
+	// 	}
+	// }
+	// return "", "", io.EOF
+}
+
+func downloadRelease(downloadURL string) error {
+	resp, err := http.Get(downloadURL)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == 200 {
+		err = os.Remove(binPath)
+		if err != nil {
+			return err
+		}
+
+		out, err := os.Create(binPath)
+		if err != nil {
+			return err
+		}
+		defer out.Close()
+
+		if _, err := io.Copy(out, resp.Body); err != nil {
+			return err
+		}
+
+		err = os.Chmod(binPath, 0755)
+		if err != nil {
+			return err
+		}
+
+		return nil
+	}
+
+	return errors.New("NON 200 OK")
+}
+
+func runBinary() (*exec.Cmd, error) {
+	cmd := exec.Command(binPath, "start")
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	cmd.Stdin = os.Stdin
+
+	err := cmd.Start()
+	if err != nil {
+		return nil, err
+	}
+
+	return cmd, nil
+}
+
+func main() {
+	if !autoUpdate {
+		cli.Start()
+	} else {
+		var cmd *exec.Cmd
+		var cmdWg sync.WaitGroup
+		curRelease := rpc.SoftwareVersion
+		newRun := true
+		for {
+			version, url, err := getLatestRelease()
+			if err != nil {
+				newRun = false
+				goto check_run
+			}
+
+			if curRelease != version {
+				curRelease = version
+				log.Println("NEW VERSION FOUND")
+				err := downloadRelease(url)
+				if err != nil {
+					newRun = false
+					goto check_run
+				}
+
+				log.Println("NEW DOWNLOAD DONE")
+
+				if cmd != nil {
+					err = cmd.Process.Signal(syscall.SIGINT)
+					if err != nil {
+						panic(err)
+					}
+				}
+
+				log.Println("SENT KILL SIGNAL")
+
+				cmdWg.Wait()
+
+				log.Println("KILLED OLD PROCESS")
+
+				newRun = true
+			} else {
+				log.Println("NO NEW VERSION FOUND")
+				newRun = false
+			}
+
+		check_run:
+			if newRun {
+				cmdWg.Add(1)
+
+				go func() {
+					defer cmdWg.Done()
+					log.Printf("Starting %s...\n", binPath)
+					cmd, err = runBinary()
+					if err != nil {
+						log.Fatalf("Failed to run binary: %v", err)
+					}
+
+					// Wait for the child process to exit
+					err = cmd.Wait()
+					log.Printf("Process exited: %v", err)
+				}()
+			}
+
+			log.Println("Checking for upgrade in 5s...")
+			time.Sleep(5 * time.Second)
+		}
+	}
+
+}

--- a/auto-update/main.go
+++ b/auto-update/main.go
@@ -148,7 +148,11 @@ func getLatestRelease() (string, string, error) {
 		return "", "", io.EOF
 	}
 
-	return "", "", errors.New("NON 200 OK")
+	bodyBytes, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", "", fmt.Errorf("HTTP %d: failed to read response body", resp.StatusCode)
+	}
+	return "", "", fmt.Errorf("HTTP %d: %s", resp.StatusCode, string(bodyBytes))
 }
 
 // downloadRelease downloads and replaces the current binary with the new version
@@ -288,7 +292,7 @@ func main() {
 					log.Println("NEW VERSION FOUND")
 					err := downloadRelease(url, downloadLock)
 					if err != nil {
-						log.Printf("Failed to download release: %v", err)
+						log.Printf("Failed to download release from %s: %v", repoOwner, err)
 						continue
 					}
 					curRelease = version

--- a/auto-update/main.go
+++ b/auto-update/main.go
@@ -285,6 +285,8 @@ func main() {
 				version, url, err := getLatestRelease()
 				if err != nil {
 					log.Printf("Failed get latest release from %s: %v", repoOwner, err)
+					log.Println("Checking for upgrade in 30m...")
+					time.Sleep(30 * time.Minute)
 					continue
 				}
 
@@ -293,6 +295,8 @@ func main() {
 					err := downloadRelease(url, downloadLock)
 					if err != nil {
 						log.Printf("Failed to download release from %s: %v", repoOwner, err)
+						log.Println("Checking for upgrade in 30m...")
+						time.Sleep(30 * time.Minute)
 						continue
 					}
 					curRelease = version

--- a/cmd/cli/admin.go
+++ b/cmd/cli/admin.go
@@ -1,4 +1,4 @@
-package main
+package cli
 
 import (
 	"encoding/json"

--- a/cmd/cli/cli.go
+++ b/cmd/cli/cli.go
@@ -46,6 +46,9 @@ func init() {
 	autoCompleteCmd.AddCommand(generateCompleteCmd)
 	autoCompleteCmd.AddCommand(autoCompleteInstallCmd)
 	rootCmd.PersistentFlags().StringVar(&DataDir, "data-dir", lib.DefaultDataDirPath(), "custom data directory location")
+	config, validatorKey = InitializeDataDirectory(DataDir, lib.NewDefaultLogger())
+	l = lib.NewLogger(lib.LoggerConfig{Level: config.GetLogLevel()})
+	client = rpc.NewClient(config.RPCUrl, config.AdminRPCUrl)
 }
 
 func Execute() {
@@ -71,9 +74,6 @@ func Start() {
 		l.Infof("Sleeping until %s", untilTime.String())
 		time.Sleep(untilTime)
 	}
-	config, validatorKey = InitializeDataDirectory(DataDir, lib.NewDefaultLogger())
-	l = lib.NewLogger(lib.LoggerConfig{Level: config.GetLogLevel()})
-	client = rpc.NewClient(config.RPCUrl, config.AdminRPCUrl)
 	// initialize and start the metrics server
 	metrics := lib.NewMetricsServer(validatorKey.PublicKey().Address(), config.MetricsConfig)
 	// create a new database object from the config

--- a/cmd/cli/cli.go
+++ b/cmd/cli/cli.go
@@ -34,7 +34,7 @@ var rootCmd = &cobra.Command{
 
 var (
 	client, config, l     = &rpc.Client{}, lib.Config{}, lib.LoggerI(nil)
-	dataDir, validatorKey = "", crypto.PrivateKeyI(nil)
+	DataDir, validatorKey = "", crypto.PrivateKeyI(nil)
 )
 
 func init() {
@@ -45,7 +45,7 @@ func init() {
 	rootCmd.AddCommand(autoCompleteCmd)
 	autoCompleteCmd.AddCommand(generateCompleteCmd)
 	autoCompleteCmd.AddCommand(autoCompleteInstallCmd)
-	rootCmd.PersistentFlags().StringVar(&dataDir, "data-dir", lib.DefaultDataDirPath(), "custom data directory location")
+	rootCmd.PersistentFlags().StringVar(&DataDir, "data-dir", lib.DefaultDataDirPath(), "custom data directory location")
 }
 
 func Execute() {
@@ -71,7 +71,7 @@ func Start() {
 		l.Infof("Sleeping until %s", untilTime.String())
 		time.Sleep(untilTime)
 	}
-	config, validatorKey = InitializeDataDirectory(dataDir, lib.NewDefaultLogger())
+	config, validatorKey = InitializeDataDirectory(DataDir, lib.NewDefaultLogger())
 	l = lib.NewLogger(lib.LoggerConfig{Level: config.GetLogLevel()})
 	client = rpc.NewClient(config.RPCUrl, config.AdminRPCUrl)
 	// initialize and start the metrics server

--- a/cmd/cli/cli.go
+++ b/cmd/cli/cli.go
@@ -1,4 +1,4 @@
-package main
+package cli
 
 import (
 	"encoding/json"
@@ -46,13 +46,9 @@ func init() {
 	autoCompleteCmd.AddCommand(generateCompleteCmd)
 	autoCompleteCmd.AddCommand(autoCompleteInstallCmd)
 	rootCmd.PersistentFlags().StringVar(&dataDir, "data-dir", lib.DefaultDataDirPath(), "custom data directory location")
-
-	config, validatorKey = InitializeDataDirectory(dataDir, lib.NewDefaultLogger())
-	l = lib.NewLogger(lib.LoggerConfig{Level: config.GetLogLevel()})
-	client = rpc.NewClient(config.RPCUrl, config.AdminRPCUrl)
 }
 
-func main() {
+func Execute() {
 	if err := rootCmd.Execute(); err != nil {
 		log.Fatal(err)
 	}
@@ -75,6 +71,9 @@ func Start() {
 		l.Infof("Sleeping until %s", untilTime.String())
 		time.Sleep(untilTime)
 	}
+	config, validatorKey = InitializeDataDirectory(dataDir, lib.NewDefaultLogger())
+	l = lib.NewLogger(lib.LoggerConfig{Level: config.GetLogLevel()})
+	client = rpc.NewClient(config.RPCUrl, config.AdminRPCUrl)
 	// initialize and start the metrics server
 	metrics := lib.NewMetricsServer(validatorKey.PublicKey().Address(), config.MetricsConfig)
 	// create a new database object from the config

--- a/cmd/cli/query.go
+++ b/cmd/cli/query.go
@@ -1,10 +1,11 @@
-package main
+package cli
 
 import (
-	"github.com/canopy-network/canopy/lib"
-	"github.com/spf13/cobra"
 	"strconv"
 	"strings"
+
+	"github.com/canopy-network/canopy/lib"
+	"github.com/spf13/cobra"
 )
 
 var queryCmd = &cobra.Command{

--- a/cmd/main/main.go
+++ b/cmd/main/main.go
@@ -1,0 +1,7 @@
+package main
+
+import "github.com/canopy-network/canopy/cmd/cli"
+
+func main() {
+	cli.Execute()
+}

--- a/lib/config.go
+++ b/lib/config.go
@@ -64,6 +64,7 @@ type MainConfig struct {
 	RootChain  []RootChain `json:"rootChain"`  // a list of the root chain(s) a node could connect to as dictated by the governance parameter 'RootChainId'
 	RunVDF     bool        `json:"runVDF"`     // whether the node should run a Verifiable Delay Function to help secure the network against Long-Range-Attacks
 	Headless   bool        `json:"headless"`   // turn off the web wallet and block explorer 'web' front ends
+	AutoUpdate bool        `json:"autoUpdate"` // check for new versions of software each X time
 }
 
 // DefaultMainConfig() sets log level to 'info'
@@ -76,9 +77,10 @@ func DefaultMainConfig() MainConfig {
 				Url:     "http://localhost:50002", // RooChainURL points to self
 			},
 		},
-		RunVDF:   true,          // run the VDF by default
-		ChainId:  CanopyChainId, // default chain url is 1
-		Headless: false,         // serve the web wallet and block explorer by default
+		RunVDF:     true,          // run the VDF by default
+		ChainId:    CanopyChainId, // default chain url is 1
+		Headless:   false,         // serve the web wallet and block explorer by default
+		AutoUpdate: true,          // set it as default while in inmature state
 	}
 }
 

--- a/lib/config.go
+++ b/lib/config.go
@@ -58,13 +58,14 @@ func DefaultConfig() Config {
 // MAIN CONFIG BELOW
 
 type MainConfig struct {
-	LogLevel   string      `json:"logLevel"`   // any level includes the levels above it: debug < info < warning < error
-	ChainId    uint64      `json:"chainId"`    // the identifier of this particular chain within a single 'network id'
-	SleepUntil uint64      `json:"sleepUntil"` // allows coordinated 'wake-ups' for genesis or chain halt events
-	RootChain  []RootChain `json:"rootChain"`  // a list of the root chain(s) a node could connect to as dictated by the governance parameter 'RootChainId'
-	RunVDF     bool        `json:"runVDF"`     // whether the node should run a Verifiable Delay Function to help secure the network against Long-Range-Attacks
-	Headless   bool        `json:"headless"`   // turn off the web wallet and block explorer 'web' front ends
-	AutoUpdate bool        `json:"autoUpdate"` // check for new versions of software each X time
+	LogLevel          string      `json:"logLevel"`          // any level includes the levels above it: debug < info < warning < error
+	ChainId           uint64      `json:"chainId"`           // the identifier of this particular chain within a single 'network id'
+	SleepUntil        uint64      `json:"sleepUntil"`        // allows coordinated 'wake-ups' for genesis or chain halt events
+	RootChain         []RootChain `json:"rootChain"`         // a list of the root chain(s) a node could connect to as dictated by the governance parameter 'RootChainId'
+	RunVDF            bool        `json:"runVDF"`            // whether the node should run a Verifiable Delay Function to help secure the network against Long-Range-Attacks
+	Headless          bool        `json:"headless"`          // turn off the web wallet and block explorer 'web' front ends
+	AutoUpdate        bool        `json:"autoUpdate"`        // check for new versions of software each X time
+	RunningAutoUpdate bool        `json:"runningAutoUpdate"` // flag to identify if the auto update software is running
 }
 
 // DefaultMainConfig() sets log level to 'info'


### PR DESCRIPTION
## Description
Add auto update main.go process to handle updates on new releases of canopy

## Related Issues
<!-- List any issues this pull request closes. -->
Closes: #162 

## Changes Made
<!-- Highlight the key changes made in the code. For example: -->
- Add cli package on cmd to separate the main.go file to its own package, this to be able to import vars from it in the auto update package.
- Change config setup to be when canopy software starts.
- Add auto update flag to the config.
- Add auto update mechanism to check for updates on the official github repo of canopy network
- Add Dockerfile on example on how to deploy it
- Update makefile to new binary location
- Add action to create release in github and add binaries

## Checklist
- [x] I have tested the changes locally and verified they work as intended.
- [x] I have appropriately titled my branch `issue-#<issue-number>`.
- [x] I have run re-built the web-wallet and/or block explorer (if applicable).
- [ ] I have run `npm run prettier` to format the web-wallet and/or block explorer (if applicable)
- [x] I have updated documentation (if applicable).
- [] I have included tests for the changes (if applicable).

<!--
## Additional Notes
 Add any additional context, screenshots, or information that reviewers might find helpful. -->
Current .docker dir was just updated to the new location of the main binary not using the auto update since its main purpose is for testing development versions
