### PR TITLE
refactor: replace sort.Slice with slices.Sort for natural ordering

### DIFF
--- a/lib/consensus_test.go
+++ b/lib/consensus_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/canopy-network/canopy/lib/crypto"
 	"github.com/drand/kyber"
 	"github.com/stretchr/testify/require"
-	"sort"
+	"slices"
 	"testing"
 )
 
@@ -1175,9 +1175,7 @@ func TestAddHeight(t *testing.T) {
 		doubleSigner.AddHeight(uint64(i))
 	}
 	// sort the heights for comparison
-	sort.Slice(doubleSigner.Heights, func(i, j int) bool {
-		return doubleSigner.Heights[i] < doubleSigner.Heights[j]
-	})
+	slices.Sort(doubleSigner.Heights)
 	// check got vs expected
 	require.Equal(t, expected, doubleSigner.Heights)
 }


### PR DESCRIPTION

There is a [new function](https://pkg.go.dev/slices#Sort) added in the go1.21 standard library, which can make the code more concise and easy to read.