### PR TITLE
feat: make addresses indexes for orders optional

### DIFF
--- a/lib/config.go
+++ b/lib/config.go
@@ -158,21 +158,25 @@ const (
 	DefaultInitialTokensPerBlock = uint64(80 * 1000000) // 80 CNPY
 	// the number of blocks between each halvening (block reward is cut in half) event
 	DefaultBlocksPerHalvening = uint64(3150000) // ~ 2 years - 20 second blocks
+	// whether to index orders by seller/buyer address for efficient lookups
+	DefaultIndexOrdersByAddresses = true
 )
 
 // StateMachineConfig houses FSM level options
 type StateMachineConfig struct {
-	InitialTokensPerBlock uint64 `json:"initialTokensPerBlock"` // initial micro tokens minted per block (before halvenings)
-	BlocksPerHalvening    uint64 `json:"blocksPerHalvening"`    // number of blocks between block reward halvings
-	FaucetAddress         string `json:"faucetAddress"`         // if set: "send" txs from this address will auto-mint on insufficient funds (dev/test only)
+	InitialTokensPerBlock  uint64 `json:"initialTokensPerBlock"`  // initial micro tokens minted per block (before halvenings)
+	BlocksPerHalvening     uint64 `json:"blocksPerHalvening"`     // number of blocks between block reward halvings
+	FaucetAddress          string `json:"faucetAddress"`          // if set: "send" txs from this address will auto-mint on insufficient funds (dev/test only)
+	IndexOrdersByAddresses bool   `json:"indexOrdersByAddresses"` // index orders by seller/buyer address for efficient lookups
 }
 
 // DefaultStateMachineConfig returns FSM defaults
 func DefaultStateMachineConfig() StateMachineConfig {
 	return StateMachineConfig{
-		InitialTokensPerBlock: DefaultInitialTokensPerBlock,
-		BlocksPerHalvening:    DefaultBlocksPerHalvening,
-		FaucetAddress:         "",
+		InitialTokensPerBlock:  DefaultInitialTokensPerBlock,
+		BlocksPerHalvening:     DefaultBlocksPerHalvening,
+		FaucetAddress:          "",
+		IndexOrdersByAddresses: DefaultIndexOrdersByAddresses,
 	}
 }
 


### PR DESCRIPTION
## Summary

- Added `IndexOrdersByAddresses` configuration option to `StateMachineConfig` that controls whether secondary indexes for order lookups by seller/buyer address are created
- When disabled, the `/v1/query/orders` endpoint returns an error if `sellersSendAddress` or `buyerSendAddress` filters are used
- Default value is `true` (indexes enabled)

## Changes

### Configuration (`lib/config.go`)
- Added `DefaultIndexOrdersByAddresses` constant
- Added `IndexOrdersByAddresses` field to `StateMachineConfig`

### State Machine (`fsm/swap.go`)
- `SetOrder`: Conditionally creates seller/buyer secondary indexes based on config
- `cleanupStaleBuyerIndex`: Skips cleanup when indexing is disabled
- `DeleteOrder`: Conditionally deletes seller/buyer secondary indexes based on config

### RPC Endpoint (`cmd/rpc/query.go`)
- `Orders`: Returns descriptive error when address-based filtering is requested but indexing is disabled