### PR TITLE
feat: add delegator support for NewValidatorSet

### DIFF
--- a/fsm/validator.go
+++ b/fsm/validator.go
@@ -491,7 +491,7 @@ func (s *StateMachine) getValidatorSet(chainId uint64, delegate bool) (vs lib.Va
 		})
 	}
 	// convert list to a validator set (includes shared public key)
-	return lib.NewValidatorSet(&lib.ConsensusValidators{ValidatorSet: members})
+	return lib.NewValidatorSet(&lib.ConsensusValidators{ValidatorSet: members}, delegate)
 }
 
 // pubKeyBytesToAddress() is a convenience function that converts a public key to an address


### PR DESCRIPTION
## Description
Delegator support for `NewValidatorSet`

## Related Issues
<!-- List any issues this pull request closes. -->
Closes: N/A

## Changes Made
<!-- Highlight the key changes made in the code. For example:
- Added a new function to handle X
- Refactored Y for better performance
- Fixed bug Z
-->
- Fix: Add delegator support for `NewValidatorSet`

## Checklist
- [X] I have tested the changes locally and verified they work as intended.
- [ ] I have appropriately titled my branch `issue-#<issue-number>`.
- [ ] I have run re-built the web-wallet and/or block explorer (if applicable).
- [ ] I have run `npm run prettier` to format the web-wallet and/or block explorer (if applicable)
- [ ] I have updated documentation (if applicable).
- [ ] I have included tests for the changes (if applicable).

## Additional Notes
<!-- Add any additional context, screenshots, or information that reviewers might find helpful. -->
This is a quick change to add delegator support on `NewValidatorSet`, however, the actual right implementation for this is to Abstract the `ValidatorSet` into an interface and provide separate implementations both validators and delegators. That is already in progress in the [validatorset-refactor](https://github.com/canopy-network/canopy/tree/validatorset-refactor) branch and will actually properly complete this issue