### PR TITLE
feat(cli): add --rpc-url/--admin-url flags and fix --data-dir targeting

### DIFF
--- a/cmd/cli/cli.go
+++ b/cmd/cli/cli.go
@@ -29,6 +29,16 @@ import (
 var rootCmd = &cobra.Command{
 	Use:   "canopy",
 	Short: "the canopy blockchain software",
+	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+		config, validatorKey = InitializeDataDirectory(DataDir, lib.NewDefaultLogger())
+		l = lib.NewLogger(lib.LoggerConfig{
+			Level:      config.GetLogLevel(),
+			Structured: config.Structured,
+			JSON:       config.JSON,
+		})
+		client = rpc.NewClient(config.RPCUrl, config.AdminRPCUrl)
+		return nil
+	},
 }
 
 var versionCmd = &cobra.Command{
@@ -54,13 +64,6 @@ func init() {
 	autoCompleteCmd.AddCommand(generateCompleteCmd)
 	autoCompleteCmd.AddCommand(autoCompleteInstallCmd)
 	rootCmd.PersistentFlags().StringVar(&DataDir, "data-dir", lib.DefaultDataDirPath(), "custom data directory location")
-	config, validatorKey = InitializeDataDirectory(DataDir, lib.NewDefaultLogger())
-	l = lib.NewLogger(lib.LoggerConfig{
-		Level:      config.GetLogLevel(),
-		Structured: config.Structured,
-		JSON:       config.JSON,
-	})
-	client = rpc.NewClient(config.RPCUrl, config.AdminRPCUrl)
 }
 
 func Execute() {

--- a/cmd/cli/cli.go
+++ b/cmd/cli/cli.go
@@ -36,6 +36,12 @@ var rootCmd = &cobra.Command{
 			Structured: config.Structured,
 			JSON:       config.JSON,
 		})
+		if rpcURLFlag != "" {
+			config.RPCUrl = rpcURLFlag
+		}
+		if adminURLFlag != "" {
+			config.AdminRPCUrl = adminURLFlag
+		}
 		client = rpc.NewClient(config.RPCUrl, config.AdminRPCUrl)
 		return nil
 	},
@@ -50,8 +56,9 @@ var versionCmd = &cobra.Command{
 }
 
 var (
-	client, config, l     = &rpc.Client{}, lib.Config{}, lib.LoggerI(nil)
-	DataDir, validatorKey = "", crypto.PrivateKeyI(nil)
+	client, config, l          = &rpc.Client{}, lib.Config{}, lib.LoggerI(nil)
+	DataDir, validatorKey      = "", crypto.PrivateKeyI(nil)
+	rpcURLFlag, adminURLFlag   string
 )
 
 func init() {
@@ -64,6 +71,8 @@ func init() {
 	autoCompleteCmd.AddCommand(generateCompleteCmd)
 	autoCompleteCmd.AddCommand(autoCompleteInstallCmd)
 	rootCmd.PersistentFlags().StringVar(&DataDir, "data-dir", lib.DefaultDataDirPath(), "custom data directory location")
+	rootCmd.PersistentFlags().StringVar(&rpcURLFlag, "rpc-url", "", "override the RPC URL from config")
+	rootCmd.PersistentFlags().StringVar(&adminURLFlag, "admin-url", "", "override the admin RPC URL from config")
 }
 
 func Execute() {

--- a/cmd/rpc/client.go
+++ b/cmd/rpc/client.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"time"
 
 	"github.com/canopy-network/canopy/fsm"
 
@@ -23,7 +24,7 @@ type Client struct {
 }
 
 func NewClient(rpcURL, adminRPCUrl string) *Client {
-	return &Client{rpcURL: rpcURL, adminRpcUrl: adminRPCUrl, client: http.Client{}}
+	return &Client{rpcURL: rpcURL, adminRpcUrl: adminRPCUrl, client: http.Client{Timeout: 10 * time.Second}}
 }
 
 func (c *Client) Version() (version *string, err lib.ErrorI) {

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,8 @@ module github.com/canopy-network/canopy
 
 go 1.24.0
 
+toolchain go1.25.3
+
 require (
 	filippo.io/edwards25519 v1.1.0
 	github.com/alecthomas/units v0.0.0-20240927000941-0f3dac36c52b


### PR DESCRIPTION
## Summary

- Fix `--data-dir` flag being ignored: moved initialization from `init()` to `PersistentPreRunE` so flags are parsed before config loads
- Add `--rpc-url` and `--admin-url` flags to override node URLs from config at runtime

## Test plan

- [ ] `canopy --data-dir /custom/path <cmd>` uses the specified directory
- [ ] `canopy --rpc-url http://localhost:9000 <cmd>` overrides config RPC URL
- [ ] `canopy --admin-url http://localhost:9001 <cmd>` overrides config admin URL
- [ ] Default behavior unchanged when flags are omitted