### PR TITLE
Eviction Improvement

### DIFF
--- a/.docker/Dockerfile
+++ b/.docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.23.9-alpine AS builder
+FROM golang:1.24-alpine AS builder
 
 RUN apk update && apk add --no-cache make bash nodejs npm
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.23.9-alpine AS builder
+FROM golang:1.24-alpine AS builder
 
 RUN apk update && apk add --no-cache make bash nodejs npm
 

--- a/lib/config.go
+++ b/lib/config.go
@@ -3,6 +3,7 @@ package lib
 import (
 	"encoding/json"
 	"math"
+	"math/rand/v2"
 	"os"
 	"path/filepath"
 	"strings"
@@ -241,11 +242,11 @@ func DefaultDataDirPath() string {
 // DefaultStoreConfig() returns the developer recommended store configuration
 func DefaultStoreConfig() StoreConfig {
 	return StoreConfig{
-		DataDirPath:          DefaultDataDirPath(), // use the default data dir path
-		DBName:               "canopy",             // 'canopy' database name
-		IndexByAccount:       true,                 // index transactions by account
-		InMemory:             false,                // persist to disk, not memory
-		CleanupBlockInterval: 50,                   // clean every 100-200 blocks (random)
+		DataDirPath:          DefaultDataDirPath(),         // use the default data dir path
+		DBName:               "canopy",                     // 'canopy' database name
+		IndexByAccount:       true,                         // index transactions by account
+		InMemory:             false,                        // persist to disk, not memory
+		CleanupBlockInterval: uint64(rand.Int32N(26) + 25), // clean every 25-50 blocks (random)
 	}
 }
 

--- a/lib/config.go
+++ b/lib/config.go
@@ -242,11 +242,11 @@ func DefaultDataDirPath() string {
 // DefaultStoreConfig() returns the developer recommended store configuration
 func DefaultStoreConfig() StoreConfig {
 	return StoreConfig{
-		DataDirPath:          DefaultDataDirPath(),         // use the default data dir path
-		DBName:               "canopy",                     // 'canopy' database name
-		IndexByAccount:       true,                         // index transactions by account
-		InMemory:             false,                        // persist to disk, not memory
-		CleanupBlockInterval: uint64(rand.Int32N(26) + 25), // clean every 25-50 blocks (random)
+		DataDirPath:          DefaultDataDirPath(),           // use the default data dir path
+		DBName:               "canopy",                       // 'canopy' database name
+		IndexByAccount:       true,                           // index transactions by account
+		InMemory:             false,                          // persist to disk, not memory
+		CleanupBlockInterval: uint64(rand.Int32N(101) + 100), // clean every 25-50 blocks (random)
 	}
 }
 

--- a/lib/config.go
+++ b/lib/config.go
@@ -246,7 +246,7 @@ func DefaultStoreConfig() StoreConfig {
 		DBName:               "canopy",                       // 'canopy' database name
 		IndexByAccount:       true,                           // index transactions by account
 		InMemory:             false,                          // persist to disk, not memory
-		CleanupBlockInterval: uint64(rand.Int32N(101) + 100), // clean every 25-50 blocks (random)
+		CleanupBlockInterval: uint64(rand.Int32N(101) + 100), // clean every 100-200 blocks (random)
 	}
 }
 

--- a/lib/config.go
+++ b/lib/config.go
@@ -3,7 +3,6 @@ package lib
 import (
 	"encoding/json"
 	"math"
-	"math/rand"
 	"os"
 	"path/filepath"
 	"strings"
@@ -242,11 +241,11 @@ func DefaultDataDirPath() string {
 // DefaultStoreConfig() returns the developer recommended store configuration
 func DefaultStoreConfig() StoreConfig {
 	return StoreConfig{
-		DataDirPath:          DefaultDataDirPath(),         // use the default data dir path
-		DBName:               "canopy",                     // 'canopy' database name
-		IndexByAccount:       true,                         // index transactions by account
-		InMemory:             false,                        // persist to disk, not memory
-		CleanupBlockInterval: uint64(rand.Intn(101) + 100), // clean every 100-200 blocks (random)
+		DataDirPath:          DefaultDataDirPath(), // use the default data dir path
+		DBName:               "canopy",             // 'canopy' database name
+		IndexByAccount:       true,                 // index transactions by account
+		InMemory:             false,                // persist to disk, not memory
+		CleanupBlockInterval: 50,                   // clean every 100-200 blocks (random)
 	}
 }
 

--- a/store/store.go
+++ b/store/store.go
@@ -30,8 +30,10 @@ const (
 var _ lib.StoreI = &Store{} // enforce the Store interface
 
 var (
-	latestStatePrefix    = "s/"       // prefix designated for the LatestStateStore where the most recent blobs of state data are held
-	latestStateKeyPrefix = "s_prefix" // key to obtain the current LSS prefix at it changes on each eviction
+	// prefix designated for the LatestStateStore where the most recent blobs of state data are held
+	latestStatePrefix = "s/"
+	// key to obtain the current LSS prefix as it changes on each eviction
+	latestStateKeyPrefix = "s_prefix"
 )
 
 /*

--- a/store/store.go
+++ b/store/store.go
@@ -420,9 +420,7 @@ func (s *Store) Evict() lib.ErrorI {
 	// }
 	// log the results
 	total, deleted := s.keyCount(lssVersion, []byte(latestStatePrefix), true)
-	// total, deleted := 0, 0
 	s.log.Debugf("Eviction process finished. current deleted %d keys, %d total keys elapsed: %s", deleted, total, time.Since(now))
-	panic("forced")
 	return nil
 }
 

--- a/store/store.go
+++ b/store/store.go
@@ -427,26 +427,15 @@ func (s *Store) Evict() lib.ErrorI {
 		defer s.db.SetDiscardTs(0)
 		// drop the entire LSS prefix to force eviction processing
 		start := time.Now()
-		fmt.Println("dropping prefix")
 		if err := s.db.DropPrefix([]byte(currentLSSPrefix)); err != nil {
 			s.log.Errorf("Failed to drop LSS prefix: %v", err)
 		}
-		fmt.Println("dropped prefix in", time.Since(start))
+		s.log.Debugf("dropped prefix, took", time.Since(start))
 	}()
-	// ValueLogGC and Flatten temporarily disabled due to increased memory usage
-	// TODO: Re-enable ValueLogGC and Flatten after optimizing memory usage
-	// flatten the DB to optimize the storage layout
-	// if err := s.db.Flatten(1); err != nil {
-	// 	return ErrCommitDB(err)
-	// }
-	// run GC to clean up unused data
-	// if err := s.db.RunValueLogGC(valueLogGCDiscardRation); err != nil &&
-	// 	err != badger.ErrNoRewrite {
-	// 	return ErrCommitDB(err)
-	// }
 	// log the results
 	total, deleted := s.keyCount(lssVersion, []byte(latestStatePrefix), true)
-	s.log.Debugf("Eviction process finished. current deleted %d keys, %d total keys elapsed: %s", deleted, total, time.Since(now))
+	s.log.Debugf("Eviction finished. current deleted %d keys, %d total keys elapsed: %s",
+		deleted, total, time.Since(now))
 	return nil
 }
 

--- a/store/store.go
+++ b/store/store.go
@@ -420,7 +420,9 @@ func (s *Store) Evict() lib.ErrorI {
 	// }
 	// log the results
 	total, deleted := s.keyCount(lssVersion, []byte(latestStatePrefix), true)
+	// total, deleted := 0, 0
 	s.log.Debugf("Eviction process finished. current deleted %d keys, %d total keys elapsed: %s", deleted, total, time.Since(now))
+	panic("forced")
 	return nil
 }
 

--- a/store/store.go
+++ b/store/store.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"math"
 	"path/filepath"
-	"runtime"
 	"time"
 
 	"github.com/canopy-network/canopy/lib"
@@ -94,7 +93,7 @@ func NewStore(config lib.Config, path string, metrics *lib.Metrics, log lib.Logg
 	db, err := badger.OpenManaged(badger.DefaultOptions(path).WithNumVersionsToKeep(math.MaxInt64).WithLoggingLevel(badger.ERROR).
 		WithValueThreshold(1024).WithCompression(options.None).WithNumMemtables(16).WithMemTableSize(256 << 20).
 		WithNumLevelZeroTables(10).WithNumLevelZeroTablesStall(20).WithBaseTableSize(128 << 20).WithBaseLevelSize(512 << 20).
-		WithNumCompactors(runtime.NumCPU()).WithCompactL0OnClose(true).WithBypassLockGuard(true).WithDetectConflicts(false).WithSyncWrites(true),
+		WithNumCompactors(0).WithCompactL0OnClose(true).WithBypassLockGuard(true).WithDetectConflicts(false),
 	)
 	if err != nil {
 		return nil, ErrOpenDB(err)


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the changes introduced in this pull request. -->
BadgerDB's `DropPrefix` feature is pretty slow and may even block writes in some occasions, this makes the eviction process to block for a long time which could even cause nodes to miss consensus, this improves the eviction process by having a dynamic LSS store prefix that changes on every eviction, and defer the `DropPrefix` method itself to a goroutine.

This even makes the store safer because the new prefix is never used until its changes have been committed so if for some reason that fails, the whole eviction process will stop and the previous prefix will continue to be used, leaving the store now with no dangers of data loss during eviction.

## Related Issues
<!-- List any issues this pull request closes. -->
Closes: #<issue-number>

## Changes Made
<!-- Highlight the key changes made in the code. For example:
- Added a new function to handle X
- Refactored Y for better performance
- Fixed bug Z
-->
- Update go docker image to 1.24 (needed for build reasons)
- Improve eviction process to make `DropPrefix` async
- Change the store to have a dynamic lss prefix
- Change eviction to be optional by settings the `CleanupBlockInterval` to 0

## Checklist
- [x] I have tested the changes locally and verified they work as intended.
- [ ] I have appropriately titled my branch `issue-#<issue-number>`.
- [ ] I have run re-built the web-wallet and/or block explorer (if applicable).
- [ ] I have run `npm run prettier` to format the web-wallet and/or block explorer (if applicable)
- [ ] I have updated documentation (if applicable).
- [ ] I have included tests for the changes (if applicable).

## Additional Notes
<!-- Add any additional context, screenshots, or information that reviewers might find helpful. -->
