### PR TITLE
Add indexer-snapshot endpoint for aggregated block data

### DIFF
--- a/cmd/cli/query.go
+++ b/cmd/cli/query.go
@@ -40,6 +40,7 @@ func init() {
 	queryCmd.AddCommand(retiredCommitteeCmd)
 	queryCmd.AddCommand(orderCmd)
 	queryCmd.AddCommand(ordersCmd)
+	queryCmd.AddCommand(indexerSnapshotCmd)
 	queryCmd.AddCommand(nonSignersCmd)
 	queryCmd.AddCommand(paramsCmd)
 	queryCmd.AddCommand(supplyCmd)
@@ -189,6 +190,14 @@ var (
 		Short: "query all sell orders for a committee",
 		Run: func(cmd *cobra.Command, args []string) {
 			writeToConsole(client.Orders(height, committee))
+		},
+	}
+
+	indexerSnapshotCmd = &cobra.Command{
+		Use:   "indexer-snapshot --height=1",
+		Short: "query comprehensive indexer snapshot data for a block height",
+		Run: func(cmd *cobra.Command, args []string) {
+			writeToConsole(client.IndexerSnapshot(height))
 		},
 	}
 

--- a/cmd/rpc/client.go
+++ b/cmd/rpc/client.go
@@ -242,6 +242,12 @@ func (c *Client) NextDexBatch(height, chainId uint64, withPoints bool) (p *lib.D
 	return
 }
 
+func (c *Client) IndexerSnapshot(height uint64) (p *IndexerSnapshotResponse, err lib.ErrorI) {
+	p = new(IndexerSnapshotResponse)
+	err = c.heightRequest(IndexerSnapshotRouteName, height, p)
+	return
+}
+
 func (c *Client) LastProposers(height uint64) (p *lib.Proposers, err lib.ErrorI) {
 	p = new(lib.Proposers)
 	err = c.heightRequest(LastProposersRouteName, height, p)

--- a/cmd/rpc/routes.go
+++ b/cmd/rpc/routes.go
@@ -49,6 +49,7 @@ const (
 	DexPriceRoutePath              = "/v1/query/dex-price"
 	DexBatchRoutePath              = "/v1/query/dex-batch"
 	NextDexBatchRoutePath          = "/v1/query/next-dex-batch"
+	IndexerSnapshotRoutePath       = "/v1/query/indexer-snapshot"
 	LastProposersRoutePath         = "/v1/query/last-proposers"
 	IsValidDoubleSignerRoutePath   = "/v1/query/valid-double-signer"
 	DoubleSignersRoutePath         = "/v1/query/double-signers"
@@ -152,6 +153,7 @@ const (
 	DexPriceRouteName              = "dex-price"
 	DexBatchRouteName              = "dex-batch"
 	NextDexBatchRouteName          = "next-dex-batch"
+	IndexerSnapshotRouteName       = "indexer-snapshot"
 	LastProposersRouteName         = "last-proposers"
 	IsValidDoubleSignerRouteName   = "valid-double-signer"
 	DoubleSignersRouteName         = "double-signers"
@@ -252,6 +254,7 @@ var routePaths = routes{
 	DexPriceRouteName:              {Method: http.MethodPost, Path: DexPriceRoutePath},
 	DexBatchRouteName:              {Method: http.MethodPost, Path: DexBatchRoutePath},
 	NextDexBatchRouteName:          {Method: http.MethodPost, Path: NextDexBatchRoutePath},
+	IndexerSnapshotRouteName:       {Method: http.MethodPost, Path: IndexerSnapshotRoutePath},
 	LastProposersRouteName:         {Method: http.MethodPost, Path: LastProposersRoutePath},
 	IsValidDoubleSignerRouteName:   {Method: http.MethodPost, Path: IsValidDoubleSignerRoutePath},
 	DoubleSignersRouteName:         {Method: http.MethodPost, Path: DoubleSignersRoutePath},
@@ -356,6 +359,7 @@ func createRouter(s *Server) *httprouter.Router {
 		DexPriceRouteName:              s.DexPrice,
 		DexBatchRouteName:              s.DexBatch,
 		NextDexBatchRouteName:          s.NextDexBatch,
+		IndexerSnapshotRouteName:       s.IndexerSnapshot,
 		LastProposersRouteName:         s.LastProposers,
 		IsValidDoubleSignerRouteName:   s.IsValidDoubleSigner,
 		DoubleSignersRouteName:         s.DoubleSigners,


### PR DESCRIPTION
## Summary
- Add new `/v1/query/indexer-snapshot` endpoint that combines data from multiple endpoints into a single response for indexers
- Includes block, transactions, events, accounts, orders, DEX prices, params, supply, committees data
- Provides change detection pairs (current + H-1) for validators, pools, non-signers, double-signers, and DEX batches
- Errors in individual fetches return null instead of failing the entire request for resilience