### PR TITLE
fix: change delete order params to not cause json unmarshal error

### DIFF
--- a/cmd/rpc/web/wallet/components/api.js
+++ b/cmd/rpc/web/wallet/components/api.js
@@ -624,7 +624,7 @@ export async function TxDeleteOrder(address, chainId, orderId, memo, fee, passwo
   return POST(
     adminRPCURL,
     txDeleteOrder,
-    newSellOrderTxRequest(address, chainId, orderId, 0, 0, "", memo, Number(fee), submit, password),
+    newSellOrderTxRequest(address, chainId, orderId, "", 0, 0, "", memo, Number(fee), submit, password),
   );
 }
 


### PR DESCRIPTION
Params used before were causing this response in delete order:
```
{
  "Value": "number",
  "Type": {},
  "Offset": 1,
  "Struct": "txRequest",
  "Field": "data"
}
```
Which was a JSON unmarshal error