### PR TITLE
Live state backup

### DIFF
--- a/lib/config.go
+++ b/lib/config.go
@@ -5,6 +5,7 @@ import (
 	"math"
 	"math/rand/v2"
 	"os"
+	"path"
 	"path/filepath"
 	"strings"
 
@@ -60,18 +61,18 @@ func DefaultConfig() Config {
 // MAIN CONFIG BELOW
 
 type MainConfig struct {
-	LogLevel         string             `json:"logLevel"`         // any level includes the levels above it: debug < info < warning < error
-	ChainId          uint64             `json:"chainId"`          // the identifier of this particular chain within a single 'network id'
-	SleepUntil       uint64             `json:"sleepUntil"`       // allows coordinated 'wake-ups' for genesis or chain halt events
-	RootChain        []RootChain        `json:"rootChain"`        // a list of the root chain(s) a node could connect to as dictated by the governance parameter 'RootChainId'
-	RunVDF           bool               `json:"runVDF"`           // whether the node should run a Verifiable Delay Function to help secure the network against Long-Range-Attacks
-	Headless         bool               `json:"headless"`         // turn off the web wallet and block explorer 'web' front ends
-	AutoUpdate           bool   `json:"autoUpdate"`           // check for new versions of software each X time
-	AutoUpdateRepoOwner  string `json:"autoUpdateRepoOwner"`  // GitHub repo owner for core auto-updates (e.g., "canopy-network")
-	AutoUpdateRepoName   string `json:"autoUpdateRepoName"`   // GitHub repo name for core auto-updates (e.g., "canopy")
-	Plugin               string `json:"plugin"`               // the configured plugin to use
-	PluginTimeoutMS  int                `json:"pluginTimeoutMS"`  // plugin request timeout in milliseconds
-	PluginAutoUpdate PluginAutoUpdateConfig `json:"pluginAutoUpdate"` // plugin auto-update configuration
+	LogLevel            string                 `json:"logLevel"`            // any level includes the levels above it: debug < info < warning < error
+	ChainId             uint64                 `json:"chainId"`             // the identifier of this particular chain within a single 'network id'
+	SleepUntil          uint64                 `json:"sleepUntil"`          // allows coordinated 'wake-ups' for genesis or chain halt events
+	RootChain           []RootChain            `json:"rootChain"`           // a list of the root chain(s) a node could connect to as dictated by the governance parameter 'RootChainId'
+	RunVDF              bool                   `json:"runVDF"`              // whether the node should run a Verifiable Delay Function to help secure the network against Long-Range-Attacks
+	Headless            bool                   `json:"headless"`            // turn off the web wallet and block explorer 'web' front ends
+	AutoUpdate          bool                   `json:"autoUpdate"`          // check for new versions of software each X time
+	AutoUpdateRepoOwner string                 `json:"autoUpdateRepoOwner"` // GitHub repo owner for core auto-updates (e.g., "canopy-network")
+	AutoUpdateRepoName  string                 `json:"autoUpdateRepoName"`  // GitHub repo name for core auto-updates (e.g., "canopy")
+	Plugin              string                 `json:"plugin"`              // the configured plugin to use
+	PluginTimeoutMS     int                    `json:"pluginTimeoutMS"`     // plugin request timeout in milliseconds
+	PluginAutoUpdate    PluginAutoUpdateConfig `json:"pluginAutoUpdate"`    // plugin auto-update configuration
 }
 
 // PluginAutoUpdateConfig holds configuration for plugin auto-updates
@@ -274,6 +275,8 @@ type StoreConfig struct {
 	// sync. Lower values also increase the risk of data loss due to a pebble issue where batches are
 	// returned before commit completion when compaction runs concurrently with commits.
 	LSSCompactionInterval uint64 `json:"lssCompactionInterval"` // interval for compacting latest store data
+	BackupDirectory       string `json:"backupDirectory"`       // directory where backups of the database are stored
+	BackupInterval        uint64 `json:"backupInterval"`        // interval in blocks for creating backups of the database (0 to disable automatic backups)
 }
 
 // DefaultDataDirPath() is $USERHOME/.canopy
@@ -294,11 +297,13 @@ func DefaultDataDirPath() string {
 // DefaultStoreConfig() returns the developer recommended store configuration
 func DefaultStoreConfig() StoreConfig {
 	return StoreConfig{
-		DataDirPath:           DefaultDataDirPath(),           // use the default data dir path
-		DBName:                "canopy",                       // 'canopy' database name
-		IndexByAccount:        true,                           // index transactions by account
-		InMemory:              false,                          // persist to disk, not memory
-		LSSCompactionInterval: uint64(rand.Int32N(101) + 500), // clean every 500-600 blocks (random)
+		DataDirPath:           DefaultDataDirPath(),                      // use the default data dir path
+		DBName:                "canopy",                                  // 'canopy' database name
+		IndexByAccount:        true,                                      // index transactions by account
+		InMemory:              false,                                     // persist to disk, not memory
+		LSSCompactionInterval: uint64(rand.Int32N(101) + 500),            // clean every 500-600 blocks (random)
+		BackupDirectory:       path.Join(DefaultDataDirPath(), "backup"), // backup directory name
+		BackupInterval:        0,                                         // backups disabled by default
 	}
 }
 

--- a/store/store.go
+++ b/store/store.go
@@ -5,7 +5,9 @@ import (
 	"context"
 	"fmt"
 	"math"
+	"os"
 	"path/filepath"
+	"strconv"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -76,6 +78,7 @@ type Store struct {
 	config     lib.Config    // config
 	mu         *sync.Mutex   // mutex for concurrent commits
 	compaction atomic.Bool   // atomic boolean for compaction status
+	backup     atomic.Bool   // atomic boolean for backup status
 	isTxn      bool          // flag indicating if the store is in transaction mode
 }
 
@@ -176,6 +179,7 @@ func NewStoreWithDB(config lib.Config, db *pebble.DB, metrics *lib.Metrics, log 
 		config:     config,
 		mu:         &sync.Mutex{},
 		compaction: atomic.Bool{},
+		backup:     atomic.Bool{},
 	}, nil
 }
 
@@ -203,6 +207,7 @@ func (s *Store) NewReadOnly(queryVersion uint64) (lib.StoreI, lib.ErrorI) {
 		metrics:    s.metrics,
 		mu:         &sync.Mutex{},
 		compaction: atomic.Bool{},
+		backup:     atomic.Bool{},
 	}, nil
 }
 
@@ -225,6 +230,7 @@ func (s *Store) Copy() (lib.StoreI, lib.ErrorI) {
 		metrics:    s.metrics,
 		mu:         &sync.Mutex{},
 		compaction: atomic.Bool{},
+		backup:     atomic.Bool{},
 	}, nil
 }
 
@@ -269,6 +275,8 @@ func (s *Store) Commit() (root []byte, err lib.ErrorI) {
 	s.Reset()
 	// compact if necessary
 	s.MaybeCompact()
+	// backup if enabled
+	s.MaybeBackup()
 	// return the root
 	return
 }
@@ -625,6 +633,69 @@ func (s *Store) MaybeCompact() {
 			}
 		}()
 	}
+}
+
+// MaybeBackup() checks if it is time to backup the current state of the database
+func (s *Store) MaybeBackup() {
+	// helper variables
+	backupInterval := s.config.StoreConfig.BackupInterval
+	backupDir := s.config.StoreConfig.BackupDirectory
+	// ensure only complete backups exists on the actual backup directory
+	tempBackupDir := backupDir + "_temp"
+	// retrieve the current version
+	version := s.Version()
+	// verify that backups are enabled in the config
+	if backupInterval == 0 || backupDir == "" {
+		return
+	}
+	// check if the current version is a multiple of the backup block interval
+	if version%backupInterval != 0 {
+		return
+	}
+	// ensure that only one backup can run at a time to avoid overlapping backups
+	if s.backup.Load() {
+		s.log.Debugf("data backup skipped [%d]: already in progress", version)
+		return
+	}
+	// perform the backup in a separate goroutine to avoid blocking the main thread
+	go func() {
+		var err error
+		start := time.Now()
+		defer func() {
+			if err == nil {
+				return
+			}
+			s.log.Errorf("backup failed at height [%d]: %w", err)
+		}()
+		// delete current backup files as pebbleDB expects an empty directory
+		if err = os.RemoveAll(tempBackupDir); err != nil {
+			err = fmt.Errorf("remove temporary backup: %w", err)
+			return
+		}
+		// perform the backup using pebble's checkpointing mechanism which creates a
+		// consistent snapshot of the database at the specified directory
+		if err = s.db.Checkpoint(tempBackupDir); err != nil {
+			err = fmt.Errorf("checkpoint creation: %w", err)
+			return
+		}
+		// write the current height to a separate file
+		heightFile := filepath.Join(tempBackupDir, "height.txt")
+		if err = os.WriteFile(heightFile, []byte(strconv.Itoa(int(version))), 0644); err != nil {
+			err = fmt.Errorf("write height file: %w", err)
+			return
+		}
+		// remove current backup directory
+		if err = os.RemoveAll(backupDir); err != nil {
+			err = fmt.Errorf("remove current backup: %w", err)
+			return
+		}
+		// rename the temporary directory to the actual backup directory
+		if err = os.Rename(tempBackupDir, backupDir); err != nil {
+			err = fmt.Errorf("finalize backup: %w", err)
+			return
+		}
+		s.log.Infof("backup completed at height [%d] in %s", version, time.Since(start))
+	}()
 }
 
 // Compact runs Pebble range compaction over the latest and optional historic state prefixes.

--- a/store/store.go
+++ b/store/store.go
@@ -7,7 +7,6 @@ import (
 	"math"
 	"os"
 	"path/filepath"
-	"strconv"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -657,15 +656,17 @@ func (s *Store) MaybeBackup() {
 		s.log.Debugf("data backup skipped [%d]: already in progress", version)
 		return
 	}
+	s.backup.Store(true)
 	// perform the backup in a separate goroutine to avoid blocking the main thread
 	go func() {
 		var err error
 		start := time.Now()
 		defer func() {
+			s.backup.Store(false)
 			if err == nil {
 				return
 			}
-			s.log.Errorf("backup failed at height [%d]: %w", err)
+			s.log.Errorf("backup failed at height [%d]: %v", err)
 		}()
 		// delete current backup files as pebbleDB expects an empty directory
 		if err = os.RemoveAll(tempBackupDir); err != nil {
@@ -680,7 +681,7 @@ func (s *Store) MaybeBackup() {
 		}
 		// write the current height to a separate file
 		heightFile := filepath.Join(tempBackupDir, "height.txt")
-		if err = os.WriteFile(heightFile, []byte(strconv.Itoa(int(version))), 0644); err != nil {
+		if err = os.WriteFile(heightFile, []byte(fmt.Sprintf("%d", version)), 0644); err != nil {
 			err = fmt.Errorf("write height file: %w", err)
 			return
 		}

--- a/store/store.go
+++ b/store/store.go
@@ -666,11 +666,18 @@ func (s *Store) MaybeBackup() {
 			if err == nil {
 				return
 			}
-			s.log.Errorf("backup failed at height [%d]: %v", err)
+			s.log.Errorf("backup failed at height [%d]: %v", version, err)
 		}()
 		// delete current backup files as pebbleDB expects an empty directory
 		if err = os.RemoveAll(tempBackupDir); err != nil {
 			err = fmt.Errorf("remove temporary backup: %w", err)
+			return
+		}
+		// flush the memtable to SST before checkpointing so the backup does not
+		// depend on WAL replay for recovery (commits use NoSync so WAL records
+		// may not be durable on disk at checkpoint time)
+		if err = s.db.Flush(); err != nil {
+			err = fmt.Errorf("flush before checkpoint: %w", err)
 			return
 		}
 		// perform the backup using pebble's checkpointing mechanism which creates a
@@ -681,19 +688,25 @@ func (s *Store) MaybeBackup() {
 		}
 		// write the current height to a separate file
 		heightFile := filepath.Join(tempBackupDir, "height.txt")
-		if err = os.WriteFile(heightFile, []byte(fmt.Sprintf("%d", version)), 0644); err != nil {
+		if err = os.WriteFile(heightFile, fmt.Appendf(nil, "%d", version), 0644); err != nil {
 			err = fmt.Errorf("write height file: %w", err)
 			return
 		}
-		// remove current backup directory
-		if err = os.RemoveAll(backupDir); err != nil {
-			err = fmt.Errorf("remove current backup: %w", err)
+		// rotate: atomically move current backup to a previous slot so there is
+		// always at least one valid backup on disk during the swap
+		prevBackupDir := backupDir + "_prev"
+		if err = os.Rename(backupDir, prevBackupDir); err != nil && !os.IsNotExist(err) {
+			err = fmt.Errorf("rotate backup: %w", err)
 			return
 		}
-		// rename the temporary directory to the actual backup directory
+		// promote: atomically move the temp backup into the active slot
 		if err = os.Rename(tempBackupDir, backupDir); err != nil {
 			err = fmt.Errorf("finalize backup: %w", err)
 			return
+		}
+		// clean up the previous backup now that the new one is safely in place
+		if removeErr := os.RemoveAll(prevBackupDir); removeErr != nil {
+			s.log.Warnf("failed to remove previous backup: %v", removeErr)
 		}
 		s.log.Infof("backup completed at height [%d] in %s", version, time.Since(start))
 	}()

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -2,7 +2,10 @@ package store
 
 import (
 	"fmt"
+	"os"
+	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/canopy-network/canopy/lib"
 	"github.com/cockroachdb/pebble/v2"
@@ -275,6 +278,63 @@ func TestRollbackWithPrefixOverlappingKeys(t *testing.T) {
 	value, err = st.Get(childKey)
 	require.NoError(t, err)
 	require.Equal(t, []byte("child-v1"), value)
+}
+
+func TestMaybeBackup(t *testing.T) {
+	// use a single base dir so db and backup share the same filesystem, making
+	// os.Rename atomic across both paths
+	baseDir := t.TempDir()
+	dbDir := filepath.Join(baseDir, "db")
+	backupDir := filepath.Join(baseDir, "backup")
+	// set up chain configs
+	config := lib.DefaultConfig()
+	config.StoreConfig.BackupInterval = 3
+	config.StoreConfig.BackupDirectory = backupDir
+	// set up new store with the configs above
+	st, e := NewStore(config, dbDir, nil, lib.NewDefaultLogger())
+	require.NoError(t, e)
+	s := st.(*Store)
+	// write a key and commit 3 blocks to reach the backup trigger;
+	// Commit() calls MaybeBackup() internally so no explicit call is needed
+	key := lib.JoinLenPrefix([]byte("state/"), []byte("value"))
+	for i := 1; i <= 3; i++ {
+		require.NoError(t, s.Set(key, fmt.Appendf(nil, "v%d", i)))
+		_, err := s.Commit()
+		require.NoError(t, err)
+	}
+	require.EqualValues(t, 3, s.Version())
+	// wait for the backup goroutine started by Commit() to complete
+	require.Eventually(t, func() bool { return !s.backup.Load() },
+		1*time.Second, 50*time.Millisecond)
+	// backup directory must exist
+	_, err := os.Stat(backupDir)
+	require.NoError(t, err)
+	// height file must reflect the block at which the backup was taken
+	heightData, err := os.ReadFile(filepath.Join(backupDir, "height.txt"))
+	require.NoError(t, err)
+	require.Equal(t, "3", string(heightData))
+	// advance more blocks so the live DB diverges from the backup
+	for i := 4; i <= 5; i++ {
+		require.NoError(t, s.Set(key, fmt.Appendf(nil, "v%d", i)))
+		_, err = s.Commit()
+		require.NoError(t, err)
+	}
+	require.EqualValues(t, 5, s.Version())
+	require.NoError(t, s.Close())
+	// simulate a catastrophic loss of the live DB directory
+	require.NoError(t, os.RemoveAll(dbDir))
+	// promote the backup to the DB path
+	require.NoError(t, os.Rename(backupDir, dbDir))
+	// reopen from the backup location — should restore to height 3
+	restored, e := NewStore(config, dbDir, nil, lib.NewDefaultLogger())
+	require.NoError(t, e)
+	defer restored.Close()
+	restoredStore := restored.(*Store)
+	require.EqualValues(t, 3, restoredStore.Version())
+	// value must be what was committed at block 3, not the later diverged state
+	restoredVal, err := restored.Get(key)
+	require.NoError(t, err)
+	require.Equal(t, []byte("v3"), restoredVal)
 }
 
 func testStore(t *testing.T) (*Store, *pebble.DB, func()) {


### PR DESCRIPTION
## Description
Implements a live backup system for the pebble database. Backups are taken automatically at configurable block intervals using pebbleDB's built-in **checkpoint** feature, which creates a consistent, point-in-time snapshot of the database by hard-linking immutable SST files and flushing the memtable — no manual file copying or node downtime required. The result is a self-contained directory that can be opened directly as a valid pebbleDB instance.

## Related Issues
Closes: N/A

## Changes Made
- Added `MaybeBackup()` to `Store`, called automatically at the end of every `Commit()`
- Backup runs in a background goroutine with an atomic guard to prevent overlapping runs

## Checklist
- [x] I have tested the changes locally and verified they work as intended.
- [ ] I have appropriately titled my branch `issue-#<issue-number>`.
- [ ] I have run re-built the web-wallet and/or block explorer (if applicable).
- [ ] I have updated documentation (if applicable).
- [x] I have included tests for the changes (if applicable).

## Additional Notes
To restore from a backup, stop the node, delete (or move) the live DB directory, and rename the backup directory to the DB path. The restored database will be at the height recorded in `height.txt` inside the backup directory.

Testing on mainnet heights took ~30ms to perform a backup (or checkpoint in PebbleDB terms)
