### PR TITLE
fix: json rpc betterments

### DIFF
--- a/cmd/rpc/README.md
+++ b/cmd/rpc/README.md
@@ -168,7 +168,9 @@ $ curl -X POST localhost:50002/v1/tx \
 
 **Request**: `null`
 
-**Response**: `uint64` - the number of the next block
+**Response**:
+
+- **height**: `uint64` - the number of the next block
 
 **Example:**:
 

--- a/cmd/rpc/client.go
+++ b/cmd/rpc/client.go
@@ -31,8 +31,8 @@ func (c *Client) Version() (version *string, err lib.ErrorI) {
 	return
 }
 
-func (c *Client) Height() (p *uint64, err lib.ErrorI) {
-	p = new(uint64)
+func (c *Client) Height() (p *lib.HeightResult, err lib.ErrorI) {
+	p = new(lib.HeightResult)
 	err = c.post(HeightRouteName, nil, p)
 	return
 }

--- a/cmd/rpc/query.go
+++ b/cmd/rpc/query.go
@@ -39,7 +39,9 @@ func (s *Server) Transaction(w http.ResponseWriter, r *http.Request, _ httproute
 func (s *Server) Height(w http.ResponseWriter, _ *http.Request, _ httprouter.Params) {
 	// Create a read-only state for the latest block and write the height
 	s.readOnlyState(0, func(state *fsm.StateMachine) lib.ErrorI {
-		write(w, state.Height(), http.StatusOK)
+		write(w, &lib.HeightResult{
+			Height: state.Height(),
+		}, http.StatusOK)
 		return nil
 	})
 }

--- a/lib/block.go
+++ b/lib/block.go
@@ -3,6 +3,7 @@ package lib
 import (
 	"bytes"
 	"encoding/json"
+
 	"github.com/canopy-network/canopy/lib/codec"
 	"github.com/canopy-network/canopy/lib/crypto"
 )
@@ -306,3 +307,8 @@ func init() {
 }
 
 var _ Pageable = new(BlockResults) // Pageable interface enforcement
+
+// HeightResult is the structure to return the height
+type HeightResult struct {
+	Height uint64 `json:"height"`
+}

--- a/store/indexer.go
+++ b/store/indexer.go
@@ -3,8 +3,9 @@ package store
 import (
 	"bytes"
 	"encoding/binary"
-	"golang.org/x/sync/errgroup"
 	"time"
+
+	"golang.org/x/sync/errgroup"
 
 	"github.com/canopy-network/canopy/lib"
 	"github.com/canopy-network/canopy/lib/crypto"
@@ -39,14 +40,16 @@ type Indexer struct {
 // IndexBlock() turns the block into bytes, indexes the block by hash and height
 // and then indexes the transactions
 func (t *Indexer) IndexBlock(b *lib.BlockResult) lib.ErrorI {
+	bz, err := lib.Marshal(b.BlockHeader)
+	if err != nil {
+		return err
+	}
+	// set meta stats for the block
+	b.Meta = &lib.BlockResultMeta{Size: uint64(len(bz))}
 	blockCache.Add(b.BlockHeader.Height, b)
 	var eg errgroup.Group
 	// index block header in its own goroutine
 	eg.Go(func() error {
-		bz, err := lib.Marshal(b.BlockHeader)
-		if err != nil {
-			return err
-		}
 		hashKey, err := t.indexBlockByHash(b.BlockHeader.Hash, bz)
 		if err != nil {
 			return err


### PR DESCRIPTION
Changes done:

- Change `query/height` to return a JSON struct instead of directly a string with the height.
- Fix in the `query/block-by-height` the `meta` field not showing automatically in new blocks.

Note:
Changing the  `query/block-by-height` endpoint to return an error when it is a block that doesn't already exist causes issues in the code logic, this change will be postponed.

Closes #248 