### PR TITLE
Multiple p2p fixes + panic fix

### DIFF
--- a/controller/tx.go
+++ b/controller/tx.go
@@ -241,13 +241,16 @@ func (m *Mempool) CheckMempool() {
 		rcBuildHeight = m.FSM.Height()
 	} else {
 		// Use mempool FSM snapshot to avoid races with controller FSM resets.
-		if rootChainID, e := m.FSM.GetRootChainId(); e != nil {
+		var rootChainID uint64
+		var e lib.ErrorI
+		if rootChainID, e = m.FSM.GetRootChainId(); e != nil {
 			m.log.Error(e.Error())
 		} else {
 			rcBuildHeight = m.controller.RCManager.GetHeight(rootChainID)
 		}
 		// for nested chains fetch and cache the DEX root batch, liveness is handled on the certificate results
-		rootDexBatch, err := m.controller.getDexRootBatch(rcBuildHeight)
+		rootDexBatch, err := m.controller.RCManager.GetDexBatch(rootChainID,
+			rcBuildHeight, m.controller.Config.ChainId, false)
 		if err != nil {
 			m.log.Warnf("Check Mempool error: %s", err.Error())
 		}

--- a/lib/metrics.go
+++ b/lib/metrics.go
@@ -118,19 +118,19 @@ type P2PMetrics struct {
 	SendQueueFull       *prometheus.CounterVec // count of send queue full events by topic
 
 	// Heartbeat / liveness telemetry (low-cardinality; no per-peer labels)
-	HeartbeatPingSent    prometheus.Counter   // heartbeat ping packets queued for send
-	HeartbeatPingRecv    prometheus.Counter   // heartbeat ping packets received from wire
-	HeartbeatPongSent    prometheus.Counter   // heartbeat pong packets queued for send
-	HeartbeatPongRecv    prometheus.Counter   // heartbeat pong packets received from wire
-	HeartbeatRTT         prometheus.Histogram // approximate RTT based on last ping send -> pong receive
-	HeartbeatTimeout     prometheus.Counter   // heartbeat timeouts that caused peer disconnect
+	HeartbeatPingSent prometheus.Counter   // heartbeat ping packets queued for send
+	HeartbeatPingRecv prometheus.Counter   // heartbeat ping packets received from wire
+	HeartbeatPongSent prometheus.Counter   // heartbeat pong packets queued for send
+	HeartbeatPongRecv prometheus.Counter   // heartbeat pong packets received from wire
+	HeartbeatRTT      prometheus.Histogram // approximate RTT based on last ping send -> pong receive
+	HeartbeatTimeout  prometheus.Counter   // heartbeat timeouts that caused peer disconnect
 
 	// Dial / peer-book churn telemetry.
 	// expected_port=true means the address uses the chain's expected P2P port (e.g. 9001 for chain 1).
-	DialAttempt  *prometheus.CounterVec // dial attempts by expected_port
-	DialSuccess  *prometheus.CounterVec // successful dials by expected_port
-	DialTimeout  *prometheus.CounterVec // dial timeouts by expected_port
-	PeerBookAdd  *prometheus.CounterVec // peer book additions by expected_port
+	DialAttempt *prometheus.CounterVec // dial attempts by expected_port
+	DialSuccess *prometheus.CounterVec // successful dials by expected_port
+	DialTimeout *prometheus.CounterVec // dial timeouts by expected_port
+	PeerBookAdd *prometheus.CounterVec // peer book additions by expected_port
 }
 
 // BFTMetrics represents the telemetry for the BFT module
@@ -173,6 +173,9 @@ type StoreMetrics struct {
 	DBCommitTime         prometheus.Histogram // how long does the db commit take?
 	DBCommitEntries      prometheus.Gauge     // how many entries in the commit batch?
 	DBCommitSize         prometheus.Gauge     // how big is the commit batch?
+	DBBackupTime         prometheus.Histogram // how long does the db backup take?
+	DBLSSCompactionTime  prometheus.Histogram // how long does the db LSS compaction take?
+	DBHSSCompactionTime  prometheus.Histogram // how long does the db HSS compaction take?
 }
 
 // MempoolMetrics represents the telemetry of the memory pool of pending transactions
@@ -494,6 +497,18 @@ func NewMetricsServer(nodeAddress crypto.AddressI, chainID float64, softwareVers
 				Name: "canopy_store_commit_size",
 				Help: "Number of bytes in the commit batch",
 			}),
+			DBBackupTime: promauto.NewHistogram(prometheus.HistogramOpts{
+				Name: "canopy_store_backup_time",
+				Help: "Execution time of the database backup",
+			}),
+			DBLSSCompactionTime: promauto.NewHistogram(prometheus.HistogramOpts{
+				Name: "canopy_store_compaction_time",
+				Help: "Execution time of LSS database compaction",
+			}),
+			DBHSSCompactionTime: promauto.NewHistogram(prometheus.HistogramOpts{
+				Name: "canopy_store_compaction_time",
+				Help: "Execution time of HSS database compaction",
+			}),
 		},
 		// MEMPOOL
 		MempoolMetrics: MempoolMetrics{
@@ -717,6 +732,26 @@ func (m *Metrics) UpdateStoreMetrics(size, entries int64, startTime time.Time, s
 		m.DBCommitEntries.Set(float64(entries))
 		// update the processing time in seconds
 		m.DBCommitTime.Observe(time.Since(startFlushTime).Seconds())
+	}
+}
+
+// UpdateStoreJobMetrics() updates the store jobs telemery
+func (m *Metrics) UpdateStoreJobMetrics(LSScompactionTime, HSSCompactionTime, backupTime time.Duration) {
+	// exit if empty
+	if m == nil {
+		return
+	}
+	if LSScompactionTime > 0 {
+		// update the compaction time metric
+		m.DBLSSCompactionTime.Observe(LSScompactionTime.Seconds())
+	}
+	if HSSCompactionTime > 0 {
+		// update the compaction time metric
+		m.DBHSSCompactionTime.Observe(HSSCompactionTime.Seconds())
+	}
+	if backupTime > 0 {
+		// update the backup time metric
+		m.DBBackupTime.Observe(backupTime.Seconds())
 	}
 }
 

--- a/lib/metrics.go
+++ b/lib/metrics.go
@@ -502,11 +502,11 @@ func NewMetricsServer(nodeAddress crypto.AddressI, chainID float64, softwareVers
 				Help: "Execution time of the database backup",
 			}),
 			DBLSSCompactionTime: promauto.NewHistogram(prometheus.HistogramOpts{
-				Name: "canopy_store_compaction_time",
+				Name: "canopy_store_lss_compaction_time",
 				Help: "Execution time of LSS database compaction",
 			}),
 			DBHSSCompactionTime: promauto.NewHistogram(prometheus.HistogramOpts{
-				Name: "canopy_store_compaction_time",
+				Name: "canopy_store_hss_compaction_time",
 				Help: "Execution time of HSS database compaction",
 			}),
 		},

--- a/p2p/conn.go
+++ b/p2p/conn.go
@@ -383,8 +383,8 @@ func (c *MultiConn) Error(err error, reputationDelta ...int32) {
 		unlock := lockWithTrace("p2p", &c.p2p.mux, c.p2p.log)
 		c.hasError.Store(true)
 		// run the callback after releasing the lock to prevent blocking other readers
-		c.onError(err, c.Address.PublicKey, c.conn.RemoteAddr().String(), c.uuid)
 		unlock()
+		c.onError(err, c.Address.PublicKey, c.conn.RemoteAddr().String(), c.uuid)
 		// stop the multi-conn
 		c.Stop()
 	})

--- a/p2p/conn.go
+++ b/p2p/conn.go
@@ -29,7 +29,7 @@ const (
 	maxStreamSendQueueSize = 1000                                // maximum number of items in a stream send queue before blocking
 	keepAlivePeriod        = 10 * time.Second                    // TCP keep-alive probe interval
 	heartbeatInterval      = time.Second                         // how often to send heartbeat pings
-	heartbeatTimeout       = 2 * time.Second                     // how long to wait for liveness before dropping the peer
+	heartbeatTimeout       = 3 * time.Second                     // how long to wait for liveness before dropping the peer
 	heartbeatTopic         = lib.Topic_HEARTBEAT                 // dedicated heartbeat stream
 	heartbeatPing          = "ping"
 	heartbeatPong          = "pong"

--- a/p2p/conn.go
+++ b/p2p/conn.go
@@ -77,10 +77,11 @@ type MultiConn struct {
 	lastPingSent  atomic.Int64                        // last time we queued a ping (unix nano)
 	lastPingRecv  atomic.Int64                        // last time we received a ping (unix nano)
 	lastPongSent  atomic.Int64                        // last time we queued a pong (unix nano)
+	peerInfo      *lib.PeerInfo                       // peer info cache
 }
 
 // NewConnection() creates and starts a new instance of a MultiConn
-func (p *P2P) NewConnection(conn net.Conn) (*MultiConn, lib.ErrorI) {
+func (p *P2P) NewConnection(conn net.Conn, info *lib.PeerInfo) (*MultiConn, lib.ErrorI) {
 	if tcpConn, ok := conn.(*net.TCPConn); ok {
 		if err := tcpConn.SetWriteBuffer(32 * 1024 * 1024); err != nil {
 			p.log.Warnf("Failed to set write buffer: %v", err)
@@ -114,6 +115,7 @@ func (p *P2P) NewConnection(conn net.Conn) (*MultiConn, lib.ErrorI) {
 		p2p:           p,
 		close:         sync.Once{},
 		log:           p.log,
+		peerInfo:      info,
 	}
 	now := time.Now().UnixNano()
 	c.lastPong.Store(now)
@@ -250,15 +252,9 @@ func (c *MultiConn) startReceiveService() {
 					c.Error(ErrBadStream(), BadStreamSlash)
 					return
 				}
-				// get the peer info from the peer set
-				info, e := c.p2p.GetPeerInfo(c.Address.PublicKey)
-				if e != nil {
-					c.Error(e)
-					return
-				}
 				// handle the packet within the stream
-				if slash, er := stream.handlePacket(info, x, c.p2p.metrics); er != nil {
-					c.log.Warnf(er.Error())
+				if slash, er := stream.handlePacket(c.peerInfo, x, c.p2p.metrics); er != nil {
+					c.log.Warn(er.Error())
 					c.Error(er, slash)
 					return
 				}

--- a/p2p/conn.go
+++ b/p2p/conn.go
@@ -196,7 +196,15 @@ func (c *MultiConn) startSendService() {
 	var pwt *PacketWithTiming
 	defer func() { m.Done() }()
 	for {
+		// prioritize heartbeat messages to avoid disconnecting from peers
+		select {
+		case pwt = <-c.streams[heartbeatTopic].sendQueue:
+			c.sendPacketWithTiming(pwt, m)
+			continue
+		default:
+		}
 		// select statement ensures the sequential coordination of the concurrent processes
+		// heartbeat is included here too so pings are never stranded when no other traffic is present
 		select {
 		case pwt = <-c.streams[heartbeatTopic].sendQueue:
 			c.sendPacketWithTiming(pwt, m)

--- a/p2p/conn.go
+++ b/p2p/conn.go
@@ -196,15 +196,7 @@ func (c *MultiConn) startSendService() {
 	var pwt *PacketWithTiming
 	defer func() { m.Done() }()
 	for {
-		// prioritize heartbeat messages to avoid disconnecting from peers
-		select {
-		case pwt = <-c.streams[heartbeatTopic].sendQueue:
-			c.sendPacketWithTiming(pwt, m)
-			continue
-		default:
-		}
 		// select statement ensures the sequential coordination of the concurrent processes
-		// heartbeat is included here too so pings are never stranded when no other traffic is present
 		select {
 		case pwt = <-c.streams[heartbeatTopic].sendQueue:
 			c.sendPacketWithTiming(pwt, m)

--- a/p2p/p2p.go
+++ b/p2p/p2p.go
@@ -508,9 +508,13 @@ func (p *P2P) DialAndDisconnect(a *lib.PeerAddress, strictPublicKey bool) lib.Er
 // OnPeerError() callback to P2P when a peer errors
 func (p *P2P) OnPeerError(err error, publicKey []byte, remoteAddr string, uuid uint64) {
 	p.log.Warn(PeerError(publicKey, remoteAddr, err))
+	// acquire the write lock before modifying the peer set
+	unlock := lockWithTrace("p2p", &p.mux, p.log)
+	removeErr := p.PeerSet.Remove(publicKey, uuid)
+	unlock()
 	// ignore error: peer may have disconnected before added
-	if err = p.PeerSet.Remove(publicKey, uuid); err != nil {
-		p.log.Errorf("Remove error: %s", err.Error())
+	if removeErr != nil {
+		p.log.Errorf("Remove error: %s", removeErr.Error())
 	}
 
 	// Add to failed peers using the configured address from must-connects when possible.

--- a/p2p/p2p.go
+++ b/p2p/p2p.go
@@ -295,13 +295,18 @@ func (p *P2P) DialFailedPeers(interval time.Duration) {
 				}
 			}
 
+			// prevent a stampede of dials by staggering with a delay
+			const reconnectStagger = 100 * time.Millisecond
 			// Attempt a single dial per tick; keep it in the failed set if it doesn't succeed.
-			go func(mapKey any, a *lib.PeerAddress) {
+			go func(mapKey any, a *lib.PeerAddress, idx int) {
+				if idx > 0 {
+					time.Sleep(time.Duration(idx) * reconnectStagger)
+				}
 				if err := p.Dial(a, false, true); err != nil {
 					return
 				}
 				p.failedPeers.Delete(mapKey)
-			}(key, reconnect)
+			}(key, reconnect, count)
 
 			count++
 			return true

--- a/p2p/p2p.go
+++ b/p2p/p2p.go
@@ -347,7 +347,7 @@ func (p *P2P) Dial(address *lib.PeerAddress, disconnect, strictPublicKey bool) l
 // the peer set and the peer book
 func (p *P2P) AddPeer(conn net.Conn, info *lib.PeerInfo, disconnect, strictPublicKey bool) (err lib.ErrorI) {
 	// create the e2e encrypted connection while establishing a full peer info object
-	connection, err := p.NewConnection(conn)
+	connection, err := p.NewConnection(conn, info)
 	if err != nil {
 		return err
 	}

--- a/store/store.go
+++ b/store/store.go
@@ -708,7 +708,11 @@ func (s *Store) MaybeBackup() {
 		if removeErr := os.RemoveAll(prevBackupDir); removeErr != nil {
 			s.log.Warnf("failed to remove previous backup: %v", removeErr)
 		}
-		s.log.Infof("backup completed at height [%d] in %s", version, time.Since(start))
+		backupDuration := time.Since(start)
+		// log results
+		s.log.Infof("backup completed at height [%d] in %s", version, backupDuration)
+		// update metrics
+		s.metrics.UpdateStoreJobMetrics(0, 0, backupDuration)
 	}()
 }
 
@@ -727,8 +731,10 @@ func (s *Store) Compact(version uint64, compactHSS bool) lib.ErrorI {
 	if err := s.db.Compact(ctx, startPrefix, endPrefix, true); err != nil {
 		return ErrCommitDB(err)
 	}
-	lssTime := time.Since(now)
-	s.log.Debugf("key compaction finished [LSS] [%d] time: %s", version, lssTime)
+	// update LSS compaction metrics
+	lssDuration := time.Since(now)
+	s.metrics.UpdateStoreJobMetrics(lssDuration, 0, 0)
+	s.log.Debugf("key compaction finished [LSS] [%d] time: %s", version, lssDuration)
 	// second compaction: historic state keys
 	if compactHSS {
 		startPrefix, endPrefix = historicStatePrefix, prefixEnd(historicStatePrefix)
@@ -736,9 +742,12 @@ func (s *Store) Compact(version uint64, compactHSS bool) lib.ErrorI {
 		if err := s.db.Compact(ctx, startPrefix, endPrefix, false); err != nil {
 			return ErrCommitDB(err)
 		}
+		hssDuration := time.Since(hssTime)
 		// log results
 		s.log.Debugf("key compaction finished [HSS] [%d] time: %s, total time: %s", version,
-			time.Since(hssTime), time.Since(now))
+			hssDuration, time.Since(now))
+		// update HSS compaction metrics
+		s.metrics.UpdateStoreJobMetrics(0, hssDuration, 0)
 	}
 	return nil
 }


### PR DESCRIPTION
## Description
Apply multiple minor fixes to p2p to improve stability and a fix for a possible mempool panic on dex check

## Related Issues
<!-- List any issues this pull request closes. -->
Closes: N/A

## Changes Made
<!-- Highlight the key changes made in the code. For example:
- Added a new function to handle X
- Refactored Y for better performance
- Fixed bug Z
-->
- Release peer error lock faster
- increase hearbeat timeout
- cache peerInfo in MultiConn
- prioritize heartbeat send
- prevent reconnect stampede on failed peers
- fix race condition on check mempool
- Add store jobs metrics (compaction + backup)

## Checklist
- [X] I have tested the changes locally and verified they work as intended.
- [ ] I have appropriately titled my branch `issue-#<issue-number>`.
- [ ] I have run re-built the web-wallet and/or block explorer (if applicable).
- [ ] I have run `npm run prettier` to format the web-wallet and/or block explorer (if applicable)
- [ ] I have updated documentation (if applicable).
- [ ] I have included tests for the changes (if applicable).

## Additional Notes
<!-- Add any additional context, screenshots, or information that reviewers might find helpful. -->
