### PR TITLE
OrderBook.GetOrder fix

### DIFF
--- a/lib/swap.go
+++ b/lib/swap.go
@@ -21,7 +21,7 @@ func (x *OrderBook) GetOrder(orderId []byte) (order *SellOrder, err ErrorI) {
 			return
 		}
 	}
-	return
+	return nil, nil
 }
 
 // Empty() indicates whether the sell order is null


### PR DESCRIPTION
Fix for OrderBook's GetOrder.

Previously it would return the last order when there were no matches.