### PR TITLE
Authorized P2P Connection Pool

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,10 +7,10 @@ toolchain go1.24.2
 require (
 	filippo.io/edwards25519 v1.1.0
 	github.com/alecthomas/units v0.0.0-20231202071711-9a357b53e9c9
+	github.com/allegro/bigcache/v3 v3.1.0
 	github.com/cenkalti/backoff/v4 v4.3.0
 	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.0.1
 	github.com/dgraph-io/badger/v4 v4.7.0
-	github.com/dgraph-io/ristretto/v2 v2.2.0
 	github.com/drand/kyber v1.3.0
 	github.com/drand/kyber-bls12381 v0.3.1
 	github.com/ethereum/go-ethereum v1.15.11
@@ -40,7 +40,6 @@ require (
 
 require (
 	github.com/StackExchange/wmi v1.2.1 // indirect
-	github.com/allegro/bigcache/v3 v3.1.0 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/bits-and-blooms/bitset v1.20.0 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
@@ -49,6 +48,7 @@ require (
 	github.com/crate-crypto/go-eth-kzg v1.3.0 // indirect
 	github.com/crate-crypto/go-ipa v0.0.0-20240724233137-53bbb0ceb27a // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/dgraph-io/ristretto/v2 v2.2.0 // indirect
 	github.com/dustin/go-humanize v1.0.1 // indirect
 	github.com/ethereum/c-kzg-4844/v2 v2.1.0 // indirect
 	github.com/ethereum/go-verkle v0.2.2 // indirect
@@ -61,7 +61,6 @@ require (
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/kilic/bls12-381 v0.1.0 // indirect
 	github.com/klauspost/compress v1.18.0 // indirect
-	github.com/klauspost/cpuid/v2 v2.0.12 // indirect
 	github.com/mattn/go-colorable v0.1.13 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/mmcloughlin/addchain v0.4.0 // indirect
@@ -74,7 +73,6 @@ require (
 	github.com/supranational/blst v0.3.14 // indirect
 	github.com/tklauser/go-sysconf v0.3.12 // indirect
 	github.com/tklauser/numcpus v0.6.1 // indirect
-	github.com/zeebo/blake3 v0.2.4 // indirect
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
 	go.opentelemetry.io/otel v1.36.0 // indirect
 	go.opentelemetry.io/otel/metric v1.36.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -89,8 +89,6 @@ github.com/kilic/bls12-381 v0.1.0 h1:encrdjqKMEvabVQ7qYOKu1OvhqpK4s47wDYtNiPtlp4
 github.com/kilic/bls12-381 v0.1.0/go.mod h1:vDTTHJONJ6G+P2R74EhnyotQDTliQDnFEwhdmfzw1ig=
 github.com/klauspost/compress v1.18.0 h1:c/Cqfb0r+Yi+JtIEq73FWXVkRonBlf0CRNYc8Zttxdo=
 github.com/klauspost/compress v1.18.0/go.mod h1:2Pp+KzxcywXVXMr50+X0Q/Lsb43OQHYWRCY2AiWywWQ=
-github.com/klauspost/cpuid/v2 v2.0.12 h1:p9dKCg8i4gmOxtv35DvrYoWqYzQrvEVdjQ762Y0OqZE=
-github.com/klauspost/cpuid/v2 v2.0.12/go.mod h1:g2LTdtYhdyuGPqyWyv7qRAmj1WBqxuObKfj5c0PQa7c=
 github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
 github.com/kr/pretty v0.3.1/go.mod h1:hoEshYVHaxMs3cyo3Yncou5ZscifuDolrwPKZanG3xk=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
@@ -156,8 +154,6 @@ github.com/tklauser/go-sysconf v0.3.12 h1:0QaGUFOdQaIVdPgfITYzaTegZvdCjmYO52cSFA
 github.com/tklauser/go-sysconf v0.3.12/go.mod h1:Ho14jnntGE1fpdOqQEEaiKRpvIavV0hSfmBq8nJbHYI=
 github.com/tklauser/numcpus v0.6.1 h1:ng9scYS7az0Bk4OZLvrNXNSAO2Pxr1XXRAPyjhIx+Fk=
 github.com/tklauser/numcpus v0.6.1/go.mod h1:1XfjsgE2zo8GVw7POkMbHENHzVg3GzmoZ9fESEdAacY=
-github.com/zeebo/blake3 v0.2.4 h1:KYQPkhpRtcqh0ssGYcKLG1JYvddkEA8QwCM/yBqhaZI=
-github.com/zeebo/blake3 v0.2.4/go.mod h1:7eeQ6d2iXWRGF6npfaxl2CU+xy2Fjo2gxeyZGCRUjcE=
 go.dedis.ch/fixbuf v1.0.3 h1:hGcV9Cd/znUxlusJ64eAlExS+5cJDIyTyEG+otu5wQs=
 go.dedis.ch/fixbuf v1.0.3/go.mod h1:yzJMt34Wa5xD37V5RTdmp38cz3QhMagdGoem9anUalw=
 go.opentelemetry.io/auto/sdk v1.1.0 h1:cH53jehLUN6UFLY71z+NDOiNJqDdPRaXzTel0sJySYA=

--- a/p2p/pool.go
+++ b/p2p/pool.go
@@ -1,0 +1,219 @@
+package p2p
+
+import (
+	"encoding/hex"
+	"net"
+	"sync"
+	"time"
+
+	"github.com/canopy-network/canopy/lib"
+)
+
+const (
+	cleanupInterval      = 1 * time.Minute // how often to cleanup expired connections
+	reconnectGracePeriod = 1 * time.Minute // time the node can attempt to reconnect without losing the connection
+)
+
+// AuthenticatedConnectionPool manages pooled authenticated connections after handshake
+// This provides connection reuse while maintaining strict security through peer identity verification
+// Only one connection per authenticated peer is kept
+type AuthenticatedConnectionPool struct {
+	pool          map[string]*AuthenticatedConn // [peer_public_key_hex] -> single connection per peer
+	cleanupTicker *time.Ticker                  // periodic cleanup timer
+	lastCleanup   time.Time                     // last time cleanup was performed
+	logger        lib.LoggerI                   // logger instance for logging
+	mu            sync.RWMutex                  // thread access
+}
+
+// AuthenticatedConn wraps a fully authenticated MultiConn for pooling
+// Only connections that have completed handshake and peer verification are pooled
+type AuthenticatedConn struct {
+	conn         *MultiConn    // the authenticated connection
+	info         *lib.PeerInfo // peer information
+	peerKey      string        // hex-encoded peer public key (pool identifier)
+	netAddress   string        // network address for reference
+	inUse        bool          // whether connection is currently in use
+	disconnectAt time.Time     // when the connection was returned to pool (disconnected)
+	mu           sync.Mutex    // thread access
+}
+
+// NewAuthConnectionPool creates a new authenticated connection pool
+func NewAuthConnectionPool(logger lib.LoggerI) *AuthenticatedConnectionPool {
+	pool := &AuthenticatedConnectionPool{
+		pool:          make(map[string]*AuthenticatedConn),
+		cleanupTicker: time.NewTicker(cleanupInterval),
+		lastCleanup:   time.Now(),
+		logger:        logger,
+		mu:            sync.RWMutex{},
+	}
+	return pool
+}
+
+// Get retrieves an idle authenticated connection for the given peer public key
+func (p *AuthenticatedConnectionPool) Get(peerPublicKey []byte) (*MultiConn, *lib.PeerInfo, bool) {
+	// cleanup stale connections
+	defer func() {
+		if time.Since(p.lastCleanup) > cleanupInterval {
+			go p.cleanup()
+		}
+	}()
+	// hex encode peer public key
+	peerKeyHex := hex.EncodeToString(peerPublicKey)
+	// p.logger.Debugf("Getting authenticated connection for peer %s", peerKeyHex)
+	// retrieve authenticated connection from pool
+	p.mu.RLock()
+	authConn, ok := p.pool[peerKeyHex]
+	p.mu.RUnlock()
+	if !ok {
+		return nil, nil, false
+	}
+	// safe locking
+	authConn.mu.Lock()
+	defer authConn.mu.Unlock()
+	// check if connection is alive and not used
+	if isConnClosed(authConn.conn.conn) || authConn.inUse {
+		return nil, nil, false
+	}
+	// check if connection is stale
+	if time.Since(authConn.disconnectAt) > reconnectGracePeriod {
+		return nil, nil, false
+	}
+	// check if connection is still healthy
+	if !p.isConnHealthy(authConn) {
+		return nil, nil, false
+	}
+	// mark connection as in use
+	authConn.inUse = true
+	// mark the connection as pooled
+	authConn.conn.pooled.Store(true)
+	// p.logger.Debugf("Reusing authenticated connection for peer %s", peerKeyHex)
+	return authConn.conn, authConn.info.Copy(), true
+}
+
+// Put returns an authenticated connection to the pool for reuse
+// The connection must be fully authenticated and healthy
+func (p *AuthenticatedConnectionPool) Put(conn *MultiConn, peerInfo *lib.PeerInfo) bool {
+	// retrieve connection
+	poolConn, peerKeyHex, exists := p.get(conn)
+	if peerKeyHex == "" {
+		return false
+	}
+	// check if connection is healthy for pooling
+	if !conn.isHealthyForPooling() {
+		return false
+	}
+	// safe locking
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	// check if there's already a connection for this peer
+	if exists {
+		poolConn.mu.Lock()
+		// if existing connection is not in use, prefer to keep the existing one
+		if !poolConn.inUse {
+			poolConn.mu.Unlock()
+			return false
+		}
+		poolConn.mu.Unlock()
+	}
+	// create new authenticated connection entry
+	authConn := &AuthenticatedConn{
+		conn:         conn,
+		info:         peerInfo.Copy(),
+		peerKey:      peerKeyHex,
+		netAddress:   conn.Address.NetAddress,
+		inUse:        false,
+		disconnectAt: time.Now(),
+	}
+	p.pool[peerKeyHex] = authConn
+	// p.logger.Debugf("Pooled authenticated connection for peer %s", peerKeyHex)
+	return true
+}
+
+// Close shuts down the connection pool and closes all connections
+func (p *AuthenticatedConnectionPool) Close() {
+	p.cleanupTicker.Stop()
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	// Close all authenticated connections
+	for _, authConn := range p.pool {
+		authConn.mu.Lock()
+		if authConn.conn != nil {
+			authConn.conn.Stop()
+		}
+		authConn.mu.Unlock()
+	}
+	// clear pools map
+	p.pool = make(map[string]*AuthenticatedConn)
+}
+
+// get retrieves an authenticated connection from the pool with basic validation
+func (p *AuthenticatedConnectionPool) get(conn *MultiConn) (*AuthenticatedConn, string, bool) {
+	// nil check
+	if conn == nil || conn.Address == nil {
+		return nil, "", false
+	}
+	// convert the key to hex
+	peerKeyHex := hex.EncodeToString(conn.Address.PublicKey)
+	// retrieve authenticated connection from pool
+	p.mu.RLock()
+	authConn, exists := p.pool[peerKeyHex]
+	p.mu.RUnlock()
+	// exit
+	return authConn, peerKeyHex, exists
+}
+
+// isConnHealthy checks if an authenticated connection is still usable
+func (p *AuthenticatedConnectionPool) isConnHealthy(authConn *AuthenticatedConn) bool {
+	// check if the underlying MultiConn is still healthy
+	if authConn.conn == nil {
+		return false
+	}
+	// check if MultiConn thinks it's healthy for pooling
+	exist := authConn.conn.isHealthyForPooling()
+	return exist
+}
+
+// cleanup removes unused idle connections
+func (p *AuthenticatedConnectionPool) cleanup() {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	now := time.Now()
+	for peerKey, authConn := range p.pool {
+		authConn.mu.Lock()
+		// remove from pool if not in use and idle for too long
+		shouldRemove := !authConn.inUse && now.Sub(authConn.disconnectAt) > reconnectGracePeriod
+		if shouldRemove {
+			// remove from pool
+			delete(p.pool, peerKey)
+			// close connection
+			if authConn.conn != nil {
+				authConn.conn.Stop()
+			}
+		}
+		authConn.mu.Unlock()
+	}
+	// update last cleanup time
+	p.lastCleanup = now
+}
+
+// isConnClosed checks if a connection is closed or broken
+func isConnClosed(conn net.Conn) bool {
+	// set a very short deadline
+	conn.SetReadDeadline(time.Now().Add(1 * time.Millisecond))
+	// reset deadline after checking
+	defer conn.SetReadDeadline(time.Time{})
+	// try to read one byte
+	one := make([]byte, 0)
+	_, err := conn.Read(one)
+	if err != nil {
+		// check for specific error types
+		if netErr, ok := err.(net.Error); ok && netErr.Timeout() {
+			// connection is alive, just no data
+			return false
+		}
+		// connection is closed or broken
+		return true
+	}
+	// got data, connection is alive
+	return false
+}

--- a/p2p/pool_test.go
+++ b/p2p/pool_test.go
@@ -1,0 +1,236 @@
+package p2p
+
+import (
+	"net"
+	"testing"
+	"time"
+
+	"github.com/canopy-network/canopy/lib"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewAuthConnectionPool(t *testing.T) {
+	logger := lib.NewNullLogger()
+	pool := NewAuthConnectionPool(logger)
+	// check minimum fields
+	require.NotNil(t, pool)
+	require.NotNil(t, pool.pool)
+	require.NotNil(t, pool.cleanupTicker)
+	require.Equal(t, logger, pool.logger)
+	// Clean up
+	pool.Close()
+}
+
+func TestAuthConnectionPool(t *testing.T) {
+	logger := lib.NewNullLogger()
+	pool := NewAuthConnectionPool(logger)
+	defer pool.Close()
+	// create test nodes
+	n1, n2 := newTestP2PNode(t), newTestP2PNode(t)
+	// create test connection
+	c1, c2 := net.Pipe()
+	defer c1.Close()
+	defer c2.Close()
+	// create test multi connection
+	multiConn := newTestMultiConnMock(t, n2.pub, c1, n1.P2P)
+	peerInfo := &lib.PeerInfo{
+		Address: &lib.PeerAddress{
+			PublicKey:  n2.pub,
+			NetAddress: "test:1234",
+		},
+		Reputation: 5,
+	}
+	// test Put operation
+	success := pool.Put(multiConn, peerInfo)
+	require.True(t, success)
+	// test Get operation
+	retrievedConn, retrievedInfo, found := pool.Get(n2.pub)
+	require.True(t, found)
+	require.Equal(t, multiConn, retrievedConn)
+	require.Equal(t, peerInfo.Address.PublicKey, retrievedInfo.Address.PublicKey)
+	require.Equal(t, peerInfo.Reputation, retrievedInfo.Reputation)
+	// connection should be marked as pooled and in use
+	require.True(t, multiConn.pooled.Load())
+	// test Get for non-existent peer
+	nonExistentKey := []byte("nonexistent")
+	_, _, found = pool.Get(nonExistentKey)
+	require.False(t, found)
+}
+
+func TestAuthConnectionPoolDuplicateConnection(t *testing.T) {
+	logger := lib.NewNullLogger()
+	pool := NewAuthConnectionPool(logger)
+	defer pool.Close()
+	n1, n2 := newTestP2PNode(t), newTestP2PNode(t)
+	// create two connections for the same peer
+	c1, c2 := net.Pipe()
+	c3, c4 := net.Pipe()
+	defer c1.Close()
+	defer c2.Close()
+	defer c3.Close()
+	defer c4.Close()
+	multiConn1 := newTestMultiConnMock(t, n2.pub, c1, n1.P2P)
+	multiConn2 := newTestMultiConnMock(t, n2.pub, c3, n1.P2P)
+	peerInfo := &lib.PeerInfo{
+		Address: &lib.PeerAddress{
+			PublicKey:  n2.pub,
+			NetAddress: "test:1234",
+		},
+	}
+	// put first connection
+	success1 := pool.Put(multiConn1, peerInfo)
+	require.True(t, success1)
+	// put second connection for same peer (should fail if first is not in use)
+	success2 := pool.Put(multiConn2, peerInfo)
+	require.False(t, success2)
+	// get the first connection (marks it as in use)
+	retrievedConn, _, found := pool.Get(n2.pub)
+	require.True(t, found)
+	require.Equal(t, multiConn1, retrievedConn)
+	// putting second connection should succeed since first is in use
+	success3 := pool.Put(multiConn2, peerInfo)
+	require.True(t, success3)
+}
+
+func TestAuthConnectionPoolExpiredConnection(t *testing.T) {
+	logger := lib.NewNullLogger()
+	pool := NewAuthConnectionPool(logger)
+	defer pool.Close()
+	// create test nodes
+	n1, n2 := newTestP2PNode(t), newTestP2PNode(t)
+	c1, c2 := net.Pipe()
+	defer c1.Close()
+	defer c2.Close()
+	multiConn := newTestMultiConnMock(t, n2.pub, c1, n1.P2P)
+	peerInfo := &lib.PeerInfo{
+		Address: &lib.PeerAddress{
+			PublicKey:  n2.pub,
+			NetAddress: "test:1234",
+		},
+	}
+	// put connection
+	success := pool.Put(multiConn, peerInfo)
+	require.True(t, success)
+	// manually set disconnectAt to past the grace period
+	pool.mu.Lock()
+	authConn := pool.pool[lib.BytesToString(n2.pub)]
+	authConn.mu.Lock()
+	authConn.disconnectAt = time.Now().Add(-2 * reconnectGracePeriod)
+	authConn.mu.Unlock()
+	pool.mu.Unlock()
+	// try to get the expired connection
+	_, _, found := pool.Get(n2.pub)
+	require.False(t, found)
+}
+
+func TestAuthConnectionPoolCleanup(t *testing.T) {
+	logger := lib.NewNullLogger()
+	pool := NewAuthConnectionPool(logger)
+	defer pool.Close()
+	// create test nodes
+	n1, n2, n3 := newTestP2PNode(t), newTestP2PNode(t), newTestP2PNode(t)
+	// create connections
+	c1, c2 := net.Pipe()
+	c3, c4 := net.Pipe()
+	defer c1.Close()
+	defer c2.Close()
+	defer c3.Close()
+	defer c4.Close()
+	multiConn1 := newTestMultiConnMock(t, n2.pub, c1, n1.P2P)
+	multiConn2 := newTestMultiConnMock(t, n3.pub, c3, n1.P2P)
+	peerInfo1 := &lib.PeerInfo{
+		Address: &lib.PeerAddress{PublicKey: n2.pub, NetAddress: "test:1234"},
+	}
+	peerInfo2 := &lib.PeerInfo{
+		Address: &lib.PeerAddress{PublicKey: n3.pub, NetAddress: "test:5678"},
+	}
+	// put both connections
+	require.True(t, pool.Put(multiConn1, peerInfo1))
+	require.True(t, pool.Put(multiConn2, peerInfo2))
+	// verify both are in pool
+	require.Len(t, pool.pool, 2)
+	// mark first connection as expired
+	authConn1 := pool.pool[lib.BytesToString(n2.pub)]
+	authConn1.disconnectAt = time.Now().Add(-2 * reconnectGracePeriod)
+	authConn1.inUse = false
+	// run cleanup
+	pool.cleanup()
+	// first connection should be removed, second should remain
+	_, found1After := pool.pool[lib.BytesToString(n2.pub)]
+	_, found2After := pool.pool[lib.BytesToString(n3.pub)]
+
+	require.False(t, found1After)
+	require.True(t, found2After)
+}
+
+func TestAuthConnectionPoolClose(t *testing.T) {
+	logger := lib.NewNullLogger()
+	pool := NewAuthConnectionPool(logger)
+	// create connections
+	n1, n2 := newTestP2PNode(t), newTestP2PNode(t)
+	c1, c2 := net.Pipe()
+	defer c2.Close()
+	multiConn := newTestMultiConnMock(t, n2.pub, c1, n1.P2P)
+	peerInfo := &lib.PeerInfo{
+		Address: &lib.PeerAddress{
+			PublicKey:  n2.pub,
+			NetAddress: "test:1234",
+		},
+	}
+	// put connection
+	success := pool.Put(multiConn, peerInfo)
+	require.True(t, success)
+	// close pool
+	pool.Close()
+	// verify pool is empty
+	require.Empty(t, pool.pool)
+	// verify connection is closed
+	require.True(t, isConnClosed(multiConn.conn))
+}
+
+func TestIsConnClosed(t *testing.T) {
+	c1, c2 := net.Pipe()
+	defer c1.Close()
+	defer c2.Close()
+	// open connection
+	closed := isConnClosed(c1)
+	require.False(t, closed)
+	// closed connection
+	c3, c4 := net.Pipe()
+	c3.Close()
+	c4.Close()
+	closed = isConnClosed(c3)
+	require.True(t, closed)
+}
+
+func TestAuthConnectionPool_GetAfterConnectionInUse(t *testing.T) {
+	logger := lib.NewNullLogger()
+	pool := NewAuthConnectionPool(logger)
+	defer pool.Close()
+
+	n1, n2 := newTestP2PNode(t), newTestP2PNode(t)
+
+	c1, c2 := net.Pipe()
+	defer c1.Close()
+	defer c2.Close()
+
+	multiConn := newTestMultiConnMock(t, n2.pub, c1, n1.P2P)
+	peerInfo := &lib.PeerInfo{
+		Address: &lib.PeerAddress{
+			PublicKey:  n2.pub,
+			NetAddress: "test:1234",
+		},
+	}
+
+	// Put connection
+	success := pool.Put(multiConn, peerInfo)
+	require.True(t, success, "Put should succeed")
+
+	// Get connection (marks as in use)
+	_, _, found := pool.Get(n2.pub)
+	require.True(t, found, "Should find connection")
+
+	// Try to get again (should fail because it's in use)
+	_, _, found2 := pool.Get(n2.pub)
+	require.False(t, found2, "Should not find in-use connection")
+}


### PR DESCRIPTION
## Description
Add a P2P auth connection pool mechanism, allowing authenticated peers that fail to reconnect right away during a set threshold once, reducing the time to produce the Handshake process

## Related Issues
<!-- List any issues this pull request closes. -->
Closes: #<issue-number>

## Changes Made
<!-- Highlight the key changes made in the code. For example:
- Added P2P connection pool
- Modified `AddPeer` and `ListenForInboundPeers` to use the connection pool if valid
-->

## Checklist
- [x] I have tested the changes locally and verified they work as intended.
- [x] I have appropriately titled my branch `issue-#<issue-number>`.
- [ ] I have run re-built the web-wallet and/or block explorer (if applicable).
- [ ] I have run `npm run prettier` to format the web-wallet and/or block explorer (if applicable)
- [ ] I have updated documentation (if applicable).
- [x] I have included tests for the changes (if applicable).

## Additional Notes
<!-- Add any additional context, screenshots, or information that reviewers might find helpful. -->
