### PR TITLE
fix: wallet was not getting urls from config.json

### DIFF
--- a/cmd/rpc/web/wallet/src/manifest/loader.ts
+++ b/cmd/rpc/web/wallet/src/manifest/loader.ts
@@ -24,14 +24,29 @@ async function fetchJson<T>(url: string): Promise<T> {
   return res.json() as Promise<T>
 }
 
+function applyWindowConfig<T extends Record<string, unknown>>(chain: T): T {
+  if (typeof window === 'undefined' || !window.__CONFIG__) return chain
+
+  const rpc = (chain.rpc ?? {}) as Record<string, string>
+  return {
+    ...chain,
+    chainId: String(window.__CONFIG__.chainId),
+    rpc: {
+      ...rpc,
+      base: window.__CONFIG__.rpcURL,
+      admin: window.__CONFIG__.adminRPCURL,
+      root: window.__CONFIG__.rpcURL,
+    },
+  }
+}
+
 export function useEmbeddedConfig(chain = DEFAULT_CHAIN) {
   const base = useMemo(() => getPluginBase(chain), [chain])
 
   const chainQ = useQuery({
     queryKey: ['chain', base],
-    queryFn: () => fetchJson<any>(`${base}/chain.json`),
-    // Use the global refetch configuration every 20s
-    // The configuration data may change, so it's good to update it
+    queryFn: () => fetchJson<Record<string, unknown>>(`${base}/chain.json`),
+    select: applyWindowConfig,
   })
 
   const manifestQ = useQuery({

--- a/cmd/rpc/web/wallet/src/types/global.d.ts
+++ b/cmd/rpc/web/wallet/src/types/global.d.ts
@@ -1,0 +1,11 @@
+declare global {
+    interface Window {
+        __CONFIG__?: {
+            rpcURL: string;
+            adminRPCURL: string;
+            chainId: number;
+        };
+    }
+}
+
+export { };


### PR DESCRIPTION
## Summary

- Fixed wallet (`cmd/rpc/web/wallet`) using hardcoded `localhost` RPC URLs in production instead of the server-injected configuration
- The Go server already injects `window.__CONFIG__` (with production `rpcURL`, `adminRPCURL`, `chainId`) into the wallet's `index.html`, but the wallet code never read from it — unlike the explorer which does

## Problem

In production, the Go RPC server (`cmd/rpc/server.go`) calls `injectConfig()` to embed a `<script>window.__CONFIG__ = {...}</script>` tag into the HTML `<head>` for **both** the wallet and explorer. The explorer picks this up in `src/lib/api.ts`, but the wallet ignored it entirely and only read RPC URLs from the static `chain.json`, which contains hardcoded `localhost:50002` / `localhost:50003` values.

## Fix

- Added `applyWindowConfig()` in `src/manifest/loader.ts` that overrides the chain config's RPC URLs with `window.__CONFIG__` values when available:
  - `window.__CONFIG__.rpcURL` → `chain.rpc.base` + `chain.rpc.root`
  - `window.__CONFIG__.adminRPCURL` → `chain.rpc.admin`
  - `window.__CONFIG__.chainId` → `chain.chainId`
- Applied via React Query's `select` option so all downstream consumers (`resolveRpcHost`, `dsCore`, hooks) automatically receive the correct production URLs
- Added `src/types/global.d.ts` with the `Window.__CONFIG__` type declaration

