### PR TITLE
fix: spelling on trusted peer ids in config

### DIFF
--- a/lib/config.go
+++ b/lib/config.go
@@ -194,7 +194,7 @@ type P2PConfig struct {
 	ExternalAddress     string   `json:"externalAddress"`     // advertise for external dialing
 	MaxInbound          int      `json:"maxInbound"`          // max inbound peers
 	MaxOutbound         int      `json:"maxOutbound"`         // max outbound peers
-	TrustedPeerIDs      []string `json:"trutedPeersIDs"`      // trusted public keys
+	TrustedPeerIDs      []string `json:"trustedPeerIDs"`      // trusted public keys
 	DialPeers           []string `json:"dialPeers"`           // peers to consistently dial until expo-backoff fails (format pubkey@ip:port)
 	BannedPeerIDs       []string `json:"bannedPeersIDs"`      // banned public keys
 	BannedIPs           []string `json:"bannedIPs"`           // banned IPs


### PR DESCRIPTION
-Fix spelling on P2P config of the json tag
Note: config jsons of testing tags were already using the correct spelling
Closes #225 