### PR TITLE
Eviction/LoadRootChainInfo optimization

### DIFF
--- a/cmd/rpc/query.go
+++ b/cmd/rpc/query.go
@@ -127,8 +127,14 @@ func (s *Server) RootChainInfo(w http.ResponseWriter, r *http.Request, _ httprou
 	if ok := unmarshal(w, r, req); !ok {
 		return
 	}
+	// if height is 0; set to the latest height
+	if req.Height == 0 {
+		req.Height = s.controller.FSM.Height()
+	}
+	// retrieve the saved last validator set if available
+	lastVS := s.controller.LastValidatorSet[req.Height][req.ID]
 	// load the root chain info directly
-	got, err := s.controller.FSM.LoadRootChainInfo(req.ID, req.Height)
+	got, err := s.controller.FSM.LoadRootChainInfo(req.ID, req.Height, lastVS)
 	if err != nil {
 		write(w, err, http.StatusBadRequest)
 		return

--- a/controller/block.go
+++ b/controller/block.go
@@ -302,8 +302,13 @@ func (c *Controller) CommitCertificate(qc *lib.QuorumCertificate, block *lib.Blo
 	c.Mempool.FSM.Reset()
 	// update telemetry (using proper defer to ensure time.Since is evaluated at defer execution)
 	defer c.UpdateTelemetry(qc, block, time.Since(start))
-	// publish the root chain info to the nested chain subscribers
-	for _, id := range c.RCManager.ChainIds() {
+	// publish root chain information to all nested chain subscribers.
+	// Currently using hardcoded chain IDs (1, 2) instead of dynamically fetching IDs
+	// from RCManager since only these two chains exist. This will be updated to use
+	// dynamic chain discovery when additional chains are added.
+	// TODO: Optimize rcManager publishing for subchains (it should publish to themselves too by default)
+	// for _, id := range c.RCManager.ChainIds() {
+	for _, id := range []uint64{1, 2} {
 		// get the root chain info
 		info, e := c.FSM.LoadRootChainInfo(id, 0, c.LastValidatorSet[c.ChainHeight()][id])
 		if e != nil {

--- a/controller/block.go
+++ b/controller/block.go
@@ -203,7 +203,7 @@ func (c *Controller) ValidateProposal(rcBuildHeight uint64, qc *lib.QuorumCertif
 		return
 	}
 	// play the block against the state machine to generate a block result
-	blockResult, err = c.ApplyAndValidateBlock(block, false)
+	blockResult, err = c.ApplyAndValidateBlock(block, c.LastValidatorSet[c.FSM.Height()][c.Config.ChainId], false)
 	if err != nil {
 		// exit with error
 		return
@@ -237,6 +237,11 @@ func (c *Controller) CommitCertificate(qc *lib.QuorumCertificate, block *lib.Blo
 	c.log.Debugf("TryCommit block %s", lib.BytesToString(qc.ResultsHash))
 	// cast the store to ensure the proper store type to complete this operation
 	storeI := c.FSM.Store().(lib.StoreI)
+	// cache new last validator set for next height
+	valSet, err := c.FSM.GetCommitteeMembers(c.Config.ChainId)
+	if err != nil {
+		return err
+	}
 	// reset the store once this code finishes; if code execution gets to `store.Commit()` - this will effectively be a noop
 	defer c.FSM.Reset()
 	// if the block result isn't 'pre-calculated'
@@ -244,7 +249,7 @@ func (c *Controller) CommitCertificate(qc *lib.QuorumCertificate, block *lib.Blo
 		// reset the FSM to ensure stale proposal validations don't come into play
 		c.FSM.Reset()
 		// apply the block against the state machine
-		blockResult, err = c.ApplyAndValidateBlock(block, true)
+		blockResult, err = c.ApplyAndValidateBlock(block, c.LastValidatorSet[c.ChainHeight()][c.Config.ChainId], true)
 		if err != nil {
 			// exit with error
 			return
@@ -288,6 +293,9 @@ func (c *Controller) CommitCertificate(qc *lib.QuorumCertificate, block *lib.Blo
 		// exit with error
 		return err
 	}
+	// add the cache validator set to the controller
+	c.LastValidatorSet[c.ChainHeight()] = make(map[uint64]*lib.ValidatorSet)
+	c.LastValidatorSet[c.ChainHeight()][c.Config.ChainId] = &valSet
 	// set up the mempool with the actual new FSM for the next height
 	// this makes c.Mempool.FSM.Reset() is unnecessary
 	if c.Mempool.FSM, err = c.FSM.Copy(); err != nil {
@@ -303,7 +311,7 @@ func (c *Controller) CommitCertificate(qc *lib.QuorumCertificate, block *lib.Blo
 	// publish the root chain info to the nested chain subscribers
 	for _, id := range c.RCManager.ChainIds() {
 		// get the root chain info
-		info, e := c.FSM.LoadRootChainInfo(id, 0)
+		info, e := c.FSM.LoadRootChainInfo(id, 0, c.LastValidatorSet[c.ChainHeight()][id])
 		if e != nil {
 			// don't log 'no-validators' error as this is possible
 			if e.Error() != lib.ErrNoValidators().Error() {
@@ -313,9 +321,20 @@ func (c *Controller) CommitCertificate(qc *lib.QuorumCertificate, block *lib.Blo
 		}
 		// set the timestamp
 		info.Timestamp = ts
+		// do not cache root chain info as it was already preloaded
+		if id != c.Config.ChainId {
+			// cache current validator set for the next height
+			valSet, _ := c.FSM.GetCommitteeMembers(id)
+			if _, found := c.LastValidatorSet[c.ChainHeight()+1]; !found {
+				c.LastValidatorSet[c.ChainHeight()+1] = make(map[uint64]*lib.ValidatorSet)
+			}
+			c.LastValidatorSet[c.ChainHeight()+1][id] = &valSet
+		}
 		// publish root chain information
 		go c.RCManager.Publish(id, info)
 	}
+	// remove previous validator set cache
+	delete(c.LastValidatorSet, c.ChainHeight()-1)
 	// exit
 	return
 }
@@ -339,7 +358,7 @@ func (c *Controller) CommitCertificateParallel(qc *lib.QuorumCertificate, block 
 		// reset the FSM to ensure stale proposal validations don't come into play
 		c.FSM.Reset()
 		// apply the block against the state machine
-		blockResult, err = c.ApplyAndValidateBlock(block, true)
+		blockResult, err = c.ApplyAndValidateBlock(block, c.LastValidatorSet[c.ChainHeight()][c.Config.ChainId], true)
 		if err != nil {
 			// exit with error
 			return
@@ -395,8 +414,18 @@ func (c *Controller) CommitCertificateParallel(qc *lib.QuorumCertificate, block 
 		}
 		// publish the root chain info to the nested chain subscribers
 		for _, id := range c.RCManager.ChainIds() {
+			// get latest validator set
+			valSet, err := c.FSM.GetCommitteeMembers(id)
+			if err != nil {
+				panic(err)
+			}
+			// TODO handle err
+			if _, found := c.LastValidatorSet[c.ChainHeight()+1]; !found {
+				c.LastValidatorSet[c.ChainHeight()+1] = make(map[uint64]*lib.ValidatorSet)
+			}
+			c.LastValidatorSet[c.ChainHeight()+1][id] = &valSet
 			// get the root chain info
-			info, e := c.FSM.LoadRootChainInfo(id, 0)
+			info, e := c.FSM.LoadRootChainInfo(id, 0, c.LastValidatorSet[c.ChainHeight()][id])
 			if e != nil {
 				// don't log 'no-validators' error as this is possible
 				if e.Error() != lib.ErrNoValidators().Error() {
@@ -445,7 +474,7 @@ func (c *Controller) CommitCertificateParallel(qc *lib.QuorumCertificate, block 
 // INTERNAL HELPERS BELOW
 
 // ApplyAndValidateBlock() plays the block against the state machine which returns a result that is compared against the candidate block header
-func (c *Controller) ApplyAndValidateBlock(block *lib.Block, commit bool) (b *lib.BlockResult, err lib.ErrorI) {
+func (c *Controller) ApplyAndValidateBlock(block *lib.Block, lastValidatorSet *lib.ValidatorSet, commit bool) (b *lib.BlockResult, err lib.ErrorI) {
 	// define convenience variables for the block header, hash, and height
 	candidate, candidateHash, candidateHeight := block.BlockHeader, lib.BytesToString(block.BlockHeader.Hash), block.BlockHeader.Height
 	// check the last qc in the candidate and set it in the ephemeral indexer to prepare for block application
@@ -456,7 +485,7 @@ func (c *Controller) ApplyAndValidateBlock(block *lib.Block, commit bool) (b *li
 	// log the start of 'apply block'
 	c.log.Debugf("Applying block %s for height %d", candidateHash[:20], candidateHeight)
 	// apply the block against the state machine
-	compare, txResults, _, failed, err := c.FSM.ApplyBlock(context.Background(), block, false)
+	compare, txResults, _, failed, err := c.FSM.ApplyBlock(context.Background(), block, lastValidatorSet, false)
 	if err != nil {
 		// exit with error
 		return

--- a/controller/block.go
+++ b/controller/block.go
@@ -284,6 +284,8 @@ func (c *Controller) CommitCertificate(qc *lib.QuorumCertificate, block *lib.Blo
 	c.log.Infof("Committed block %s at H:%d 🔒", lib.BytesToTruncatedString(qc.BlockHash), block.BlockHeader.Height)
 	// set up the finite state machine for the next height
 	c.FSM, err = fsm.New(c.Config, storeI, c.Metrics, c.log)
+	// set the reference to lastCertificate again
+	c.FSM.LastValidatorSet = &c.LastValidatorSet
 	if err != nil {
 		// exit with error
 		return err

--- a/controller/block.go
+++ b/controller/block.go
@@ -284,8 +284,8 @@ func (c *Controller) CommitCertificate(qc *lib.QuorumCertificate, block *lib.Blo
 	c.log.Infof("Committed block %s at H:%d 🔒", lib.BytesToTruncatedString(qc.BlockHash), block.BlockHeader.Height)
 	// set up the finite state machine for the next height
 	c.FSM, err = fsm.New(c.Config, storeI, c.Metrics, c.log)
-	// set the reference to lastCertificate again
-	c.FSM.LastValidatorSet = &c.LastValidatorSet
+	// set the reference to lastCertificate on the new FSM
+	c.FSM.LastValidatorSet = c.LastValidatorSet
 	if err != nil {
 		// exit with error
 		return err

--- a/controller/controller.go
+++ b/controller/controller.go
@@ -63,9 +63,9 @@ func New(fsm *fsm.StateMachine, c lib.Config, valKey crypto.PrivateKeyI, metrics
 		FSM:              fsm,
 		Mempool:          mempool,
 		Consensus:        nil,
-		LastValidatorSet: make(map[uint64]map[uint64]*lib.ValidatorSet),
 		P2P:              p2p.New(valKey, maxMembersPerCommittee, metrics, c, l),
 		isSyncing:        &atomic.Bool{},
+		LastValidatorSet: make(map[uint64]map[uint64]*lib.ValidatorSet),
 		log:              l,
 		Mutex:            &sync.Mutex{},
 	}
@@ -73,6 +73,8 @@ func New(fsm *fsm.StateMachine, c lib.Config, valKey crypto.PrivateKeyI, metrics
 	controller.Consensus, err = bft.New(c, valKey, fsm.Height(), fsm.Height()-1, controller, c.RunVDF, metrics, l)
 	// initialize the mempool controller
 	mempool.controller = controller
+	// add the last validator set reference to the FSM
+	fsm.LastValidatorSet = &controller.LastValidatorSet
 	// if an error occurred initializing the bft module
 	if err != nil {
 		// exit with error

--- a/controller/controller.go
+++ b/controller/controller.go
@@ -18,11 +18,12 @@ var _ bft.Controller = new(Controller)
 
 // Controller acts as the 'manager' of the modules of the application
 type Controller struct {
-	Address    []byte             // self address
-	PublicKey  []byte             // self public key
-	PrivateKey crypto.PrivateKeyI // self private key
-	Config     lib.Config         // node configuration
-	Metrics    *lib.Metrics       // telemetry
+	Address          []byte                                  // self address
+	PublicKey        []byte                                  // self public key
+	PrivateKey       crypto.PrivateKeyI                      // self private key
+	Config           lib.Config                              // node configuration
+	Metrics          *lib.Metrics                            // telemetry
+	LastValidatorSet map[uint64]map[uint64]*lib.ValidatorSet // cache [height][chainID] -> set
 
 	FSM       *fsm.StateMachine // the core protocol component responsible for maintaining and updating the state of the blockchain
 	Mempool   *Mempool          // the in memory list of pending transactions
@@ -54,18 +55,19 @@ func New(fsm *fsm.StateMachine, c lib.Config, valKey crypto.PrivateKeyI, metrics
 	}
 	// create the controller
 	controller = &Controller{
-		Address:    address.Bytes(),
-		PublicKey:  valKey.PublicKey().Bytes(),
-		PrivateKey: valKey,
-		Config:     c,
-		Metrics:    metrics,
-		FSM:        fsm,
-		Mempool:    mempool,
-		Consensus:  nil,
-		P2P:        p2p.New(valKey, maxMembersPerCommittee, metrics, c, l),
-		isSyncing:  &atomic.Bool{},
-		log:        l,
-		Mutex:      &sync.Mutex{},
+		Address:          address.Bytes(),
+		PublicKey:        valKey.PublicKey().Bytes(),
+		PrivateKey:       valKey,
+		Config:           c,
+		Metrics:          metrics,
+		FSM:              fsm,
+		Mempool:          mempool,
+		Consensus:        nil,
+		LastValidatorSet: make(map[uint64]map[uint64]*lib.ValidatorSet),
+		P2P:              p2p.New(valKey, maxMembersPerCommittee, metrics, c, l),
+		isSyncing:        &atomic.Bool{},
+		log:              l,
+		Mutex:            &sync.Mutex{},
 	}
 	// initialize the consensus in the controller, passing a reference to itself
 	controller.Consensus, err = bft.New(c, valKey, fsm.Height(), fsm.Height()-1, controller, c.RunVDF, metrics, l)
@@ -94,6 +96,13 @@ func (c *Controller) Start() {
 		c.log.Warnf("Attempting to connect to the root-chain")
 		// set a timer to go off once per second
 		t := time.NewTicker(time.Second)
+		// cold start the last validator set
+		valSet, err := c.FSM.LoadCommittee(rootChainId, c.ChainHeight()-1)
+		if err != nil {
+			c.log.Fatal(err.Error())
+		}
+		c.LastValidatorSet[c.ChainHeight()] = make(map[uint64]*lib.ValidatorSet)
+		c.LastValidatorSet[c.ChainHeight()][c.Config.ChainId] = &valSet
 		// once function completes, stop the timer
 		defer t.Stop()
 		// each time the timer fires

--- a/controller/controller.go
+++ b/controller/controller.go
@@ -97,7 +97,7 @@ func (c *Controller) Start() {
 		// set a timer to go off once per second
 		t := time.NewTicker(time.Second)
 		// cold start the last validator set
-		valSet, err := c.FSM.LoadCommittee(rootChainId, c.ChainHeight()-1)
+		valSet, err := c.FSM.LoadCommittee(c.Config.ChainId, c.ChainHeight()-1)
 		if err != nil {
 			c.log.Fatal(err.Error())
 		}

--- a/controller/controller.go
+++ b/controller/controller.go
@@ -74,7 +74,7 @@ func New(fsm *fsm.StateMachine, c lib.Config, valKey crypto.PrivateKeyI, metrics
 	// initialize the mempool controller
 	mempool.controller = controller
 	// add the last validator set reference to the FSM
-	fsm.LastValidatorSet = &controller.LastValidatorSet
+	fsm.LastValidatorSet = controller.LastValidatorSet
 	// if an error occurred initializing the bft module
 	if err != nil {
 		// exit with error

--- a/controller/tx.go
+++ b/controller/tx.go
@@ -3,11 +3,12 @@ package controller
 import (
 	"context"
 	"fmt"
-	"github.com/canopy-network/canopy/bft"
 	"math"
 	"sync"
 	"sync/atomic"
 	"time"
+
+	"github.com/canopy-network/canopy/bft"
 
 	"github.com/canopy-network/canopy/fsm"
 	"github.com/canopy-network/canopy/lib"
@@ -226,7 +227,8 @@ func (m *Mempool) CheckMempool() {
 	// set the cancel function
 	m.stop = stop
 	// apply the block against the state machine and populate the resulting merkle `roots` in the block header
-	block.BlockHeader, blockResult.Transactions, oversized, failed, err = m.FSM.ApplyBlock(ctx, block, true)
+	lastVs := m.controller.LastValidatorSet[m.FSM.Height()][m.controller.Config.ChainId]
+	block.BlockHeader, blockResult.Transactions, oversized, failed, err = m.FSM.ApplyBlock(ctx, block, lastVs, true)
 	if err != nil {
 		m.log.Warnf("Check Mempool error: %s", err.Error())
 		return

--- a/fsm/automatic.go
+++ b/fsm/automatic.go
@@ -7,7 +7,7 @@ import (
 /* This file handles 'automatic' (non-transaction-induced) state changes that occur ath the beginning and ending of a block */
 
 // BeginBlock() is code that is executed at the start of `applying` the block
-func (s *StateMachine) BeginBlock() lib.ErrorI {
+func (s *StateMachine) BeginBlock(lastValidatorSet *lib.ValidatorSet) lib.ErrorI {
 	// prevent attempting to load the certificate for height 0
 	if s.Height() <= 1 {
 		return nil
@@ -39,11 +39,7 @@ func (s *StateMachine) BeginBlock() lib.ErrorI {
 	}
 	// if is root-chain: load the committee from state as the certificate result
 	// will match the evidence and there's no Transaction to HandleMessageCertificateResults
-	committee, err := s.LoadCommittee(s.Config.ChainId, s.Height()-1)
-	if err != nil {
-		return err
-	}
-	return s.HandleCertificateResults(lastCertificate, &committee)
+	return s.HandleCertificateResults(lastCertificate, lastValidatorSet)
 }
 
 // EndBlock() is code that is executed at the end of `applying` the block

--- a/fsm/automatic_test.go
+++ b/fsm/automatic_test.go
@@ -2,11 +2,12 @@ package fsm
 
 import (
 	"fmt"
+	"math"
+	"testing"
+
 	"github.com/canopy-network/canopy/lib"
 	"github.com/canopy-network/canopy/lib/crypto"
 	"github.com/stretchr/testify/require"
-	"math"
-	"testing"
 )
 
 func TestBeginBlock(t *testing.T) {
@@ -122,8 +123,10 @@ func TestBeginBlock(t *testing.T) {
 			if test.isGenesis {
 				sm.height = 1
 			}
+			// get last validator set for begin block
 			// ensure expected error on function call
-			require.Equal(t, test.error, sm.BeginBlock())
+			valSet, _ := sm.LoadCommittee(lib.CanopyChainId, sm.Height()-1)
+			require.Equal(t, test.error, sm.BeginBlock(&valSet))
 			if test.error != nil {
 				return
 			}

--- a/fsm/message.go
+++ b/fsm/message.go
@@ -320,7 +320,7 @@ func (s *StateMachine) HandleMessageCertificateResults(msg *MessageCertificateRe
 		return ErrNonSubsidizedCommittee()
 	}
 	// get committee for the QC from the cache
-	committee := (*s.LastValidatorSet)[msg.Qc.Header.RootHeight][chainId]
+	committee := (*s.LastValidatorSet)[msg.Qc.Header.RootHeight+1][chainId]
 	if committee == nil {
 		// otherwise, retrieve it from the store
 		valSet, err := s.LoadCommittee(chainId, msg.Qc.Header.RootHeight)

--- a/fsm/message.go
+++ b/fsm/message.go
@@ -320,7 +320,10 @@ func (s *StateMachine) HandleMessageCertificateResults(msg *MessageCertificateRe
 		return ErrNonSubsidizedCommittee()
 	}
 	// get committee for the QC from the cache
-	committee := (*s.LastValidatorSet)[msg.Qc.Header.RootHeight+1][chainId]
+	var committee *lib.ValidatorSet
+	if s.LastValidatorSet != nil {
+		committee = s.LastValidatorSet[msg.Qc.Header.RootHeight+1][chainId]
+	}
 	if committee == nil {
 		// otherwise, retrieve it from the store
 		valSet, err := s.LoadCommittee(chainId, msg.Qc.Header.RootHeight)

--- a/fsm/message.go
+++ b/fsm/message.go
@@ -2,6 +2,7 @@ package fsm
 
 import (
 	"bytes"
+
 	"github.com/canopy-network/canopy/lib"
 	"github.com/canopy-network/canopy/lib/crypto"
 )
@@ -318,14 +319,19 @@ func (s *StateMachine) HandleMessageCertificateResults(msg *MessageCertificateRe
 	if poolBalance == 0 {
 		return ErrNonSubsidizedCommittee()
 	}
-	// get committee for the QC
-	committee, err := s.LoadCommittee(chainId, msg.Qc.Header.RootHeight)
-	if err != nil {
-		return err
+	// get committee for the QC from the cache
+	committee := (*s.LastValidatorSet)[msg.Qc.Header.RootHeight][chainId]
+	if committee == nil {
+		// otherwise, retrieve it from the store
+		valSet, err := s.LoadCommittee(chainId, msg.Qc.Header.RootHeight)
+		if err != nil {
+			return err
+		}
+		committee = &valSet
 	}
 	// ensure it's a valid QC
 	// max block size is 0 here because there should not be a block attached to this QC
-	isPartialQC, err := msg.Qc.Check(committee, 0, &lib.View{NetworkId: uint64(s.NetworkID), ChainId: chainId}, false)
+	isPartialQC, err := msg.Qc.Check(*committee, 0, &lib.View{NetworkId: uint64(s.NetworkID), ChainId: chainId}, false)
 	if err != nil {
 		return err
 	}
@@ -334,7 +340,7 @@ func (s *StateMachine) HandleMessageCertificateResults(msg *MessageCertificateRe
 		return lib.ErrNoMaj23()
 	}
 	// handle the certificate results
-	return s.HandleCertificateResults(msg.Qc, &committee)
+	return s.HandleCertificateResults(msg.Qc, committee)
 }
 
 // HandleMessageSubsidy() is the proper handler for a `Subsidy` message

--- a/fsm/state.go
+++ b/fsm/state.go
@@ -21,17 +21,17 @@ const (
 type StateMachine struct {
 	store lib.RWStoreI
 
-	ProtocolVersion    uint64                                   // the version of the protocol this node is running
-	NetworkID          uint32                                   // the id of the network this node is configured to be on
-	height             uint64                                   // the 'version' of the state based on number of blocks currently on
-	totalVDFIterations uint64                                   // the number of 'verifiable delay iterations' in the blockchain up to this version
-	slashTracker       *SlashTracker                            // tracks total slashes across multiple blocks
-	proposeVoteConfig  GovProposalVoteConfig                    // the configuration of how the state machine behaves with governance proposals
-	Config             lib.Config                               // the main configuration as defined by the 'config.json' file
-	Metrics            *lib.Metrics                             // the telemetry module
-	log                lib.LoggerI                              // the logger for standard output and debugging
-	cache              *cache                                   // the state machine cache
-	LastValidatorSet   *map[uint64]map[uint64]*lib.ValidatorSet // reference to the last validator set saved in the controller
+	ProtocolVersion    uint64                                  // the version of the protocol this node is running
+	NetworkID          uint32                                  // the id of the network this node is configured to be on
+	height             uint64                                  // the 'version' of the state based on number of blocks currently on
+	totalVDFIterations uint64                                  // the number of 'verifiable delay iterations' in the blockchain up to this version
+	slashTracker       *SlashTracker                           // tracks total slashes across multiple blocks
+	proposeVoteConfig  GovProposalVoteConfig                   // the configuration of how the state machine behaves with governance proposals
+	Config             lib.Config                              // the main configuration as defined by the 'config.json' file
+	Metrics            *lib.Metrics                            // the telemetry module
+	log                lib.LoggerI                             // the logger for standard output and debugging
+	cache              *cache                                  // the state machine cache
+	LastValidatorSet   map[uint64]map[uint64]*lib.ValidatorSet // reference to the last validator set saved in the controller
 }
 
 // cache is the set of items to be cached used by the state machine

--- a/fsm/state.go
+++ b/fsm/state.go
@@ -21,16 +21,17 @@ const (
 type StateMachine struct {
 	store lib.RWStoreI
 
-	ProtocolVersion    uint64                // the version of the protocol this node is running
-	NetworkID          uint32                // the id of the network this node is configured to be on
-	height             uint64                // the 'version' of the state based on number of blocks currently on
-	totalVDFIterations uint64                // the number of 'verifiable delay iterations' in the blockchain up to this version
-	slashTracker       *SlashTracker         // tracks total slashes across multiple blocks
-	proposeVoteConfig  GovProposalVoteConfig // the configuration of how the state machine behaves with governance proposals
-	Config             lib.Config            // the main configuration as defined by the 'config.json' file
-	Metrics            *lib.Metrics          // the telemetry module
-	log                lib.LoggerI           // the logger for standard output and debugging
-	cache              *cache                // the state machine cache
+	ProtocolVersion    uint64                                   // the version of the protocol this node is running
+	NetworkID          uint32                                   // the id of the network this node is configured to be on
+	height             uint64                                   // the 'version' of the state based on number of blocks currently on
+	totalVDFIterations uint64                                   // the number of 'verifiable delay iterations' in the blockchain up to this version
+	slashTracker       *SlashTracker                            // tracks total slashes across multiple blocks
+	proposeVoteConfig  GovProposalVoteConfig                    // the configuration of how the state machine behaves with governance proposals
+	Config             lib.Config                               // the main configuration as defined by the 'config.json' file
+	Metrics            *lib.Metrics                             // the telemetry module
+	log                lib.LoggerI                              // the logger for standard output and debugging
+	cache              *cache                                   // the state machine cache
+	LastValidatorSet   *map[uint64]map[uint64]*lib.ValidatorSet // reference to the last validator set saved in the controller
 }
 
 // cache is the set of items to be cached used by the state machine
@@ -525,6 +526,7 @@ func (s *StateMachine) Copy() (*StateMachine, lib.ErrorI) {
 		cache: &cache{
 			accounts: make(map[uint64]*Account),
 		},
+		LastValidatorSet: s.LastValidatorSet,
 	}, nil
 }
 

--- a/fsm/state.go
+++ b/fsm/state.go
@@ -97,7 +97,8 @@ func (s *StateMachine) Initialize(store lib.StoreI) (genesis bool, err lib.Error
 // NOTES:
 // - this function may be used to validate 'additional' transactions outside the normal block size as if they were to be included
 // - a list of failed transactions are returned
-func (s *StateMachine) ApplyBlock(ctx context.Context, b *lib.Block, allowOversize bool) (header *lib.BlockHeader, txResults, oversized []*lib.TxResult, failed []*lib.FailedTx, err lib.ErrorI) {
+func (s *StateMachine) ApplyBlock(ctx context.Context, b *lib.Block, lastValidatorSet *lib.ValidatorSet, allowOversize bool) (
+	header *lib.BlockHeader, txResults, oversized []*lib.TxResult, failed []*lib.FailedTx, err lib.ErrorI) {
 	// catch in case there's a panic
 	defer func() {
 		if r := recover(); r != nil {
@@ -113,7 +114,7 @@ func (s *StateMachine) ApplyBlock(ctx context.Context, b *lib.Block, allowOversi
 		return nil, nil, nil, nil, ErrWrongStoreType()
 	}
 	// automated execution at the 'beginning of a block'
-	if err = s.BeginBlock(); err != nil {
+	if err = s.BeginBlock(lastValidatorSet); err != nil {
 		return nil, nil, nil, nil, err
 	}
 	// apply all Transactions in the block
@@ -127,8 +128,6 @@ func (s *StateMachine) ApplyBlock(ctx context.Context, b *lib.Block, allowOversi
 	if err = s.EndBlock(b.BlockHeader.ProposerAddress); err != nil {
 		return nil, nil, nil, nil, err
 	}
-	// load the validator set for the previous height
-	lastValidatorSet, _ := s.LoadCommittee(s.Config.ChainId, s.Height()-1)
 	// calculate the merkle root of the last validators to maintain validator continuity between blocks (if root)
 	lastValidatorRoot, err := lastValidatorSet.ValidatorSet.Root()
 	if err != nil {
@@ -438,7 +437,7 @@ func (s *StateMachine) GetMaxBlockSize() (uint64, lib.ErrorI) {
 }
 
 // LoadRootChainInfo() returns the 'need-to-know' information for a nested chain
-func (s *StateMachine) LoadRootChainInfo(id, height uint64) (*lib.RootChainInfo, lib.ErrorI) {
+func (s *StateMachine) LoadRootChainInfo(id, height uint64, lastValidatorSet ...*lib.ValidatorSet) (*lib.RootChainInfo, lib.ErrorI) {
 	lastHeight := uint64(1)
 	// update the metrics once complete
 	defer s.Metrics.UpdateGetRootChainInfo(time.Now())
@@ -471,7 +470,13 @@ func (s *StateMachine) LoadRootChainInfo(id, height uint64) (*lib.RootChainInfo,
 	}
 	// get the previous committee
 	// allow an error here to have size 0 validator sets
-	lastValidatorSet, _ := lastSM.GetCommitteeMembers(id)
+	if len(lastValidatorSet) == 0 || lastValidatorSet[0] == nil {
+		lvs, err := lastSM.GetCommitteeMembers(id)
+		if err != nil {
+			return nil, err
+		}
+		lastValidatorSet = []*lib.ValidatorSet{&lvs}
+	}
 	// get the delegate lottery winner
 	lotteryWinner, err := sm.LotteryWinner(id)
 	if err != nil {
@@ -487,7 +492,7 @@ func (s *StateMachine) LoadRootChainInfo(id, height uint64) (*lib.RootChainInfo,
 		RootChainId:      s.Config.ChainId,
 		Height:           sm.height,
 		ValidatorSet:     validatorSet.ValidatorSet,
-		LastValidatorSet: lastValidatorSet.ValidatorSet,
+		LastValidatorSet: lastValidatorSet[0].ValidatorSet,
 		LotteryWinner:    lotteryWinner,
 		Orders:           orders,
 	}, nil
@@ -521,16 +526,6 @@ func (s *StateMachine) Copy() (*StateMachine, lib.ErrorI) {
 			accounts: make(map[uint64]*Account),
 		},
 	}, nil
-}
-
-// ResetToBeginBlock() resets the store and executes 'begin-block'
-func (s *StateMachine) ResetToBeginBlock() {
-	// reset the state machine (store)
-	s.Reset()
-	// run the 'begin block' code
-	if err := s.BeginBlock(); err != nil {
-		s.log.Errorf("BEGIN_BLOCK FAILURE: %s", err.Error())
-	}
 }
 
 // Set() upserts a key-value pair under a key

--- a/fsm/state_test.go
+++ b/fsm/state_test.go
@@ -263,8 +263,10 @@ func TestApplyBlock(t *testing.T) {
 				// set the protocol version to not trigger an error
 				sm.ProtocolVersion = 1
 			}
+			// load the last block validator set
+			valSet, _ := sm.LoadCommittee(lib.CanopyChainId, sm.Height()-1)
 			// execute the function call
-			header, txResults, _, failed, e := sm.ApplyBlock(context.Background(), test.block, false)
+			header, txResults, _, failed, e := sm.ApplyBlock(context.Background(), test.block, &valSet, false)
 			// validate the expected error
 			require.Equal(t, test.error != "", e != nil || len(failed) != 0, e)
 			if len(failed) != 0 {

--- a/lib/config.go
+++ b/lib/config.go
@@ -3,6 +3,7 @@ package lib
 import (
 	"encoding/json"
 	"math"
+	"math/rand"
 	"os"
 	"path/filepath"
 	"strings"
@@ -227,23 +228,25 @@ type StoreConfig struct {
 func DefaultDataDirPath() string {
 	// get the user home
 	home, err := os.UserHomeDir()
+	// home, err := os.Getwd()
 	// if unable to get the user home
 	if err != nil {
 		// fatal error
 		panic(err)
 	}
 	// exit with full default data directory path
+	// return filepath.Join(home, "canopy_2")
 	return filepath.Join(home, ".canopy")
 }
 
 // DefaultStoreConfig() returns the developer recommended store configuration
 func DefaultStoreConfig() StoreConfig {
 	return StoreConfig{
-		DataDirPath:          DefaultDataDirPath(), // use the default data dir path
-		DBName:               "canopy",             // 'canopy' database name
-		IndexByAccount:       true,                 // index transactions by account
-		InMemory:             false,                // persist to disk, not memory
-		CleanupBlockInterval: 200,                  // clean every 200 blocks
+		DataDirPath:          DefaultDataDirPath(),         // use the default data dir path
+		DBName:               "canopy",                     // 'canopy' database name
+		IndexByAccount:       true,                         // index transactions by account
+		InMemory:             false,                        // persist to disk, not memory
+		CleanupBlockInterval: uint64(rand.Intn(101) + 100), // clean every 100-200 blocks (random)
 	}
 }
 

--- a/store/store.go
+++ b/store/store.go
@@ -199,14 +199,12 @@ func (s *Store) Commit() (root []byte, err lib.ErrorI) {
 	if e := s.writer.Flush(); e != nil {
 		return nil, ErrCommitDB(e)
 	}
-	// Trigger eviction of LSS deleted keys
 	// check if the current version is a multiple of the cleanup block interval
 	if s.Version()%s.config.StoreConfig.CleanupBlockInterval == 0 {
-		go func() {
-			if err := s.Evict(); err != nil {
-				s.log.Errorf("failed to evict LSS deleted keys: %s", err)
-			}
-		}()
+		// trigger eviction of LSS deleted keys
+		if err := s.Evict(); err != nil {
+			s.log.Errorf("failed to evict LSS deleted keys: %s", err)
+		}
 	}
 	// update the metrics once complete
 	s.metrics.UpdateStoreMetrics(size, entries, time.Time{}, startTime)
@@ -379,33 +377,36 @@ func (s *Store) setCommitID(version uint64, root []byte) lib.ErrorI {
 }
 
 // Evict deletes all entries marked for eviction.
-// BadgerDB GC's behavior is undocumented which may lead to unexpected behavior.
-// This eviction process is a workaround to guarantee the deletion of entries marked for
-// deletion or eviction. It works as follows:
-// 1. Create a trigger key and write it to the database.
-// 2. Mark entries for eviction with the correct meta bits.
-// 3. Set discard timestamp to enable BadgerDB GC.
-// 4. Drop the trigger prefix to force eviction processing.
-// 5. Clean up by resetting discard timestamp and deleting trigger key.
+// It is done by backing up the LSS store, discarding all the entries with
+// that prefix and restoring again the backup with none of the deleted keys.
+// This is done to ensure that the LSS keys are consistently deleted
 func (s *Store) Evict() lib.ErrorI {
+	now := time.Now()
 	s.log.Debugf("Eviction process started at height %d", s.Version())
-	// evict LSS deleted keys, part of the workaround for previously set keys for deletion
-	triggerEvict := fmt.Appendf(nil, "zzz/trigger_key_%s", lib.RandSlice(evictRandKeySize))
-	writer := s.db.NewWriteBatchAt(lssVersion)
-	if err := writer.Set(triggerEvict, nil); err != nil {
-		return ErrStoreSet(err)
-	}
-	if err := writer.Flush(); err != nil {
+	// backup the LSS store
+	lssBackup, err := s.GetItems(lssVersion, []byte(latestStatePrefix), true)
+	if err != nil {
 		return ErrCommitDB(err)
 	}
-	// set discard timestamp, before marking entries for eviction
+	// set discard timestamp, before evicting entries
 	s.db.SetDiscardTs(lssVersion)
-	// drop the trigger to force eviction
-	if err := s.db.DropPrefix(triggerEvict); err != nil {
-		return ErrCommitDB(err)
-	}
 	// reset discard timestamp after eviction
 	defer s.db.SetDiscardTs(0)
+	// drop the entire LSS prefix to force eviction processing
+	if err := s.db.DropPrefix([]byte(latestStatePrefix)); err != nil {
+		return ErrCommitDB(err)
+	}
+	// restore the LSS store without the deleted keys
+	writer := s.db.NewWriteBatchAt(lssVersion)
+	for _, entry := range lssBackup {
+		if err := writer.SetEntryAt(entry, lssVersion); err != nil {
+			return ErrStoreSet(err)
+		}
+	}
+	// commit the LSS restore
+	if err := writer.Flush(); err != nil {
+		return ErrFlushBatch(err)
+	}
 	// ValueLogGC and Flatten temporarily disabled due to increased memory usage
 	// TODO: Re-enable ValueLogGC and Flatten after optimizing memory usage
 	// flatten the DB to optimize the storage layout
@@ -419,7 +420,7 @@ func (s *Store) Evict() lib.ErrorI {
 	// }
 	// log the results
 	total, deleted := s.keyCount(lssVersion, []byte(latestStatePrefix), true)
-	s.log.Debugf("Eviction process finished. Removed %d keys, %d total keys", deleted, total)
+	s.log.Debugf("Eviction process finished. current deleted %d keys, %d total keys elapsed: %s", deleted, total, time.Since(now))
 	return nil
 }
 
@@ -450,6 +451,44 @@ func (s *Store) keyCount(version uint64, prefix []byte, noDiscardBit bool) (coun
 	}
 	// return the counts
 	return count, deleted
+}
+
+// GetItems returns all items in the store with the given version and prefix.
+func (s *Store) GetItems(version uint64, prefix []byte, skipDeleted bool) ([]*badger.Entry, error) {
+	// create the items slice
+	items := make([]*badger.Entry, 0)
+	// create a new transaction at the specified version
+	txn := s.db.NewTransactionAt(version, false)
+	defer txn.Discard()
+	// create a new iterator for the transaction on the given prefix
+	it := txn.NewIterator(badger.IteratorOptions{
+		Prefix:      prefix,
+		AllVersions: true,
+	})
+	// close the iterator when done
+	defer it.Close()
+	// iterate over the items
+	for it.Rewind(); it.Valid(); it.Next() {
+		item := it.Item()
+		// check if the item is deleted or expired
+		if skipDeleted && item.IsDeletedOrExpired() {
+			continue
+		}
+		value, err := item.ValueCopy(nil)
+		if err != nil {
+			return nil, ErrReadBytes(err)
+		}
+		// copy the item's key, value, and metadata
+		newItem := &badger.Entry{
+			Key:   item.KeyCopy(nil),
+			Value: value,
+		}
+		setMeta(newItem, getItemMeta(item))
+		// append the item to the items slice
+		items = append(items, newItem)
+	}
+	// return the items
+	return items, nil
 }
 
 // getLatestCommitID() retrieves the latest CommitID from the database

--- a/store/store.go
+++ b/store/store.go
@@ -406,12 +406,12 @@ func (s *Store) Evict() lib.ErrorI {
 	}
 	// reset discard timestamp after eviction
 	defer s.db.SetDiscardTs(0)
+	// ValueLogGC and Flatten temporarily disabled due to increased memory usage
+	// TODO: Re-enable ValueLogGC and Flatten after optimizing memory usage
 	// flatten the DB to optimize the storage layout
-	if err := s.db.Flatten(1); err != nil {
-		return ErrCommitDB(err)
-	}
-	// ValueLogGC temporarily disabled due to increased memory usage
-	// TODO: Re-enable ValueLogGC after optimizing memory usage
+	// if err := s.db.Flatten(1); err != nil {
+	// 	return ErrCommitDB(err)
+	// }
 	// run GC to clean up unused data
 	// if err := s.db.RunValueLogGC(valueLogGCDiscardRation); err != nil &&
 	// 	err != badger.ErrNoRewrite {


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the changes introduced in this pull request. -->
Optimize eviction process of deleting expired LSS keys and greatly boosts `LoadRootChainInfo` times by caching the current validator set for the next height

## Related Issues
<!-- List any issues this pull request closes. -->
Closes: #<issue-number>

## Changes Made
<!-- Highlight the key changes made in the code. For example:
- Added a new function to handle X
- Refactored Y for better performance
- Fixed bug Z
-->
- Add new "mark and sweep" eviction process: backups all the LSS keys and drops the LSS prefix completely, restoring the 
backup afterwards
- Add `LastValidatorSet` to the controller and heavily caches the current validator set as the last one for the next height
- Updates the `Controller` and `FSM` to use`LastValidatorSet` whenever possible

## Checklist
- [x] I have tested the changes locally and verified they work as intended.
- [ ] I have appropriately titled my branch `issue-#<issue-number>`.
- [ ] I have run re-built the web-wallet and/or block explorer (if applicable).
- [ ] I have run `npm run prettier` to format the web-wallet and/or block explorer (if applicable)
- [ ] I have updated documentation (if applicable).
- [x] I have included tests for the changes (if applicable).

## Additional Notes
<!-- Add any additional context, screenshots, or information that reviewers might find helpful. -->
