### PR TITLE
Fix metrics

### DIFF
--- a/cmd/cli/cli.go
+++ b/cmd/cli/cli.go
@@ -87,7 +87,7 @@ func Start() {
 		time.Sleep(untilTime)
 	}
 	// initialize and start the metrics server
-	metrics := lib.NewMetricsServer(validatorKey.PublicKey().Address(), config.MetricsConfig, l)
+	metrics := lib.NewMetricsServer(validatorKey.PublicKey().Address(), float64(config.ChainId), rpc.SoftwareVersion, config.MetricsConfig, l)
 	// create a new database object from the config
 	db, err := store.New(config, metrics, l)
 	if err != nil {

--- a/controller/consensus.go
+++ b/controller/consensus.go
@@ -656,6 +656,8 @@ func (c *Controller) finishSyncing() {
 	c.Lock()
 	// when function completes, unlock
 	defer c.Unlock()
+	// set the startup block metric (block height when first sync completed)
+	c.Metrics.SetStartupBlock(c.FSM.Height())
 	// signal a reset of bft for the chain
 	c.Consensus.ResetBFT <- bft.ResetBFT{StartTime: c.LoadLastCommitTime(c.FSM.Height())}
 	// set syncing to false

--- a/lib/metrics.go
+++ b/lib/metrics.go
@@ -83,7 +83,7 @@ type NodeMetrics struct {
 type BlockMetrics struct {
 	BlockProcessingTime prometheus.Histogram // how long does it take for this node to commit a block?
 	BlockSize           prometheus.Gauge     // what is the size of the block in bytes?
-	BlockNumTxs         prometheus.Counter   // how many transactions has the node processed?
+	BlockNumTxs         prometheus.Gauge     // how many transactions has the node processed?
 	LargestTxSize       prometheus.Gauge     // what is the largest tx size in a block?
 	BlockVDFIterations  prometheus.Gauge     // how many vdf iterations are included in the block?
 	NonSignerPercent    prometheus.Gauge     // what percent of the voting power were non signers
@@ -508,13 +508,16 @@ func (m *Metrics) UpdateValidator(address string, stakeAmount uint64, unstaking,
 	switch {
 	case unstaking:
 		// if the val is unstaking
-		m.ValidatorStatus.WithLabelValues(address).Set(1)
+		m.ValidatorStatus.WithLabelValues(address).Set(2)
 	case paused:
 		// if the val is paused
-		m.ValidatorStatus.WithLabelValues(address).Set(2)
+		m.ValidatorStatus.WithLabelValues(address).Set(3)
+	case stakeAmount == 0:
+		// if the val is unstaked
+		m.ValidatorStatus.WithLabelValues(address).Set(0)
 	default:
 		// if the val is active
-		m.ValidatorStatus.WithLabelValues(address).Set(0)
+		m.ValidatorStatus.WithLabelValues(address).Set(1)
 	}
 }
 
@@ -566,7 +569,7 @@ func (m *Metrics) UpdateBlockMetrics(proposerAddress []byte, blockSize, txCount,
 		m.ProposerCount.Inc()
 	}
 	// update the number of transactions
-	m.BlockNumTxs.Add(float64(txCount))
+	m.BlockNumTxs.Set(float64(txCount))
 	// update the block processing time in seconds
 	m.BlockProcessingTime.Observe(duration.Seconds())
 	// update block size

--- a/lib/metrics.go
+++ b/lib/metrics.go
@@ -163,7 +163,7 @@ func NewMetricsServer(nodeAddress crypto.AddressI, config MetricsConfig, logger 
 			}),
 			SyncingStatus: promauto.NewGauge(prometheus.GaugeOpts{
 				Name: "canopy_syncing_status",
-				Help: "Node syncing status (1 for syncing, 0 for synced)",
+				Help: "Node syncing status (0 for syncing, 1 for synced)",
 			}),
 			ProposerCount: promauto.NewCounter(prometheus.CounterOpts{
 				Name: "canopy_proposer_count",
@@ -396,9 +396,9 @@ func (m *Metrics) UpdateNodeMetrics(isSyncing bool) {
 	m.NodeStatus.Set(1)
 	// update syncing status
 	if isSyncing {
-		m.SyncingStatus.Set(1)
-	} else {
 		m.SyncingStatus.Set(0)
+	} else {
+		m.SyncingStatus.Set(1)
 	}
 }
 

--- a/p2p/set.go
+++ b/p2p/set.go
@@ -3,11 +3,12 @@ package p2p
 import (
 	"bytes"
 	"fmt"
+	"slices"
+	"sync"
+
 	"github.com/canopy-network/canopy/lib"
 	"github.com/canopy-network/canopy/lib/crypto"
 	"google.golang.org/protobuf/proto"
-	"slices"
-	"sync"
 )
 
 const (
@@ -82,7 +83,7 @@ func (ps *PeerSet) Add(p *Peer) (err lib.ErrorI) {
 	// set the peer
 	ps.set(p)
 	// update metrics
-	ps.metrics.UpdatePeerMetrics(len(ps.m), ps.inbound, ps.outbound)
+	ps.metrics.UpdatePeerMetrics(ps.outbound+ps.inbound, ps.inbound, ps.outbound)
 	return nil
 }
 
@@ -96,7 +97,7 @@ func (ps *PeerSet) Remove(publicKey []byte) (peer *Peer, err lib.ErrorI) {
 	}
 	ps.remove(peer)
 	// update metrics
-	ps.metrics.UpdatePeerMetrics(len(ps.m), ps.inbound, ps.outbound)
+	ps.metrics.UpdatePeerMetrics(ps.outbound+ps.inbound, ps.inbound, ps.outbound)
 	return
 }
 
@@ -303,7 +304,7 @@ func (ps *PeerSet) changeIOCount(increment, outbound bool) {
 			ps.inbound--
 		}
 	}
-	ps.metrics.UpdatePeerMetrics(len(ps.m), ps.inbound, ps.outbound)
+	ps.metrics.UpdatePeerMetrics(ps.outbound+ps.inbound, ps.inbound, ps.outbound)
 }
 
 // map based CRUD operations below


### PR DESCRIPTION
- Add `canopy_chain_id` and `canopy_sofware_version` metrics that are just updated on start up of the node
- Change `canopy_block_num_txs` to a Gauge that resets in each block
- Change `canopy_syncing_status` to 1 for synced and 0 for syncing since synced is the healthy status
- Fix `canopy_validator_status` to actually fullfil the values in help `Validator status (0: Unstaked, 1: Staked, 2: Unstaking, 3: Paused)`
- Change `canopy_peer_total` to be updated to the added up value of inbound and outbound peers so it shows the same value as the wallet
- Add `canopy_startup_block` metric to save the block where a node started

Closes #229 