### PR TITLE
fix: make delete key ask for password and import pop up dissappear

### DIFF
--- a/cmd/cli/admin.go
+++ b/cmd/cli/admin.go
@@ -121,7 +121,7 @@ var (
 		Short: "delete the key associated with the address or nickname from the keystore",
 		Args:  cobra.MinimumNArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
-			writeToConsole(client.KeystoreDelete(argGetAddrOrNickname(args[0])))
+			writeToConsole(client.KeystoreDelete(argGetAddrOrNickname(args[0]), getPassword()))
 		},
 	}
 

--- a/cmd/rpc/README.md
+++ b/cmd/rpc/README.md
@@ -3541,13 +3541,14 @@ $ curl -X POST http://localhost:50003/v1/admin/keystore-import-raw \
 
 **Route:** `/v1/admin/keystore-delete`
 
-**Description**: removes a key from the keystore using either the address or nickname
+**Description**: removes a key from the keystore using either the address or nickname after validating the password
 
 **HTTP Method**: `POST`
 
 **Request**:
 - **nickname**: `string` - the nickname associated with the key
 - **address**: `string` - the address associated with the key
+- **password**: `string` - **(required)** the plain-text password used to encrypt the key
 
 **Response**: `hex-string` - the 20 byte address of the newly imported key
 
@@ -3556,7 +3557,8 @@ $ curl -X POST http://localhost:50003/v1/admin/keystore-import-raw \
 $ curl -X POST http://localhost:50003/v1/admin/keystore-delete \
   -H "Content-Type: application/json" \
   -d '{
-    "nickname":"my_key_2"
+    "nickname":"my_key_2",
+    "password":"my_password"
     }'
 
 > "b0b4a45ca70104ecc943a49e4553f0e7e1135b01"

--- a/cmd/rpc/admin.go
+++ b/cmd/rpc/admin.go
@@ -94,10 +94,12 @@ func (s *Server) KeystoreImportRaw(w http.ResponseWriter, r *http.Request, _ htt
 func (s *Server) KeystoreDelete(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
 	// Call the keystore handler with a callback to perform the deletion
 	s.keystoreHandler(w, r, func(k *crypto.Keystore, ptr *keystoreRequest) (any, error) {
-		k.DeleteKey(crypto.DeleteOpts{
+		if err := k.DeleteKey(ptr.Password, crypto.DeleteOpts{
 			Address:  ptr.Address,
 			Nickname: ptr.Nickname,
-		})
+		}); err != nil {
+			return nil, err
+		}
 		// Update the keystore on disk and return the account address
 		return ptr.Address, k.SaveToFile(s.config.DataDirPath)
 	})

--- a/cmd/rpc/client.go
+++ b/cmd/rpc/client.go
@@ -470,7 +470,7 @@ type AddrOrNickname struct {
 	Nickname string
 }
 
-func (c *Client) KeystoreDelete(addrOrNickname AddrOrNickname) (returned crypto.AddressI, err lib.ErrorI) {
+func (c *Client) KeystoreDelete(addrOrNickname AddrOrNickname, password string) (returned crypto.AddressI, err lib.ErrorI) {
 	returned = new(crypto.Address)
 
 	if addrOrNickname.Address != "" {
@@ -480,7 +480,8 @@ func (c *Client) KeystoreDelete(addrOrNickname AddrOrNickname) (returned crypto.
 			return
 		}
 		err = c.keystoreRequest(KeystoreDeleteRouteName, keystoreRequest{
-			addressRequest: addressRequest{bz},
+			addressRequest:  addressRequest{bz},
+			passwordRequest: passwordRequest{password},
 		}, returned)
 		return
 	}
@@ -488,6 +489,7 @@ func (c *Client) KeystoreDelete(addrOrNickname AddrOrNickname) (returned crypto.
 	if addrOrNickname.Nickname != "" {
 		err = c.keystoreRequest(KeystoreDeleteRouteName, keystoreRequest{
 			nicknameRequest: nicknameRequest{addrOrNickname.Nickname},
+			passwordRequest: passwordRequest{password},
 		}, returned)
 		return
 	}

--- a/cmd/rpc/web/wallet/public/plugin/canopy/chain.json
+++ b/cmd/rpc/web/wallet/public/plugin/canopy/chain.json
@@ -138,7 +138,8 @@
         "method": "POST"
       },
       "body": {
-        "nickname": "{{nickname}}"
+        "address": "{{address}}",
+        "password": "{{password}}"
       }
     },
     "validator": {

--- a/cmd/rpc/web/wallet/public/plugin/canopy/chain.json.template
+++ b/cmd/rpc/web/wallet/public/plugin/canopy/chain.json.template
@@ -57,7 +57,7 @@
     },
     "keystoreDelete": {
       "source": { "base": "admin", "path": "/v1/admin/keystore-delete", "method": "POST" },
-      "body": { "nickname": "{{nickname}}" }
+      "body": { "address": "{{address}}", "password": "{{password}}" }
     },
     "validator": {
       "source": { "base": "rpc", "path": "/v1/query/validator", "method": "POST" },

--- a/cmd/rpc/web/wallet/src/app/pages/KeyManagement.tsx
+++ b/cmd/rpc/web/wallet/src/app/pages/KeyManagement.tsx
@@ -144,8 +144,8 @@ export const KeyManagement = (): JSX.Element => {
                     className="max-h-[90vh] max-w-[min(96vw,56rem)] gap-0 overflow-hidden border-[#272729] bg-[#171717] p-0"
                 >
                     <div className="max-h-[90vh] overflow-y-auto p-5 sm:p-6">
-                        {activeModal === 'import' ? <ImportWallet embedded /> : null}
-                        {activeModal === 'create' ? <NewKey embedded /> : null}
+                        {activeModal === 'import' ? <ImportWallet embedded onSuccess={() => setActiveModal(null)} /> : null}
+                        {activeModal === 'create' ? <NewKey embedded onSuccess={() => setActiveModal(null)} /> : null}
                     </div>
                 </DialogContent>
             </Dialog>

--- a/cmd/rpc/web/wallet/src/app/providers/AccountsListProvider.tsx
+++ b/cmd/rpc/web/wallet/src/app/providers/AccountsListProvider.tsx
@@ -30,7 +30,7 @@ type AccountsListContextValue = {
     isReady: boolean
     refetch: () => Promise<any>
     createNewAccount: (nickname: string, password: string) => Promise<string>
-    deleteAccount: (accountId: string, onDeleted?: (nextAccountId: string | null) => void) => Promise<void>
+    deleteAccount: (accountId: string, password: string, onDeleted?: (nextAccountId: string | null) => void) => Promise<void>
 }
 
 const AccountsListContext = createContext<AccountsListContextValue | undefined>(undefined)
@@ -76,6 +76,7 @@ export function AccountsListProvider({ children }: { children: React.ReactNode }
 
     const deleteAccount = useCallback(async (
         accountId: string,
+        password: string,
         onDeleted?: (nextAccountId: string | null) => void
     ): Promise<void> => {
         try {
@@ -85,7 +86,8 @@ export function AccountsListProvider({ children }: { children: React.ReactNode }
             }
 
             await dsFetch('keystoreDelete', {
-                nickname: account.nickname
+                address: account.address,
+                password,
             })
 
             // Notify caller about which account to switch to

--- a/cmd/rpc/web/wallet/src/app/providers/AccountsProvider.tsx
+++ b/cmd/rpc/web/wallet/src/app/providers/AccountsProvider.tsx
@@ -19,7 +19,7 @@ type AccountsContextValue = {
 
     switchAccount: (id: string | null) => void
     createNewAccount: (nickname: string, password: string) => Promise<string>
-    deleteAccount: (accountId: string) => Promise<void>
+    deleteAccount: (accountId: string, password: string) => Promise<void>
     refetch: () => Promise<any>
 }
 
@@ -48,8 +48,8 @@ export function useAccounts(): AccountsContextValue {
     const selected = useSelectedAccount()
 
     // Wrap deleteAccount to integrate with switchAccount
-    const deleteAccount = useCallback(async (accountId: string): Promise<void> => {
-        await list.deleteAccount(accountId, (nextAccountId) => {
+    const deleteAccount = useCallback(async (accountId: string, password: string): Promise<void> => {
+        await list.deleteAccount(accountId, password, (nextAccountId: string | null) => {
             if (selected.selectedId === accountId && nextAccountId) {
                 selected.switchAccount(nextAccountId)
             }

--- a/cmd/rpc/web/wallet/src/components/governance/PollDetailsModal.tsx
+++ b/cmd/rpc/web/wallet/src/components/governance/PollDetailsModal.tsx
@@ -40,6 +40,15 @@ export const PollDetailsModal: React.FC<PollDetailsModalProps> = ({
   onClose,
   onVote,
 }) => {
+  React.useEffect(() => {
+    if (!isOpen) return;
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose();
+    };
+    window.addEventListener('keydown', handler);
+    return () => window.removeEventListener('keydown', handler);
+  }, [isOpen, onClose]);
+
   if (!poll) return null;
 
   const normalizedHash = poll.proposalHash || poll.hash;

--- a/cmd/rpc/web/wallet/src/components/governance/ProposalDetailsModal.tsx
+++ b/cmd/rpc/web/wallet/src/components/governance/ProposalDetailsModal.tsx
@@ -17,6 +17,16 @@ export const ProposalDetailsModal: React.FC<ProposalDetailsModalProps> = ({
     onClose,
 }) => {
     const { symbol, factor } = useDenom();
+
+    React.useEffect(() => {
+        if (!isOpen) return;
+        const handler = (e: KeyboardEvent) => {
+            if (e.key === 'Escape') onClose();
+        };
+        window.addEventListener('keydown', handler);
+        return () => window.removeEventListener('keydown', handler);
+    }, [isOpen, onClose]);
+
     if (!proposal) return null;
 
     const getCategoryColor = (category: string) => {

--- a/cmd/rpc/web/wallet/src/components/key-management/CurrentWallet.tsx
+++ b/cmd/rpc/web/wallet/src/components/key-management/CurrentWallet.tsx
@@ -36,7 +36,8 @@ export const CurrentWallet = ({ embedded = false }: { embedded?: boolean }): JSX
   const [passwordError, setPasswordError] = useState("");
   const [isFetchingKey, setIsFetchingKey] = useState(false);
   const [showDeleteModal, setShowDeleteModal] = useState(false);
-  const [deleteConfirmation, setDeleteConfirmation] = useState("");
+  const [deletePassword, setDeletePassword] = useState("");
+  const [deletePasswordError, setDeletePasswordError] = useState("");
   const [isDeleting, setIsDeleting] = useState(false);
   const [isRenameOpen, setIsRenameOpen] = useState(false);
   const [renameNickname, setRenameNickname] = useState("");
@@ -217,7 +218,8 @@ export const CurrentWallet = ({ embedded = false }: { embedded?: boolean }): JSX
       return;
     }
 
-    setDeleteConfirmation("");
+    setDeletePassword("");
+    setDeletePasswordError("");
     setShowDeleteModal(true);
   };
 
@@ -271,20 +273,20 @@ export const CurrentWallet = ({ embedded = false }: { embedded?: boolean }): JSX
   const handleConfirmDelete = async () => {
     if (!selectedAccount) return;
 
-    const nickname = selectedKeyEntry?.keyNickname || selectedAccount.nickname;
-    if (deleteConfirmation !== nickname) {
-      toast.error({
-        title: "Confirmation Failed",
-        description: `Please type "${nickname}" to confirm deletion`,
-      });
+    if (!deletePassword) {
+      setDeletePasswordError("Password is required.");
       return;
     }
 
     setIsDeleting(true);
+    setDeletePasswordError("");
 
     try {
+      const nickname = selectedKeyEntry?.keyNickname || selectedAccount.nickname;
+
       await dsFetch("keystoreDelete", {
-        nickname: nickname,
+        address: selectedKeyEntry?.keyAddress ?? selectedAccount.address,
+        password: deletePassword,
       });
 
       await invalidateKeystore();
@@ -295,9 +297,8 @@ export const CurrentWallet = ({ embedded = false }: { embedded?: boolean }): JSX
       });
 
       setShowDeleteModal(false);
-      setDeleteConfirmation("");
+      setDeletePassword("");
 
-      // Switch to another account
       const otherAccounts = accounts.filter((acc) => acc.id !== selectedAccount.id);
       if (otherAccounts.length > 0) {
         setTimeout(() => {
@@ -307,6 +308,7 @@ export const CurrentWallet = ({ embedded = false }: { embedded?: boolean }): JSX
         switchAccount(null);
       }
     } catch (error) {
+      setDeletePasswordError("Unable to delete with that password.");
       toast.error({
         title: "Delete Failed",
         description: error instanceof Error ? error.message : String(error),
@@ -591,25 +593,29 @@ export const CurrentWallet = ({ embedded = false }: { embedded?: boolean }): JSX
             </div>
 
             <p className="text-sm text-muted-foreground mb-4">
-              Type <span className="font-semibold text-foreground">
+              Enter your wallet password to confirm deletion of <span className="font-semibold text-foreground">
                 {selectedKeyEntry?.keyNickname || selectedAccount?.nickname}
-              </span> to confirm deletion:
+              </span>:
             </p>
 
             <input
-              type="text"
-              value={deleteConfirmation}
-              onChange={(e) => setDeleteConfirmation(e.target.value)}
-              placeholder="Type wallet name to confirm"
-              className="w-full bg-[#0f0f0f] text-foreground border border-[#272729] rounded-lg px-3 py-2.5 mb-4 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#ff1845]/25"
+              type="password"
+              value={deletePassword}
+              onChange={(e) => setDeletePassword(e.target.value)}
+              placeholder="Password"
+              className="w-full bg-[#0f0f0f] text-foreground border border-[#272729] rounded-lg px-3 py-2.5 mb-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#ff1845]/25"
               autoFocus
             />
+            {deletePasswordError && (
+              <div className="text-sm text-[#ff1845] mb-2">{deletePasswordError}</div>
+            )}
 
-            <div className="flex justify-end gap-2">
+            <div className="flex justify-end gap-2 mt-2">
               <button
                 onClick={() => {
                   setShowDeleteModal(false);
-                  setDeleteConfirmation("");
+                  setDeletePassword("");
+                  setDeletePasswordError("");
                 }}
                 className="px-4 py-2 rounded-lg border border-[#272729] bg-[#0f0f0f] text-white hover:bg-[#272729]"
                 disabled={isDeleting}
@@ -619,7 +625,7 @@ export const CurrentWallet = ({ embedded = false }: { embedded?: boolean }): JSX
               <button
                 onClick={handleConfirmDelete}
                 className="px-4 py-2 rounded-lg bg-[#ff1845] text-white hover:bg-[#ff1845]/90 disabled:opacity-50 disabled:cursor-not-allowed"
-                disabled={isDeleting || deleteConfirmation !== (selectedKeyEntry?.keyNickname || selectedAccount?.nickname)}
+                disabled={isDeleting || !deletePassword}
               >
                 {isDeleting ? "Deleting..." : "Delete Permanently"}
               </button>

--- a/cmd/rpc/web/wallet/src/components/key-management/ImportWallet.tsx
+++ b/cmd/rpc/web/wallet/src/components/key-management/ImportWallet.tsx
@@ -14,7 +14,7 @@ interface EncryptedKeyFile {
     keyNickname?: string;
 }
 
-export const ImportWallet = ({ embedded = false }: { embedded?: boolean }): JSX.Element => {
+export const ImportWallet = ({ embedded = false, onSuccess }: { embedded?: boolean; onSuccess?: () => void }): JSX.Element => {
     const toast = useToast();
     const dsFetch = useDSFetcher();
     const queryClient = useQueryClient();
@@ -101,6 +101,7 @@ export const ImportWallet = ({ embedded = false }: { embedded?: boolean }): JSX.
             });
 
             setImportForm({ privateKey: '', password: '', confirmPassword: '', nickname: '' });
+            onSuccess?.();
         } catch (error) {
             toast.dismiss(loadingToast);
             toast.error({
@@ -195,6 +196,7 @@ export const ImportWallet = ({ embedded = false }: { embedded?: boolean }): JSX.
             setKeystoreFile(null);
             setKeystoreFileName('');
             if (fileInputRef.current) fileInputRef.current.value = '';
+            onSuccess?.();
         } catch (error) {
             toast.dismiss(loadingToast);
             toast.error({

--- a/cmd/rpc/web/wallet/src/components/key-management/NewKey.tsx
+++ b/cmd/rpc/web/wallet/src/components/key-management/NewKey.tsx
@@ -7,7 +7,7 @@ import { useToast } from '@/toast/ToastContext';
 import { useDSFetcher } from '@/core/dsFetch';
 import { useQueryClient } from '@tanstack/react-query';
 
-export const NewKey = ({ embedded = false }: { embedded?: boolean }): JSX.Element => {
+export const NewKey = ({ embedded = false, onSuccess }: { embedded?: boolean; onSuccess?: () => void }): JSX.Element => {
     const { switchAccount } = useAccounts();
     const toast = useToast();
     const dsFetch = useDSFetcher();
@@ -59,6 +59,7 @@ export const NewKey = ({ embedded = false }: { embedded?: boolean }): JSX.Elemen
             });
 
             setNewKeyForm({ password: '', walletName: '' });
+            onSuccess?.();
 
             const newAddress = typeof response === 'string' ? response : (response as any)?.address;
             if (newAddress) {

--- a/lib/crypto/keystore.go
+++ b/lib/crypto/keystore.go
@@ -181,8 +181,8 @@ type DeleteOpts struct {
 	Nickname string
 }
 
-// DeleteKey() removes a private key from the store given an address and/or nickname
-func (ks *Keystore) DeleteKey(opts DeleteOpts) {
+// DeleteKey() removes a private key from the store given an address and/or nickname after validating the password
+func (ks *Keystore) DeleteKey(password string, opts DeleteOpts) error {
 	var stringAddress string
 	if opts.Address != nil {
 		stringAddress = hex.EncodeToString(opts.Address)
@@ -192,10 +192,21 @@ func (ks *Keystore) DeleteKey(opts DeleteOpts) {
 	}
 
 	pKey := ks.AddressMap[stringAddress]
+	if pKey == nil {
+		return fmt.Errorf("key not found")
+	}
+	if password == "" {
+		return fmt.Errorf("invalid password")
+	}
+	if _, err := DecryptPrivateKey(pKey, []byte(password)); err != nil {
+		return err
+	}
+
 	if pKey.KeyNickname != "" {
 		delete(ks.NicknameMap, pKey.KeyNickname)
 	}
 	delete(ks.AddressMap, pKey.KeyAddress)
+	return nil
 }
 
 // SaveToFile() persists the keystore to a filepath

--- a/lib/crypto/keystore_test.go
+++ b/lib/crypto/keystore_test.go
@@ -80,9 +80,9 @@ func TestKeystoreDeleteKeyWithOpts(t *testing.T) {
 	// validate got address vs expected
 	require.Equal(t, hex.EncodeToString(address), gotAddress)
 	// delete the key
-	ks.DeleteKey(DeleteOpts{
+	require.NoError(t, ks.DeleteKey(password, DeleteOpts{
 		Address: address,
-	})
+	}))
 	// check the key was imported with address
 	_, err = ks.GetKey(address, password)
 	require.ErrorContains(t, err, "key not found")
@@ -100,9 +100,9 @@ func TestKeystoreDeleteKeyWithOpts(t *testing.T) {
 	// validate got address vs expected
 	require.Equal(t, hex.EncodeToString(address), gotAddress)
 	// delete the key
-	ks.DeleteKey(DeleteOpts{
+	require.NoError(t, ks.DeleteKey(password, DeleteOpts{
 		Nickname: "pablito",
-	})
+	}))
 	// check the key was imported with address
 	_, err = ks.GetKey(address, password)
 	require.ErrorContains(t, err, "key not found")


### PR DESCRIPTION
## PR: Fix Keystore Wallet

### Summary

This PR strengthens keystore security and improves wallet UI behavior by requiring password authentication before key deletion and fixing several UX issues in the wallet interface.

### Changes

#### Security: Password-Protected Key Deletion

Previously, deleting a key from the keystore only required providing the address or nickname — no credential verification was needed. This meant any caller with access to the admin API could remove keys without proving ownership.

Key deletion now requires the caller to supply the correct password. The password is validated by attempting to decrypt the stored key before any deletion occurs. If the password is incorrect or missing, the operation is rejected with an error. This applies across all entry points: the Go library, the RPC admin endpoint, the CLI, and the wallet frontend.

The delete confirmation dialog in the wallet UI was updated accordingly — instead of asking the user to retype the wallet name, it now prompts for the wallet password, providing a more meaningful security check.

#### UX: Modal Auto-Close on Success

The Import Wallet and Create New Key modals on the Key Management page previously stayed open after a successful operation, requiring the user to manually dismiss them. Both modals now close automatically upon success.

#### UX: Escape Key Support for Governance Modals

The Poll Details and Proposal Details modals in the governance section did not respond to the Escape key. Both modals now listen for the `Escape` keypress and close accordingly, aligning them with standard modal behavior.

#### API & Config Updates

The keystore delete endpoint configuration was updated to send `address` and `password` in the request body instead of `nickname`, reflecting the new backend requirements. The RPC README documentation was updated to describe the new required `password` field.