### PR TITLE
docs: fix contributing links and branch guidance

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,7 +19,7 @@ We always appreciate a well-written, thorough bug report. :v:
 In short, since you are most likely a developer, **provide a ticket that you would like to
 receive**.
 
-- **Review the [documentation](TODO) before opening a new issue.
+- **Review the [documentation](https://canopy-network.gitbook.io/docs) before opening a new issue.**
 
 - **Do not open a duplicate issue.** Search through existing issues to see if your issue has
   previously been reported. If your issue exists, comment with any additional information you have.
@@ -62,7 +62,7 @@ discuss your intended approach for solving the problem in the comments for an ex
 
 - **Coordinate bigger changes.** For large and non-trivial changes, open an issue to discuss a
   strategy with the maintainers. Or better yet, contact us directly on our
-  [Discord](https://discord.gg/your-discord-link). Otherwise, you risk doing a lot of work for
+  [Discord](https://discord.gg/pNcSJj7Wdh). Otherwise, you risk doing a lot of work for
   nothing!
 
 - **Prioritize understanding over cleverness.** Write code clearly and concisely. Remember that
@@ -121,9 +121,8 @@ Key requirements:
   - Example: `// Transaction represents a single blockchain transaction.`
 
 - **Branch Strategy**: All pull requests should be:
-  - Based on the `development` branch
-  - Opened against the `development` branch
-  - Merged into `development` first before being promoted to `main`
+  - Based on the `main` branch
+  - Opened against the `main` branch
 
 - **EditorConfig Support**: We recommend using EditorConfig to maintain consistent coding styles.
   The project includes an `.editorconfig` file that defines common formatting rules.

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ make test
 - Code must adhere to official Go formatting (use [`gofmt`](https://golang.org/cmd/gofmt)).
 - (Optional) Use [EditorConfig](https://editorconfig.org) for consistent formatting.
 - All code should follow Go documentation/commentary guidelines.
-- PRs should be opened against the `development` branch.
+- PRs should be opened against the `main` branch.
 
 [![Pre-Release](https://img.shields.io/github/release-pre/canopy-network/canopy.svg)](https://github.com/canopy-network/canopy/releases)
 [![Go Report Card](https://goreportcard.com/badge/github.com/canopy-network/canopy)](https://goreportcard.com/report/github.com/canopy-network/canopy)


### PR DESCRIPTION
## Description
Fix stale and placeholder links in the contribution docs, and align branch guidance with the repository's default branch.

## Changes Made
- Replace the TODO documentation link with the official Canopy docs URL
- Replace the placeholder Discord link with the active invite already used elsewhere in the docs
- Update README and CONTRIBUTING branch guidance from development to main

## Testing
- Documentation-only change
- Verified the repository default branch is main
- Verified the development branch is not present via GitHub API