### PR TITLE
fix: make auto update to not send kill to child when child fied first

### DIFF
--- a/cmd/rpc/server.go
+++ b/cmd/rpc/server.go
@@ -31,7 +31,7 @@ import (
 const (
 	colon = ":"
 
-	SoftwareVersion = "beta-0.1.4"
+	SoftwareVersion = "beta-0.1.5"
 	ContentType     = "Content-MessageType"
 	ApplicationJSON = "application/json; charset=utf-8"
 


### PR DESCRIPTION
- Add atomic bool to control when kill signal is sent from child
- Get logging a bit better
- Use continues instead of returns where needed