### PR TITLE
Fix for --data-dir and InitializeDataDirectory() call timing.

### DIFF
--- a/cmd/cli/cli.go
+++ b/cmd/cli/cli.go
@@ -29,6 +29,9 @@ import (
 var rootCmd = &cobra.Command{
 	Use:   "canopy",
 	Short: "the canopy blockchain software",
+	PersistentPreRun: func(cmd *cobra.Command, args []string) {
+		initEnv()
+	},
 }
 
 var versionCmd = &cobra.Command{
@@ -54,12 +57,19 @@ func init() {
 	autoCompleteCmd.AddCommand(generateCompleteCmd)
 	autoCompleteCmd.AddCommand(autoCompleteInstallCmd)
 	rootCmd.PersistentFlags().StringVar(&DataDir, "data-dir", lib.DefaultDataDirPath(), "custom data directory location")
-	config, validatorKey = InitializeDataDirectory(DataDir, lib.NewDefaultLogger())
+}
+
+// initEnv initializes global components required for operation
+func initEnv() {
+	// create logger used throughout the application
 	l = lib.NewLogger(lib.LoggerConfig{
 		Level:      config.GetLogLevel(),
 		Structured: config.Structured,
 		JSON:       config.JSON,
 	})
+	// initialize data directory, creating required files if neccessary
+	config, validatorKey = InitializeDataDirectory(DataDir, lib.NewDefaultLogger())
+	// create an rpc client for this node
 	client = rpc.NewClient(config.RPCUrl, config.AdminRPCUrl)
 }
 


### PR DESCRIPTION
Cobra command line parameters are not yet parsed in the init() function, meaning the --data-dir parameter is not yet populated when InitializeDataDirectory is called.

This PR moves a few lines of code to the Start() function where the CLI parameters have been evaluated.