### PR TITLE
Feat: Multiple P2P fixes

### DIFF
--- a/controller/tx.go
+++ b/controller/tx.go
@@ -241,13 +241,16 @@ func (m *Mempool) CheckMempool() {
 		rcBuildHeight = m.FSM.Height()
 	} else {
 		// Use mempool FSM snapshot to avoid races with controller FSM resets.
-		if rootChainID, e := m.FSM.GetRootChainId(); e != nil {
+		var rootChainID uint64
+		var e lib.ErrorI
+		if rootChainID, e = m.FSM.GetRootChainId(); e != nil {
 			m.log.Error(e.Error())
 		} else {
 			rcBuildHeight = m.controller.RCManager.GetHeight(rootChainID)
 		}
 		// for nested chains fetch and cache the DEX root batch, liveness is handled on the certificate results
-		rootDexBatch, err := m.controller.getDexRootBatch(rcBuildHeight)
+		rootDexBatch, err := m.controller.RCManager.GetDexBatch(rootChainID,
+			rcBuildHeight, m.controller.Config.ChainId, false)
 		if err != nil {
 			m.log.Warnf("Check Mempool error: %s", err.Error())
 		}

--- a/p2p/conn.go
+++ b/p2p/conn.go
@@ -29,7 +29,7 @@ const (
 	maxStreamSendQueueSize = 1000                                // maximum number of items in a stream send queue before blocking
 	keepAlivePeriod        = 10 * time.Second                    // TCP keep-alive probe interval
 	heartbeatInterval      = time.Second                         // how often to send heartbeat pings
-	heartbeatTimeout       = 2 * time.Second                     // how long to wait for liveness before dropping the peer
+	heartbeatTimeout       = 3 * time.Second                     // how long to wait for liveness before dropping the peer
 	heartbeatTopic         = lib.Topic_HEARTBEAT                 // dedicated heartbeat stream
 	heartbeatPing          = "ping"
 	heartbeatPong          = "pong"
@@ -77,10 +77,11 @@ type MultiConn struct {
 	lastPingSent  atomic.Int64                        // last time we queued a ping (unix nano)
 	lastPingRecv  atomic.Int64                        // last time we received a ping (unix nano)
 	lastPongSent  atomic.Int64                        // last time we queued a pong (unix nano)
+	peerInfo      *lib.PeerInfo                       // peer info cache
 }
 
 // NewConnection() creates and starts a new instance of a MultiConn
-func (p *P2P) NewConnection(conn net.Conn) (*MultiConn, lib.ErrorI) {
+func (p *P2P) NewConnection(conn net.Conn, info *lib.PeerInfo) (*MultiConn, lib.ErrorI) {
 	if tcpConn, ok := conn.(*net.TCPConn); ok {
 		if err := tcpConn.SetWriteBuffer(32 * 1024 * 1024); err != nil {
 			p.log.Warnf("Failed to set write buffer: %v", err)
@@ -114,6 +115,7 @@ func (p *P2P) NewConnection(conn net.Conn) (*MultiConn, lib.ErrorI) {
 		p2p:           p,
 		close:         sync.Once{},
 		log:           p.log,
+		peerInfo:      info,
 	}
 	now := time.Now().UnixNano()
 	c.lastPong.Store(now)
@@ -194,10 +196,15 @@ func (c *MultiConn) startSendService() {
 	var pwt *PacketWithTiming
 	defer func() { m.Done() }()
 	for {
-		// select statement ensures the sequential coordination of the concurrent processes
+		// prioritize heartbeat messages to avoid disconnecting from peers
 		select {
 		case pwt = <-c.streams[heartbeatTopic].sendQueue:
 			c.sendPacketWithTiming(pwt, m)
+			continue
+		default:
+		}
+		// select statement ensures the sequential coordination of the concurrent processes
+		select {
 		case pwt = <-c.streams[lib.Topic_CONSENSUS].sendQueue:
 			c.sendPacketWithTiming(pwt, m)
 		case pwt = <-c.streams[lib.Topic_BLOCK].sendQueue:
@@ -250,15 +257,9 @@ func (c *MultiConn) startReceiveService() {
 					c.Error(ErrBadStream(), BadStreamSlash)
 					return
 				}
-				// get the peer info from the peer set
-				info, e := c.p2p.GetPeerInfo(c.Address.PublicKey)
-				if e != nil {
-					c.Error(e)
-					return
-				}
 				// handle the packet within the stream
-				if slash, er := stream.handlePacket(info, x, c.p2p.metrics); er != nil {
-					c.log.Warnf(er.Error())
+				if slash, er := stream.handlePacket(c.peerInfo, x, c.p2p.metrics); er != nil {
+					c.log.Warn(er.Error())
 					c.Error(er, slash)
 					return
 				}
@@ -387,8 +388,8 @@ func (c *MultiConn) Error(err error, reputationDelta ...int32) {
 		unlock := lockWithTrace("p2p", &c.p2p.mux, c.p2p.log)
 		c.hasError.Store(true)
 		// run the callback after releasing the lock to prevent blocking other readers
-		c.onError(err, c.Address.PublicKey, c.conn.RemoteAddr().String(), c.uuid)
 		unlock()
+		c.onError(err, c.Address.PublicKey, c.conn.RemoteAddr().String(), c.uuid)
 		// stop the multi-conn
 		c.Stop()
 	})
@@ -516,9 +517,12 @@ func (s *Stream) queueSends(packets []*Packet, sendStart time.Time, metrics *lib
 
 // queueSend() schedules the packet to be sent
 func (s *Stream) queueSend(p *Packet, sendStart time.Time, metrics *lib.Metrics) bool {
+	s.mu.Lock()
 	if s.closed {
+		s.mu.Unlock()
 		return false
 	}
+	s.mu.Unlock()
 	queueStart := time.Now()
 	pwt := &PacketWithTiming{
 		packet:     p,

--- a/p2p/conn.go
+++ b/p2p/conn.go
@@ -77,11 +77,10 @@ type MultiConn struct {
 	lastPingSent  atomic.Int64                        // last time we queued a ping (unix nano)
 	lastPingRecv  atomic.Int64                        // last time we received a ping (unix nano)
 	lastPongSent  atomic.Int64                        // last time we queued a pong (unix nano)
-	peerInfo      *lib.PeerInfo                       // peer info cache
 }
 
 // NewConnection() creates and starts a new instance of a MultiConn
-func (p *P2P) NewConnection(conn net.Conn, info *lib.PeerInfo) (*MultiConn, lib.ErrorI) {
+func (p *P2P) NewConnection(conn net.Conn) (*MultiConn, lib.ErrorI) {
 	if tcpConn, ok := conn.(*net.TCPConn); ok {
 		if err := tcpConn.SetWriteBuffer(32 * 1024 * 1024); err != nil {
 			p.log.Warnf("Failed to set write buffer: %v", err)
@@ -115,7 +114,6 @@ func (p *P2P) NewConnection(conn net.Conn, info *lib.PeerInfo) (*MultiConn, lib.
 		p2p:           p,
 		close:         sync.Once{},
 		log:           p.log,
-		peerInfo:      info,
 	}
 	now := time.Now().UnixNano()
 	c.lastPong.Store(now)
@@ -257,9 +255,15 @@ func (c *MultiConn) startReceiveService() {
 					c.Error(ErrBadStream(), BadStreamSlash)
 					return
 				}
+				// get the peer info from the peer set
+				info, e := c.p2p.GetPeerInfo(c.Address.PublicKey)
+				if e != nil {
+					c.Error(e)
+					return
+				}
 				// handle the packet within the stream
-				if slash, er := stream.handlePacket(c.peerInfo, x, c.p2p.metrics); er != nil {
-					c.log.Warn(er.Error())
+				if slash, er := stream.handlePacket(info, x, c.p2p.metrics); er != nil {
+					c.log.Warnf(er.Error())
 					c.Error(er, slash)
 					return
 				}

--- a/p2p/conn.go
+++ b/p2p/conn.go
@@ -517,12 +517,9 @@ func (s *Stream) queueSends(packets []*Packet, sendStart time.Time, metrics *lib
 
 // queueSend() schedules the packet to be sent
 func (s *Stream) queueSend(p *Packet, sendStart time.Time, metrics *lib.Metrics) bool {
-	s.mu.Lock()
 	if s.closed {
-		s.mu.Unlock()
 		return false
 	}
-	s.mu.Unlock()
 	queueStart := time.Now()
 	pwt := &PacketWithTiming{
 		packet:     p,

--- a/p2p/p2p.go
+++ b/p2p/p2p.go
@@ -76,7 +76,7 @@ func New(p crypto.PrivateKeyI, maxMembersPerCommittee uint64, m *lib.Metrics, c 
 	for _, ip := range c.BannedIPs {
 		i, err := net.ResolveIPAddr("", ip)
 		if err != nil {
-			l.Fatalf(err.Error())
+			l.Fatal(err.Error())
 		}
 		bannedIPs = append(bannedIPs, *i)
 	}
@@ -200,7 +200,7 @@ func (p *P2P) DialForOutboundPeers() {
 		peerAddress, err := getPeerFromString(peerString)
 		if err != nil {
 			// log the invalid format
-			p.log.Errorf(err.Error())
+			p.log.Error(err.Error())
 			// continue with the next
 			continue
 		}
@@ -232,7 +232,7 @@ func (p *P2P) DialForOutboundPeers() {
 				// otherwise, fallback to config's dial peers
 				dialPeer, err := getPeerFromString(p.config.DialPeers[rand.Intn(len(p.config.DialPeers))])
 				if err != nil {
-					p.log.Errorf(err.Error())
+					p.log.Error(err.Error())
 					return
 				}
 				peer = dialPeer
@@ -295,13 +295,18 @@ func (p *P2P) DialFailedPeers(interval time.Duration) {
 				}
 			}
 
+			// prevent a stampede of dials by staggering with a delay
+			const reconnectStagger = 100 * time.Millisecond
 			// Attempt a single dial per tick; keep it in the failed set if it doesn't succeed.
-			go func(mapKey any, a *lib.PeerAddress) {
+			go func(mapKey any, a *lib.PeerAddress, idx int) {
+				if idx > 0 {
+					time.Sleep(time.Duration(idx) * reconnectStagger)
+				}
 				if err := p.Dial(a, false, true); err != nil {
 					return
 				}
 				p.failedPeers.Delete(mapKey)
-			}(key, reconnect)
+			}(key, reconnect, count)
 
 			count++
 			return true
@@ -347,7 +352,7 @@ func (p *P2P) Dial(address *lib.PeerAddress, disconnect, strictPublicKey bool) l
 // the peer set and the peer book
 func (p *P2P) AddPeer(conn net.Conn, info *lib.PeerInfo, disconnect, strictPublicKey bool) (err lib.ErrorI) {
 	// create the e2e encrypted connection while establishing a full peer info object
-	connection, err := p.NewConnection(conn)
+	connection, err := p.NewConnection(conn, info)
 	if err != nil {
 		return err
 	}

--- a/p2p/p2p.go
+++ b/p2p/p2p.go
@@ -352,7 +352,7 @@ func (p *P2P) Dial(address *lib.PeerAddress, disconnect, strictPublicKey bool) l
 // the peer set and the peer book
 func (p *P2P) AddPeer(conn net.Conn, info *lib.PeerInfo, disconnect, strictPublicKey bool) (err lib.ErrorI) {
 	// create the e2e encrypted connection while establishing a full peer info object
-	connection, err := p.NewConnection(conn, info)
+	connection, err := p.NewConnection(conn)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## Description
Apply multiple minor fixes to p2p to improve stability and a fix for a possible mempool panic on dex check

## Related Issues
<!-- List any issues this pull request closes. -->
Closes: N/A

## Changes Made
<!-- Highlight the key changes made in the code. For example:
- Added a new function to handle X
- Refactored Y for better performance
- Fixed bug Z
-->
- Release peer error lock faster
- increase hearbeat timeout
- cache peerInfo in MultiConn
- prioritize heartbeat send
- prevent reconnect stampede on failed peers
- fix race condition on check mempool

## Checklist
- [X] I have tested the changes locally and verified they work as intended.
- [ ] I have appropriately titled my branch `issue-#<issue-number>`.
- [ ] I have run re-built the web-wallet and/or block explorer (if applicable).
- [ ] I have run `npm run prettier` to format the web-wallet and/or block explorer (if applicable)
- [ ] I have updated documentation (if applicable).
- [ ] I have included tests for the changes (if applicable).

## Additional Notes
<!-- Add any additional context, screenshots, or information that reviewers might find helpful. -->
