### PR TITLE
Periodically dial failed peers 

### DIFF
--- a/p2p/p2p.go
+++ b/p2p/p2p.go
@@ -261,14 +261,16 @@ func (p *P2P) DialFailedPeers(interval time.Duration) {
 	defer ticker.Stop()
 	for range ticker.C {
 		var count int
-		p.failedPeers.Range(func(_, rawPeer any) bool {
+		p.failedPeers.Range(func(key, rawPeer any) bool {
 			peer, ok := rawPeer.(*lib.PeerAddress)
-			// ignore error and continue with the next peer
+			// invalid peer, remove
 			if !ok {
+				p.failedPeers.Delete(key)
 				return true
 			}
-			// confirm peer is a must connect
+			// confirm peer is a must connect, otherwise remove
 			if !p.PeerSet.IsMustConnect(peer.PublicKey) {
+				p.failedPeers.Delete(key)
 				return true
 			}
 			// attempt to reconnect to the peer


### PR DESCRIPTION
## Description
Provides a persistent goroutine that calls any must connect peer that has failed as soon as possible

## Related Issues
<!-- List any issues this pull request closes. -->
Closes: N/A

## Changes Made
<!-- Highlight the key changes made in the code. For example:
- Added a new function to handle X
- Refactored Y for better performance
- Fixed bug Z
-->
- Goroutine to call disconnected / err peers 

## Checklist
- [X] I have tested the changes locally and verified they work as intended.
- [ ] I have appropriately titled my branch `issue-#<issue-number>`.
- [ ] I have run re-built the web-wallet and/or block explorer (if applicable).
- [ ] I have run `npm run prettier` to format the web-wallet and/or block explorer (if applicable)
- [ ] I have updated documentation (if applicable).
- [ ] I have included tests for the changes (if applicable).

## Additional Notes
<!-- Add any additional context, screenshots, or information that reviewers might find helpful. -->
