### PR TITLE
fix: delete unnecessary cli logic from auto update and fix version command

### DIFF
--- a/auto-update/main.go
+++ b/auto-update/main.go
@@ -220,9 +220,6 @@ func runBinary() (*exec.Cmd, error) {
 }
 
 func runAutoUpdate() {
-	// save in the config file that the auto update software is running
-	config.RunningAutoUpdate = true
-	config.WriteToFile(configFilePath)
 	if !config.AutoUpdate {
 		cli.Start()
 	} else {
@@ -345,13 +342,6 @@ func runAutoUpdate() {
 				// block until kill signal is received
 				s := <-stop
 				log.Printf("Exit command %s received in auto update\n", s)
-				config, err = lib.NewConfigFromFile(configFilePath)
-				if err != nil {
-					log.Printf("Failed to read config file on closure: %v", err)
-					continue
-				}
-				config.RunningAutoUpdate = false
-				config.WriteToFile(configFilePath)
 				if !killedFromChild.Load() {
 					// Gracefully terminate the current process
 					err = cmd.Process.Signal(syscall.SIGINT)
@@ -404,13 +394,8 @@ func main() {
 	if err != nil {
 		log.Print(err.Error())
 	}
-	// run regular way if not saved it is already running
-	if !config.RunningAutoUpdate {
-		go runAutoUpdate()
-		// Block forever
-		select {}
-		// if the auto update software is already running just setup cli commands
-	} else {
-		cli.Execute()
-	}
+	// Run auto update
+	go runAutoUpdate()
+	// Block forever
+	select {}
 }

--- a/cmd/cli/cli.go
+++ b/cmd/cli/cli.go
@@ -27,9 +27,16 @@ import (
 )
 
 var rootCmd = &cobra.Command{
-	Use:     "canopy",
-	Short:   "the canopy blockchain software",
-	Version: rpc.SoftwareVersion,
+	Use:   "canopy",
+	Short: "the canopy blockchain software",
+}
+
+var versionCmd = &cobra.Command{
+	Use:   "version",
+	Short: "Print the version number",
+	Run: func(cmd *cobra.Command, args []string) {
+		fmt.Println(rpc.SoftwareVersion)
+	},
 }
 
 var (
@@ -40,6 +47,7 @@ var (
 func init() {
 	flag.Parse()
 	rootCmd.AddCommand(startCmd)
+	rootCmd.AddCommand(versionCmd)
 	rootCmd.AddCommand(queryCmd)
 	rootCmd.AddCommand(adminCmd)
 	rootCmd.AddCommand(autoCompleteCmd)

--- a/lib/config.go
+++ b/lib/config.go
@@ -59,14 +59,13 @@ func DefaultConfig() Config {
 // MAIN CONFIG BELOW
 
 type MainConfig struct {
-	LogLevel          string      `json:"logLevel"`          // any level includes the levels above it: debug < info < warning < error
-	ChainId           uint64      `json:"chainId"`           // the identifier of this particular chain within a single 'network id'
-	SleepUntil        uint64      `json:"sleepUntil"`        // allows coordinated 'wake-ups' for genesis or chain halt events
-	RootChain         []RootChain `json:"rootChain"`         // a list of the root chain(s) a node could connect to as dictated by the governance parameter 'RootChainId'
-	RunVDF            bool        `json:"runVDF"`            // whether the node should run a Verifiable Delay Function to help secure the network against Long-Range-Attacks
-	Headless          bool        `json:"headless"`          // turn off the web wallet and block explorer 'web' front ends
-	AutoUpdate        bool        `json:"autoUpdate"`        // check for new versions of software each X time
-	RunningAutoUpdate bool        `json:"runningAutoUpdate"` // flag to identify if the auto update software is running
+	LogLevel   string      `json:"logLevel"`   // any level includes the levels above it: debug < info < warning < error
+	ChainId    uint64      `json:"chainId"`    // the identifier of this particular chain within a single 'network id'
+	SleepUntil uint64      `json:"sleepUntil"` // allows coordinated 'wake-ups' for genesis or chain halt events
+	RootChain  []RootChain `json:"rootChain"`  // a list of the root chain(s) a node could connect to as dictated by the governance parameter 'RootChainId'
+	RunVDF     bool        `json:"runVDF"`     // whether the node should run a Verifiable Delay Function to help secure the network against Long-Range-Attacks
+	Headless   bool        `json:"headless"`   // turn off the web wallet and block explorer 'web' front ends
+	AutoUpdate bool        `json:"autoUpdate"` // check for new versions of software each X time
 }
 
 // DefaultMainConfig() sets log level to 'info'


### PR DESCRIPTION
- Delete unnecessary CLI management command, now the downloaded binary can run CLI commands correctly
- Fix canopy version command