### PR TITLE
fix: delete link to explorer from wallet, fix staking view in wallet, add orders to global search in explorer and fix is pending in transaction view in explorer

### DIFF
--- a/cmd/rpc/server.go
+++ b/cmd/rpc/server.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"io"
 	"io/fs"
-	"net"
 	"net/http"
 	"os"
 	"path"
@@ -425,29 +424,10 @@ func (s *Server) runStaticFileServer(fileSys fs.FS, dir, port string, conf lib.C
 
 // injectConfig() injects the config.json into the HTML file
 func injectConfig(html string, config lib.Config, r *http.Request) string {
-	forwardedHost := strings.TrimSpace(strings.Split(r.Header.Get("X-Forwarded-Host"), ",")[0])
-	if forwardedHost == "" {
-		forwardedHost = r.Host
-	}
-
-	scheme := "http"
-	if r.TLS != nil {
-		scheme = "https"
-	}
-	if forwardedProto := strings.TrimSpace(strings.Split(r.Header.Get("X-Forwarded-Proto"), ",")[0]); forwardedProto != "" {
-		scheme = forwardedProto
-	}
-
-	hostname := forwardedHost
-	if host, _, err := net.SplitHostPort(forwardedHost); err == nil {
-		hostname = host
-	}
-
 	injectedConfig, err := json.Marshal(map[string]any{
-		"rpcURL":          config.RPCUrl,
-		"adminRPCURL":     config.AdminRPCUrl,
-		"explorerBaseURL": fmt.Sprintf("%s://%s", scheme, net.JoinHostPort(hostname, config.ExplorerPort)),
-		"chainId":         config.ChainId,
+		"rpcURL":      config.RPCUrl,
+		"adminRPCURL": config.AdminRPCUrl,
+		"chainId":     config.ChainId,
 	})
 	if err != nil {
 		injectedConfig = []byte("{}")

--- a/cmd/rpc/web/explorer/src/components/layouts/ExplorerSidebar.tsx
+++ b/cmd/rpc/web/explorer/src/components/layouts/ExplorerSidebar.tsx
@@ -248,7 +248,7 @@ export const ExplorerSidebar = (): React.JSX.Element => {
                                                 type="text"
                                                 value={searchTerm}
                                                 onChange={(event) => setSearchTerm(event.target.value)}
-                                                placeholder="Search blocks, transactions, addresses..."
+                                                placeholder="Search blocks, transactions, addresses, orders..."
                                                 className="h-full min-w-0 flex-1 bg-transparent text-sm text-white placeholder:text-zinc-500 outline-none"
                                             />
                                             <button

--- a/cmd/rpc/web/explorer/src/components/layouts/ExplorerTopBar.tsx
+++ b/cmd/rpc/web/explorer/src/components/layouts/ExplorerTopBar.tsx
@@ -44,7 +44,7 @@ export const ExplorerTopBar = (): React.JSX.Element => {
                         type="text"
                         value={searchTerm}
                         onChange={(event) => setSearchTerm(event.target.value)}
-                        placeholder="Search blocks, transactions, addresses..."
+                        placeholder="Search blocks, transactions, addresses, orders..."
                         className="h-full min-w-0 flex-1 bg-transparent text-sm text-white placeholder:text-zinc-500 outline-none"
                     />
                 </label>

--- a/cmd/rpc/web/explorer/src/components/search/SearchFilters.tsx
+++ b/cmd/rpc/web/explorer/src/components/search/SearchFilters.tsx
@@ -15,7 +15,8 @@ const SearchFilters: React.FC<SearchFiltersProps> = ({ filters, onFilterChange }
         { value: 'blocks', label: 'Blocks' },
         { value: 'transactions', label: 'Transactions' },
         { value: 'addresses', label: 'Addresses' },
-        { value: 'validators', label: 'Validators' }
+        { value: 'validators', label: 'Validators' },
+        { value: 'orders', label: 'Orders' }
     ]
 
     const dateOptions = [

--- a/cmd/rpc/web/explorer/src/components/search/SearchResults.tsx
+++ b/cmd/rpc/web/explorer/src/components/search/SearchResults.tsx
@@ -48,13 +48,14 @@ const SearchResults: React.FC<SearchResultsProps> = ({ results, filters }) => {
 
     // Calculate actual counts from filtered results (using same logic as getFilteredResults)
     const getActualCounts = () => {
-        if (!results) return { all: 0, blocks: 0, transactions: 0, addresses: 0, validators: 0 }
+        if (!results) return { all: 0, blocks: 0, transactions: 0, addresses: 0, validators: 0, orders: 0 }
 
         // Use the same filtering logic as getFilteredResults to get accurate counts
         const uniqueBlocksMap = new Map()
         const uniqueTxMap = new Map()
         const uniqueAddressesMap = new Map()
         const uniqueValidatorsMap = new Map()
+        const uniqueOrdersMap = new Map()
 
         // Process blocks with same validation as getFilteredResults
         results.blocks?.forEach((block: any) => {
@@ -98,12 +99,23 @@ const SearchResults: React.FC<SearchResultsProps> = ({ results, filters }) => {
             }
         })
 
+        // Process orders
+        results.orders?.forEach((order: any) => {
+            if (order && order.data) {
+                const oid = order.id || order.data.id || order.data.Id
+                if (oid && !uniqueOrdersMap.has(oid)) {
+                    uniqueOrdersMap.set(oid, true)
+                }
+            }
+        })
+
         return {
-            all: uniqueBlocksMap.size + uniqueTxMap.size + uniqueAddressesMap.size + uniqueValidatorsMap.size,
+            all: uniqueBlocksMap.size + uniqueTxMap.size + uniqueAddressesMap.size + uniqueValidatorsMap.size + uniqueOrdersMap.size,
             blocks: uniqueBlocksMap.size,
             transactions: uniqueTxMap.size,
             addresses: uniqueAddressesMap.size,
-            validators: uniqueValidatorsMap.size
+            validators: uniqueValidatorsMap.size,
+            orders: uniqueOrdersMap.size
         }
     }
 
@@ -114,7 +126,8 @@ const SearchResults: React.FC<SearchResultsProps> = ({ results, filters }) => {
         { id: 'blocks', label: 'Blocks', count: actualCounts.blocks },
         { id: 'transactions', label: 'Transactions', count: actualCounts.transactions },
         { id: 'addresses', label: 'Addresses', count: actualCounts.addresses },
-        { id: 'validators', label: 'Validators', count: actualCounts.validators }
+        { id: 'validators', label: 'Validators', count: actualCounts.validators },
+        { id: 'orders', label: 'Orders', count: actualCounts.orders }
     ]
 
     const parseTimestampToDate = (timestamp: unknown): Date | null => {
@@ -393,7 +406,40 @@ const SearchResults: React.FC<SearchResultsProps> = ({ results, filters }) => {
                     { label: 'Auto-Compound:', value: `${(item.compound ?? false) ? 'Yes' : 'No'}` },
                     { label: 'Net Address:', value: `${item.netAddress ? item.netAddress : 'tcp://delegation'}` }
                 ] as FieldConfig[]
-            }
+            },
+            order: (() => {
+                const oid = item.id || item.Id || ''
+                const committee = item.committee ?? item.Chain ?? ''
+                const buyerSendAddr = item.buyerSendAddress || item.BuyerSendAddress || ''
+                const orderStatus = buyerSendAddr ? 'Locked' : 'Active'
+                const amountForSale = item.amountForSale ?? item.AmountForSale ?? 0
+                const requestedAmount = item.requestedAmount ?? item.RequestedAmount ?? 0
+                const sellerSendAddr = item.sellersSendAddress || item.SellersSendAddress || 'N/A'
+                const sellerReceiveAddr = item.sellerReceiveAddress || item.SellerReceiveAddress || 'N/A'
+
+                return {
+                    icon: 'fa-right-left',
+                    iconColor: 'text-yellow-500',
+                    bgColor: 'bg-yellow-700/30',
+                    badgeClass: GREEN_BADGE_CLASS,
+                    badgeText: orderStatus,
+                    title: `Order ${oid.length > 16 ? truncateHash(oid, 8) : oid}`,
+                    borderColor: 'border-gray-400/10',
+                    hoverColor: 'hover:border-gray-400/20',
+                    linkTo: `/order/${committee}/${oid}`,
+                    copyValue: oid,
+                    copyLabel: 'Copy Order ID',
+                    fields: [
+                        { label: 'Order ID:', value: truncateHash(oid, 10) },
+                        { label: 'Committee:', value: String(committee) },
+                        { label: 'Status:', value: orderStatus },
+                        { label: 'Amount For Sale:', value: `${toCNPY(Number(amountForSale)).toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })} CNPY` },
+                        { label: 'Requested:', value: `${toCNPY(Number(requestedAmount)).toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })} CNPY` },
+                        { label: 'Seller Send:', value: truncateHash(sellerSendAddr, 6) },
+                        { label: 'Seller Receive:', value: truncateHash(sellerReceiveAddr, 6) },
+                    ] as FieldConfig[]
+                }
+            })()
         }
 
         const config = configs[type as keyof typeof configs]
@@ -442,6 +488,10 @@ const SearchResults: React.FC<SearchResultsProps> = ({ results, filters }) => {
                                     linkTo = `/account/${item.address}`
                                 } else if (type === 'validator' && field.label === 'Address:') {
                                     linkTo = `/validator/${item.address}`
+                                } else if (type === 'order' && field.label === 'Order ID:') {
+                                    const oid = item.id || item.Id || ''
+                                    const committee = item.committee ?? item.Chain ?? ''
+                                    linkTo = `/order/${committee}/${oid}`
                                 }
 
                                 return (
@@ -492,6 +542,7 @@ const SearchResults: React.FC<SearchResultsProps> = ({ results, filters }) => {
         const uniqueTxMap = new Map()
         const uniqueAddressesMap = new Map()
         const uniqueValidatorsMap = new Map()
+        const uniqueOrdersMap = new Map()
 
         // Process blocks and remove duplicates - filter out invalid blocks
         results.blocks?.forEach((block: any) => {
@@ -537,11 +588,22 @@ const SearchResults: React.FC<SearchResultsProps> = ({ results, filters }) => {
             }
         })
 
+        // Process orders
+        results.orders?.forEach((order: any) => {
+            if (order && order.data) {
+                const oid = order.id || order.data.id || order.data.Id
+                if (oid && !uniqueOrdersMap.has(oid)) {
+                    uniqueOrdersMap.set(oid, { ...order.data, resultType: 'order' })
+                }
+            }
+        })
+
         // Get unique arrays from Maps
         const uniqueBlocks = Array.from(uniqueBlocksMap.values())
         const uniqueTransactions = Array.from(uniqueTxMap.values())
         const uniqueAddresses = Array.from(uniqueAddressesMap.values())
         const uniqueValidators = Array.from(uniqueValidatorsMap.values())
+        const uniqueOrders = Array.from(uniqueOrdersMap.values())
 
         // Determine which results to show based on activeTab
         let filteredResults = []
@@ -551,7 +613,8 @@ const SearchResults: React.FC<SearchResultsProps> = ({ results, filters }) => {
                 ...uniqueBlocks,
                 ...uniqueTransactions,
                 ...uniqueAddresses,
-                ...uniqueValidators
+                ...uniqueValidators,
+                ...uniqueOrders
             ]
         } else if (activeTab === 'blocks') {
             filteredResults = uniqueBlocks
@@ -561,6 +624,8 @@ const SearchResults: React.FC<SearchResultsProps> = ({ results, filters }) => {
             filteredResults = uniqueAddresses
         } else if (activeTab === 'validators') {
             filteredResults = uniqueValidators
+        } else if (activeTab === 'orders') {
+            filteredResults = uniqueOrders
         }
 
         // Apply filters if provided

--- a/cmd/rpc/web/explorer/src/components/transaction/TransactionDetailPage.tsx
+++ b/cmd/rpc/web/explorer/src/components/transaction/TransactionDetailPage.tsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect } from 'react'
 import { useParams, useNavigate } from 'react-router-dom'
 import { motion } from 'framer-motion'
 import { Copy } from 'lucide-react'
-import { useTxByHash, useBlockByHeight } from '../../hooks/useApi'
+import { useTxByHash, useBlockByHeight, useLatestBlock } from '../../hooks/useApi'
 import toast from 'react-hot-toast'
 import { format, formatDistanceToNow, parseISO, isValid } from 'date-fns'
 
@@ -69,6 +69,17 @@ const TransactionDetailPage: React.FC = () => {
     // Use the real hook to get transaction data
     const { data: transactionData, isLoading, error } = useTxByHash(transactionHash || '')
 
+    // Get the latest confirmed block height to detect pending transactions.
+    // If the tx height is ahead of the current chain height, it hasn't been
+    // included in a block yet — it's a pending (mempool) transaction.
+    const { data: latestBlockData } = useLatestBlock()
+    const latestHeight = Number(
+        latestBlockData?.results?.[0]?.blockHeader?.height
+        ?? latestBlockData?.results?.[0]?.height
+        ?? latestBlockData?.height
+        ?? 0
+    )
+
     // Get block data to find all transactions in the same block
     const txBlockHeight = transactionData?.result?.height || transactionData?.height || 0
     const { data: blockData } = useBlockByHeight(txBlockHeight)
@@ -78,10 +89,12 @@ const TransactionDetailPage: React.FC = () => {
     const transactionFeeMicro = transaction?.transaction?.fee || transaction?.fee || 0
     const txType = transaction?.transaction?.type || transaction?.messageType || transaction?.type || 'send'
 
+    const txHeight = transaction?.height || transaction?.blockHeight || transaction?.block || 0
+    const isPending = latestHeight > 0 && txHeight > latestHeight
+
     // Helper function to normalize hash for comparison
     const normalizeHash = (hash: string): string => {
         if (!hash) return ''
-        // Remove '0x' prefix if present and convert to lowercase
         return hash.replace(/^0x/i, '').toLowerCase()
     }
 
@@ -243,10 +256,7 @@ const TransactionDetailPage: React.FC = () => {
     }
 
     // Extract data from the API response (using transaction already extracted above)
-    const blockHeight = transaction?.height || transaction?.blockHeight || transaction?.block || 0
-    const rawStatus = transaction?.status || ''
-    const isPending = blockHeight === 0 || rawStatus.toLowerCase() === 'pending'
-    const status = isPending ? 'pending' : (rawStatus || 'success')
+    const blockHeight = txHeight
     const timestamp = transaction?.transaction?.time || transaction?.timestamp || transaction?.time || new Date().toISOString()
     const fee = formatFee(transactionFeeMicro)
 
@@ -377,12 +387,20 @@ const TransactionDetailPage: React.FC = () => {
 
                                     <div className="flex flex-col border-b border-gray-400/30 pb-4 gap-2">
                                         <span className="text-gray-400 text-sm">Block</span>
-                                        <span className="text-primary">{blockHeight.toLocaleString()}</span>
+                                        {isPending ? (
+                                            <span className="text-sm font-medium text-yellow-400">Mempool</span>
+                                        ) : (
+                                            <span className="text-primary">{blockHeight.toLocaleString()}</span>
+                                        )}
                                     </div>
 
                                     <div className="flex flex-col border-b border-gray-400/30 pb-4 gap-2">
                                         <span className="text-gray-400 text-sm">Timestamp</span>
-                                        <span className="text-white text-sm">{formatTimestamp(timestamp)}</span>
+                                        {isPending ? (
+                                            <span className="text-sm font-medium text-yellow-400">Pending</span>
+                                        ) : (
+                                            <span className="text-white text-sm">{formatTimestamp(timestamp)}</span>
+                                        )}
                                     </div>
 
                                     <div className="flex flex-col border-b border-gray-400/30 pb-4 gap-2">
@@ -535,7 +553,7 @@ const TransactionDetailPage: React.FC = () => {
                                         <span className="text-gray-400 text-sm">Transaction Type</span>
                                         <TransactionTypeBadge type={txType} />
                                     </div>
-                                    {position !== null && (
+                                    {position !== null && !isPending && (
                                         <div className="flex justify-between items-center">
                                             <span className="text-gray-400 text-sm">Position in Block</span>
                                             <span className="text-white text-sm">{position}</span>

--- a/cmd/rpc/web/explorer/src/components/transaction/TransactionDetailPage.tsx
+++ b/cmd/rpc/web/explorer/src/components/transaction/TransactionDetailPage.tsx
@@ -90,7 +90,8 @@ const TransactionDetailPage: React.FC = () => {
     const txType = transaction?.transaction?.type || transaction?.messageType || transaction?.type || 'send'
 
     const txHeight = transaction?.height || transaction?.blockHeight || transaction?.block || 0
-    const isPending = latestHeight > 0 && txHeight > latestHeight
+    const rawStatus = String(transaction?.status || '').toLowerCase()
+    const isPending = txHeight === 0 || rawStatus === 'pending' || (latestHeight > 0 && txHeight > latestHeight)
 
     // Helper function to normalize hash for comparison
     const normalizeHash = (hash: string): string => {

--- a/cmd/rpc/web/explorer/src/hooks/useSearch.ts
+++ b/cmd/rpc/web/explorer/src/hooks/useSearch.ts
@@ -6,16 +6,17 @@ import {
     BlockByHash,
     TxByHash,
     Validator,
-    Account
+    Account,
+    Orders,
 } from '../lib/api'
 import { toCNPY } from '../lib/utils'
 
 interface SearchResult {
-    type: 'block' | 'transaction' | 'address' | 'validator'
+    type: 'block' | 'transaction' | 'address' | 'validator' | 'order'
     id: string
     title: string
     subtitle?: string
-    data: any
+    data: Record<string, unknown>
 }
 
 interface SearchResults {
@@ -24,6 +25,7 @@ interface SearchResults {
     transactions: SearchResult[]
     addresses: SearchResult[]
     validators: SearchResult[]
+    orders: SearchResult[]
 }
 
 const formatAccountBalanceSubtitle = (amount: number | string | undefined) =>
@@ -61,7 +63,8 @@ export const useSearch = (searchTerm: string) => {
                 blocks: [],
                 transactions: [],
                 addresses: [],
-                validators: []
+                validators: [],
+                orders: []
             }
 
             // DIRECT SEARCH FOR BLOCKS, TRANSACTIONS, ACCOUNTS, AND VALIDATORS
@@ -351,6 +354,42 @@ export const useSearch = (searchTerm: string) => {
                 )
             }
 
+            // 4. Search orders by ID (uses /v1/query/orders and filters client-side)
+            searchPromises.push(
+                Orders()
+                    .then((ordersData: Record<string, unknown>) => {
+                        const ordersList = Array.isArray(ordersData?.orders)
+                            ? ordersData.orders as Record<string, unknown>[]
+                            : Array.isArray(ordersData?.results)
+                                ? ordersData.results as Record<string, unknown>[]
+                                : []
+
+                        const termLower = term.toLowerCase()
+                        const matchingOrders = ordersList.filter((order: Record<string, unknown>) => {
+                            const id = String(order.id || order.Id || '')
+                            return id.toLowerCase().includes(termLower)
+                        })
+
+                        matchingOrders.forEach((order: Record<string, unknown>) => {
+                            const id = String(order.id || order.Id || '')
+                            const committee = order.committee ?? order.Chain ?? ''
+                            const buyerSendAddress = order.buyerSendAddress || order.BuyerSendAddress || ''
+                            const status = buyerSendAddress ? 'Locked' : 'Active'
+
+                            if (!searchResults.orders.some(o => o.id === id)) {
+                                searchResults.orders.push({
+                                    type: 'order' as const,
+                                    id,
+                                    title: `Order ${id.length > 16 ? id.slice(0, 8) + '...' + id.slice(-8) : id}`,
+                                    subtitle: `Committee ${committee} · ${status}`,
+                                    data: order
+                                })
+                            }
+                        })
+                    })
+                    .catch(err => console.log('Order search error:', err))
+            )
+
             // Wait for all promises to complete
             await Promise.all(searchPromises)
 
@@ -358,7 +397,8 @@ export const useSearch = (searchTerm: string) => {
             const total = searchResults.blocks.length +
                 searchResults.transactions.length +
                 searchResults.addresses.length +
-                searchResults.validators.length
+                searchResults.validators.length +
+                searchResults.orders.length
 
             setResults({
                 ...searchResults,

--- a/cmd/rpc/web/explorer/src/hooks/useSearch.ts
+++ b/cmd/rpc/web/explorer/src/hooks/useSearch.ts
@@ -7,7 +7,7 @@ import {
     TxByHash,
     Validator,
     Account,
-    Orders,
+    AllOrders,
 } from '../lib/api'
 import { toCNPY } from '../lib/utils'
 
@@ -354,16 +354,10 @@ export const useSearch = (searchTerm: string) => {
                 )
             }
 
-            // 4. Search orders by ID (uses /v1/query/orders and filters client-side)
+            // 4. Search orders by ID across all paginated order-book results
             searchPromises.push(
-                Orders()
-                    .then((ordersData: Record<string, unknown>) => {
-                        const ordersList = Array.isArray(ordersData?.orders)
-                            ? ordersData.orders as Record<string, unknown>[]
-                            : Array.isArray(ordersData?.results)
-                                ? ordersData.results as Record<string, unknown>[]
-                                : []
-
+                AllOrders()
+                    .then((ordersList: Record<string, unknown>[]) => {
                         const termLower = term.toLowerCase()
                         const matchingOrders = ordersList.filter((order: Record<string, unknown>) => {
                             const id = String(order.id || order.Id || '')

--- a/cmd/rpc/web/explorer/src/lib/api.ts
+++ b/cmd/rpc/web/explorer/src/lib/api.ts
@@ -861,8 +861,40 @@ export function EcoParams(chain_id: number) {
     return POST(rpcURL, chainRequest(chain_id), ecoParamsPath);
 }
 
-export function Orders() {
-    return POST(rpcURL, JSON.stringify({ height: 0 }), ordersPath);
+export function Orders(page: number = 1, perPage: number = 10, committee: number = 0, height: number = 0) {
+    return POST(rpcURL, JSON.stringify({
+        committee,
+        height,
+        pageNumber: page,
+        perPage,
+    }), ordersPath);
+}
+
+export async function AllOrders(perPage: number = 5000) {
+    const firstPage = await Orders(1, perPage);
+    const firstPageResults = Array.isArray(firstPage?.results)
+        ? firstPage.results
+        : Array.isArray(firstPage?.orders)
+            ? firstPage.orders
+            : [];
+    const totalPages = Math.max(Number(firstPage?.totalPages || 1), 1);
+
+    if (totalPages === 1) {
+        return firstPageResults;
+    }
+
+    const remainingPages = await Promise.all(
+        Array.from({ length: totalPages - 1 }, (_, index) => Orders(index + 2, perPage))
+    );
+
+    return remainingPages.reduce<any[]>((allOrders, page) => {
+        const pageResults = Array.isArray(page?.results)
+            ? page.results
+            : Array.isArray(page?.orders)
+                ? page.orders
+                : [];
+        return allOrders.concat(pageResults);
+    }, [...firstPageResults]);
 }
 
 export function Order(committee: number, order_id: string, height: number = 0) {

--- a/cmd/rpc/web/explorer/src/pages/Search.tsx
+++ b/cmd/rpc/web/explorer/src/pages/Search.tsx
@@ -92,7 +92,7 @@ const SearchPage: React.FC = () => {
                     className="mb-8"
                 >
                     <h1 className="explorer-page-title">Search Results</h1>
-                    <p className="explorer-page-subtitle">Find blocks, transactions, addresses, and validators</p>
+                    <p className="explorer-page-subtitle">Find blocks, transactions, addresses, validators, and orders</p>
                 </motion.div>
 
                 {/* Search Input */}
@@ -107,7 +107,7 @@ const SearchPage: React.FC = () => {
                             type="text"
                             value={searchTerm}
                             onChange={(e) => setSearchTerm(e.target.value)}
-                            placeholder="Search blocks, transactions, addresses..."
+                            placeholder="Search blocks, transactions, addresses, orders..."
                             className="w-full bg-input border border-white/8 rounded-lg px-4 py-3 pl-12 pr-3 text-white placeholder-gray-500 focus:outline-none focus:ring focus:ring-primary/50 focus:border-primary"
                         />
                         {searchTerm && (
@@ -187,7 +187,7 @@ const SearchPage: React.FC = () => {
                         >
                             <i className="fa-solid fa-search text-4xl text-gray-600 mb-4"></i>
                             <h3 className="text-xl font-semibold text-white mb-2">Start searching</h3>
-                            <p className="text-gray-400">Enter a block height, transaction hash, address, or validator name</p>
+                            <p className="text-gray-400">Enter a block height, transaction hash, address, validator name, or order ID</p>
                         </motion.div>
                     )}
                 </AnimatePresence>

--- a/cmd/rpc/web/wallet/public/plugin/canopy/chain.json
+++ b/cmd/rpc/web/wallet/public/plugin/canopy/chain.json
@@ -11,10 +11,6 @@
     "base": "http://localhost:50002",
     "admin": "http://localhost:50003"
   },
-  "explorer": {
-    "tx": "http://localhost:50001/transaction",
-    "order": "http://localhost:50001/order"
-  },
   "address": {
     "format": "evm"
   },

--- a/cmd/rpc/web/wallet/public/plugin/canopy/chain.json.template
+++ b/cmd/rpc/web/wallet/public/plugin/canopy/chain.json.template
@@ -11,10 +11,6 @@
     "base": "/rpc",
     "admin": "/adminrpc"
   },
-  "explorer": {
-    "tx": "http://localhost:50001/transaction",
-    "order": "http://localhost:50001/order"
-  },
   "address": {
     "format": "evm"
   },

--- a/cmd/rpc/web/wallet/public/plugin/canopy/manifest.json
+++ b/cmd/rpc/web/wallet/public/plugin/canopy/manifest.json
@@ -305,15 +305,7 @@
         "onSuccess": {
           "variant": "success",
           "title": "Send!",
-          "description": "{{result}}",
-          "actions": [
-            {
-              "type": "link",
-              "label": "Explorer",
-              "href": "{{chain.explorer.tx}}/{{result}}",
-              "newTab": true
-            }
-          ]
+          "description": "Transaction ID: {{result}}"
         }
       }
     },
@@ -891,15 +883,7 @@
         "onSuccess": {
           "variant": "success",
           "title": "Send!",
-          "description": "{{result}}",
-          "actions": [
-            {
-              "type": "link",
-              "label": "Explorer",
-              "href": "{{chain.explorer.tx}}/{{result}}",
-              "newTab": true
-            }
-          ]
+          "description": "Transaction ID: {{result}}"
         }
       }
     },
@@ -2083,15 +2067,7 @@
         "onSuccess": {
           "variant": "success",
           "title": "Unstake Successful!",
-          "description": "Your validator has been unstaked. Funds will be available after the unstaking period",
-          "actions": [
-            {
-              "type": "link",
-              "label": "View Transaction",
-              "href": "{{chain.explorer.tx}}/{{result}}",
-              "newTab": true
-            }
-          ]
+          "description": "Your validator has been unstaked. Funds will be available after the unstaking period.\nTransaction ID: {{result}}"
         },
         "onError": {
           "variant": "error",
@@ -4161,7 +4137,10 @@
         "admin.config": {},
         "account": {
           "account": {
-            "address": "{{account.address}}"
+            "address": "{{form.address || account.address}}"
+          },
+          "__options": {
+            "enabled": "{{ form.address || account.address }}"
           }
         },
         "keystore": {},
@@ -4427,21 +4406,7 @@
         "onSuccess": {
           "variant": "success",
           "title": "Order Submitted",
-          "description": "Node accepted transaction: {{result}}",
-          "actions": [
-            {
-              "type": "link",
-              "label": "View Order",
-              "href": "{{chain.explorer.order}}/{{form.committees}}/{{slice<{{result}}, 0, 40>}}",
-              "newTab": true
-            },
-            {
-              "type": "link",
-              "label": "View Transaction",
-              "href": "{{chain.explorer.tx}}/{{result}}",
-              "newTab": true
-            }
-          ]
+          "description": "Order ID: {{slice<{{result}}, 0, 40>}}\nTransaction ID: {{result}}"
         }
       }
     },

--- a/cmd/rpc/web/wallet/scripts/generate-chain-config.js
+++ b/cmd/rpc/web/wallet/scripts/generate-chain-config.js
@@ -15,7 +15,6 @@ const __dirname = path.dirname(__filename);
 // Read environment variables
 const rpcTarget = process.env.VITE_WALLET_RPC_PROXY_TARGET || 'http://localhost:50002';
 const adminRpcTarget = process.env.VITE_WALLET_ADMIN_RPC_PROXY_TARGET || 'http://localhost:50003';
-const explorerBasePath = process.env.VITE_EXPLORER_BASE_PATH || 'http://localhost:50001';
 
 // Path to chain.json template and output
 const templatePath = path.join(__dirname, '../public/plugin/canopy/chain.json.template');
@@ -39,17 +38,9 @@ chainConfig.rpc = {
   admin: adminRpcTarget,
 };
 
-// Update explorer paths (built from the base URL)
-const trimmedExplorer = explorerBasePath.replace(/\/+$/, '');
-chainConfig.explorer = {
-  tx: `${trimmedExplorer}/transaction`,
-  order: `${trimmedExplorer}/order`
-};
-
 // Write the updated config
 fs.writeFileSync(outputPath, JSON.stringify(chainConfig, null, 2));
 
 console.log(`✅ Generated chain.json with RPC targets:`);
 console.log(`   - base: ${rpcTarget}`);
 console.log(`   - admin: ${adminRpcTarget}`);
-console.log(`   - explorer: ${explorerBasePath}`);

--- a/cmd/rpc/web/wallet/src/components/staking/ValidatorCard.tsx
+++ b/cmd/rpc/web/wallet/src/components/staking/ValidatorCard.tsx
@@ -1,15 +1,17 @@
 import React from "react";
 import { motion } from "framer-motion";
-import { Copy, LockOpen, Pause, Pen, Play, Scan } from "lucide-react";
-import { useCopyToClipboard } from "@/hooks/useCopyToClipboard";
+import { LockOpen, Pause, Pen, Play, Scan } from "lucide-react";
 import { useActionModal } from "@/app/providers/ActionModalProvider";
 import { useDenom } from "@/hooks/useDenom";
+import { getCanopySymbolByHash } from "@/lib/utils/canopySymbols";
 import { ActionTooltip } from "@/components/ui/ActionTooltip";
+import { CopyableIdentifier } from "@/components/ui/CopyableIdentifier";
 import { WALLET_BADGE_CLASS, WALLET_BADGE_TONE } from "@/components/ui/badgeStyles";
 
 interface ValidatorCardProps {
   validator: {
     address: string;
+    nickname?: string;
     stakedAmount: number;
     status: "Staked" | "Paused" | "Unstaking" | "Delegate";
     rewards24h: number;
@@ -54,55 +56,10 @@ const statusBadgeClass = (status: ValidatorCardProps["validator"]["status"]) => 
 const actionButtonClass =
   "inline-flex items-center justify-center rounded-lg border border-border/60 p-2 text-foreground transition-colors hover:border-white/20 hover:bg-accent";
 
-type DetailRowProps = {
-  label: string;
-  value?: string;
-  onCopy?: () => void;
-  title?: string;
-  children?: React.ReactNode;
-};
-
-const DetailRow: React.FC<DetailRowProps> = ({
-  label,
-  value,
-  onCopy,
-  title,
-  children,
-}) => (
-  <div className="flex items-start gap-2">
-    <span className="w-20 shrink-0 pt-0.5 text-[11px] font-medium uppercase tracking-wider text-white/50">
-      {label}
-    </span>
-    <div className="min-w-0 flex-1">
-      {children ?? (
-        <div className="flex items-center gap-1.5">
-          <span
-            className="min-w-0 break-all text-xs text-muted-foreground"
-            title={title ?? value}
-          >
-            {value || "—"}
-          </span>
-          {onCopy && value ? (
-            <button
-              type="button"
-              className="rounded p-0.5 text-muted-foreground/40 transition-colors hover:bg-accent/60 hover:text-primary"
-              onClick={onCopy}
-              title={`Copy ${label}`}
-            >
-              <Copy className="h-2.5 w-2.5" />
-            </button>
-          ) : null}
-        </div>
-      )}
-    </div>
-  </div>
-);
-
 export const ValidatorCard: React.FC<ValidatorCardProps> = ({
   validator,
   onViewDetails,
 }) => {
-  const { copyToClipboard } = useCopyToClipboard();
   const { openAction } = useActionModal();
   const { symbol, factor } = useDenom();
 
@@ -251,12 +208,23 @@ export const ValidatorCard: React.FC<ValidatorCardProps> = ({
       </div>
 
       <div className="mt-3 border-t border-[#272729] pt-3">
-        <DetailRow
-          label="Address"
-          value={truncateAddress(validator.address)}
-          title={validator.address}
-          onCopy={() => copyToClipboard(validator.address, "Validator Address")}
-        />
+        <div className="flex items-center gap-3">
+          <img
+            src={getCanopySymbolByHash(validator.address)}
+            alt=""
+            className="h-7 w-7 rounded-lg object-contain flex-shrink-0"
+          />
+          <div>
+            <div className="text-sm font-medium text-foreground leading-tight">
+              {validator.nickname || truncateAddress(validator.address)}
+            </div>
+            <div className="flex items-center gap-1 mt-0.5">
+              <CopyableIdentifier value={validator.address} label="Validator Address" className="max-w-[13rem] text-[11px] text-muted-foreground leading-tight">
+                {truncateAddress(validator.address)}
+              </CopyableIdentifier>
+            </div>
+          </div>
+        </div>
       </div>
     </motion.div>
   );

--- a/cmd/rpc/web/wallet/src/components/staking/ValidatorList.tsx
+++ b/cmd/rpc/web/wallet/src/components/staking/ValidatorList.tsx
@@ -134,15 +134,22 @@ const DesktopValidatorRow: React.FC<{
         className={desktopRowCellClass}
         style={{ borderTopLeftRadius: "10px", borderBottomLeftRadius: "10px" }}
       >
-        <div className="flex items-center gap-1.5">
+        <div className="flex items-center gap-3">
           <img
             src={getCanopySymbolByHash(validator.address)}
             alt=""
             className="h-7 w-7 rounded-lg object-contain flex-shrink-0"
           />
-          <CopyableIdentifier value={validator.address} label="Validator address" className="text-sm font-medium text-foreground">
-            {truncateAddress(validator.address)}
-          </CopyableIdentifier>
+          <div>
+            <div className="text-sm font-medium text-foreground leading-tight">
+              {validator.nickname || truncateAddress(validator.address)}
+            </div>
+            <div className="flex items-center gap-1 mt-0.5">
+              <CopyableIdentifier value={validator.address} label="Validator address" className="max-w-[13rem] text-[11px] text-muted-foreground leading-tight">
+                {truncateAddress(validator.address)}
+              </CopyableIdentifier>
+            </div>
+          </div>
         </div>
       </td>
       <td className={desktopRowCellClass}>

--- a/cmd/rpc/web/wallet/src/components/transactions/TransactionDetailModal.tsx
+++ b/cmd/rpc/web/wallet/src/components/transactions/TransactionDetailModal.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { AnimatePresence, motion } from "framer-motion";
-import { X, Copy, ExternalLink, CheckCircle2, AlertTriangle, Info } from "lucide-react";
+import { X, Copy, CheckCircle2, AlertTriangle, Info } from "lucide-react";
 import { useConfig } from "@/app/providers/ConfigProvider";
 import { LucideIcon } from "@/components/ui/LucideIcon";
 import { useCopyToClipboard } from "@/hooks/useCopyToClipboard";
@@ -144,8 +144,6 @@ export const TransactionDetailModal: React.FC<TransactionDetailModalProps> = ({
   const symbol = chain?.denom?.symbol ?? "CNPY";
   const decimals = Number(chain?.denom?.decimals ?? 6);
   const toDisplay = (n: number) => n / Math.pow(10, decimals);
-
-  const explorerTxUrl = chain?.explorer?.tx ?? "";
 
   React.useEffect(() => {
     if (!open) return;
@@ -344,20 +342,6 @@ export const TransactionDetailModal: React.FC<TransactionDetailModalProps> = ({
                   </section>
                 )}
               </div>
-
-              {explorerTxUrl && (
-                <div className="px-6 py-4 border-t border-border/50 flex justify-end">
-                  <a
-                    href={`${explorerTxUrl}/${tx.hash}`}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="inline-flex items-center gap-1.5 text-sm font-medium text-[#216cd0] hover:text-[#216cd0]/80 transition-colors"
-                  >
-                    View on Explorer
-                    <ExternalLink className="w-3.5 h-3.5" />
-                  </a>
-                </div>
-              )}
             </motion.div>
           </motion.div>
         </>

--- a/cmd/rpc/web/wallet/src/manifest/loader.ts
+++ b/cmd/rpc/web/wallet/src/manifest/loader.ts
@@ -28,8 +28,6 @@ function applyWindowConfig<T extends Record<string, unknown>>(chain: T): T {
   if (typeof window === 'undefined' || !window.__CONFIG__) return chain
 
   const rpc = (chain.rpc ?? {}) as Record<string, string>
-  const explorer = (chain.explorer ?? {}) as Record<string, string>
-  const explorerBaseURL = window.__CONFIG__.explorerBaseURL?.replace(/\/+$/, '')
   return {
     ...chain,
     chainId: String(window.__CONFIG__.chainId),
@@ -38,13 +36,6 @@ function applyWindowConfig<T extends Record<string, unknown>>(chain: T): T {
       base: window.__CONFIG__.rpcURL,
       admin: window.__CONFIG__.adminRPCURL,
     },
-    explorer: explorerBaseURL
-      ? {
-          ...explorer,
-          tx: `${explorerBaseURL}/transaction`,
-          order: `${explorerBaseURL}/order`,
-        }
-      : explorer,
   }
 }
 

--- a/cmd/rpc/web/wallet/src/types/global.d.ts
+++ b/cmd/rpc/web/wallet/src/types/global.d.ts
@@ -3,7 +3,6 @@ declare global {
         __CONFIG__?: {
             rpcURL: string;
             adminRPCURL: string;
-            explorerBaseURL?: string;
             chainId: number;
         };
     }


### PR DESCRIPTION
## Fix Config, Wallet & Explorer Issues

### Summary

This PR addresses several issues across the wallet and explorer web applications, focusing on removing a broken cross-app dependency, improving the staking UI, and expanding search capabilities.

### Changes

- **Removed explorer link coupling from the wallet**: The wallet no longer builds or injects explorer URLs into its configuration. This eliminates the fragile dependency where the wallet tried to derive the explorer's base URL from request headers and config, which was error-prone and unnecessary. The "View on Explorer" link in the transaction detail modal has been removed accordingly.

- **Improved staking validator display in the wallet**: Validator cards and list rows now show validator nicknames when available, with a cleaner layout that includes identicon images alongside copyable addresses. This replaces the previous inline-only address display with a more informative two-line format (nickname + truncated address).

- **Added order search support in the explorer**: The global search now includes orders as a searchable and filterable entity type. Search results render order details (ID, committee, status, amounts, and addresses) consistently with other entity types, and search placeholders have been updated to reflect the new capability.

- **Fixed pending status detection in the explorer transaction view**: The transaction detail page now correctly determines whether a transaction is pending, resolving cases where the status was not displayed accurately.