### PR TITLE
feat: Add error handling and constraints for port ranges

### DIFF
--- a/lib/error.go
+++ b/lib/error.go
@@ -163,6 +163,7 @@ const (
 	CodeNewHeight                       ErrorCode = 64
 	CodeWrongViewHeight                 ErrorCode = 65
 	CodeBadPort                         ErrorCode = 66
+	CodeBadPortLowLimit                 ErrorCode = 67
 
 	// State Machine Module
 	StateMachineModule ErrorModule = "state_machine"
@@ -741,6 +742,10 @@ func ErrHashSize() ErrorI {
 func ErrMaxPort() ErrorI { return NewError(CodeMaxPort, MainModule, "max port exceeded") }
 
 func ErrBadPort() ErrorI { return NewError(CodeBadPort, MainModule, "port not numerical") }
+
+func ErrBadPortLowLimit() ErrorI {
+	return NewError(CodeBadPortLowLimit, MainModule, fmt.Sprintf("port must be greater than %d", MinAllowedPort))
+}
 
 func ErrProtoParse(err error) ErrorI {
 	return NewError(CodeProtoParse, MainModule, fmt.Sprintf("proto parse failed with error: %s", err.Error()))

--- a/lib/peer.go
+++ b/lib/peer.go
@@ -15,6 +15,10 @@ import (
 
 /* This file contains shared code for peers and messages that are routed by the controller throughout the app */
 
+const (
+	DefaultPort = "9000" // default port when not specified
+)
+
 // MESSAGE CODE BELOW
 
 // Channels are logical communication paths or streams that operate over a single 'multiplexed' network connection
@@ -78,7 +82,9 @@ func ResolvePort(oldPort string, chainId uint64) (string, ErrorI) {
 	if oldPort != "" {
 		return AddToPort(strings.ReplaceAll(oldPort, ":", ""), chainId)
 	}
-	return AddToPort("9000", chainId)
+	//TODO review if max chainID should be limited for now to 56,535, combined with defaultPort, or 64,510, combined with the lower bound port (1025)
+	//any higher value will return bad port error
+	return AddToPort(DefaultPort, chainId)
 }
 
 // ResolveAndReplacePort resolves the appropriate port and replaces the port in the net address

--- a/lib/peer_test.go
+++ b/lib/peer_test.go
@@ -3,9 +3,11 @@ package lib
 import (
 	"container/list"
 	"encoding/json"
-	"github.com/canopy-network/canopy/lib/crypto"
+	"fmt"
 	"testing"
 	"time"
+
+	"github.com/canopy-network/canopy/lib/crypto"
 
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/runtime/protoimpl"
@@ -370,6 +372,51 @@ func TestResolveAndReplacePort(t *testing.T) {
 			netaddr:  "tcp://[2001:db8::1]",
 			expected: "[2001:db8::1]:9002",
 			chainId:  2,
+		},
+		{
+			name:     "with port chain 20",
+			netaddr:  "tcp://example.com:9000",
+			expected: "example.com:9020",
+			chainId:  20,
+		},
+		{
+			name:        "with port chain 20 on port lower than 1024",
+			netaddr:     "tcp://example.com:80",
+			expected:    "",
+			chainId:     20,
+			expectedErr: fmt.Sprintf("port must be greater than %d", MinAllowedPort),
+		},
+		{
+			name:     "with port chain 5",
+			netaddr:  "tcp://example.com:1025",
+			expected: "example.com:1030",
+			chainId:  5,
+		},
+		{
+			name:     "default with chain 56,535 ",
+			netaddr:  "tcp://example.com",
+			expected: "example.com:65535",
+			chainId:  56535,
+		},
+		{
+			name:        "default with chain 56,536 ",
+			netaddr:     "tcp://example.com",
+			expected:    "",
+			chainId:     56536,
+			expectedErr: "max port exceeded",
+		},
+		{
+			name:     "port 1025 with chain 64,510 ",
+			netaddr:  "tcp://example.com:1025",
+			expected: "example.com:65535",
+			chainId:  64510,
+		},
+		{
+			name:        "port 1025 with chain 64,511 ",
+			netaddr:     "tcp://example.com:1025",
+			expected:    "",
+			chainId:     64511,
+			expectedErr: "max port exceeded",
 		},
 	}
 	for _, test := range tests {

--- a/lib/util.go
+++ b/lib/util.go
@@ -24,7 +24,10 @@ import (
 	"google.golang.org/protobuf/types/known/anypb"
 )
 
-/* This file implements shared general utility functions that are used throughout the app */
+const (
+	MaxAllowedPort = 65535 // maxAllowedPort is the maximum port number allowed.
+	MinAllowedPort = 1025  // minAllowedPort is the minimum port number allowed to ensure it avoids commonly reserved system ports.
+)
 
 // PAGE CODE BELOW
 
@@ -556,10 +559,14 @@ func AddToPort(portStr string, add uint64) (string, ErrorI) {
 	if err != nil {
 		return "", ErrBadPort()
 	}
+	// check if port is valid, should be higher than 1024 to avoid port conflicts
+	if port < MinAllowedPort {
+		return "", ErrBadPortLowLimit()
+	}
 	// add the given number to the port
 	newPort := port + int(add)
 	// ensure the new port doesn't exceed the max port number (65535)
-	if newPort > 65535 {
+	if newPort > MaxAllowedPort {
 		return "", ErrMaxPort()
 	}
 	return fmt.Sprintf("%d", newPort), nil


### PR DESCRIPTION
Main task:
- Introduced constants `MinAllowedPort` and `MaxAllowedPort` to define valid port range.
- Added `ErrBadPortLowLimit` for ports below the minimum limit.
- Updated `AddToPort` function to validate port ranges and return appropriate errors.
- Updated test cases to handle new constraints and scenarios.

Secondary: 
Review potential chainID max / control  as we are coupling it with the ports