### PR TITLE
fix: add reflect check to prevent panic

### DIFF
--- a/store/store.go
+++ b/store/store.go
@@ -520,18 +520,15 @@ func (s *Store) Compact(version uint64, compactHSS bool) lib.ErrorI {
 	// check if batch's db closed field is not nil using reflection
 	batchValue := reflect.ValueOf(batch).Elem()
 	batchDBField := batchValue.FieldByName("db")
-	if batchDBField.IsValid() && !batchDBField.IsNil() {
-		dbValue := batchDBField.Elem()
-		closedField := dbValue.FieldByName("closed")
-		if closedField.IsNil() {
-			s.mu.Unlock() // unlock commit op
-			s.log.Debugf("key compaction skipped [%d]: closed field is nil", version)
-			return nil
-		}
-	} else {
+	if !batchDBField.IsValid() || batchDBField.IsNil() {
 		s.mu.Unlock() // unlock commit op
-		s.log.Debugf("key compaction skipped [%d]: db field is nil", version)
-		return nil
+		return ErrCommitDB(fmt.Errorf("db field is nil"))
+	}
+	dbValue := batchDBField.Elem()
+	closedField := dbValue.FieldByName("closed")
+	if !closedField.IsValid() || closedField.IsNil() {
+		s.mu.Unlock() // unlock commit op
+		return ErrCommitDB(fmt.Errorf("closed field is nil"))
 	}
 	if err := batch.Commit(pebble.Sync); err != nil {
 		s.mu.Unlock() // unlock commit op


### PR DESCRIPTION
Add reflect field check as bandaid to prevent nil pointer deference in pebble