### PR TITLE
Added Low Spec Hardware Optimization Guide

### DIFF
--- a/LOW_SPEC_GUIDE.md
+++ b/LOW_SPEC_GUIDE.md
@@ -1,0 +1,6 @@
+# Canopy Node: Low Spec Optimization
+Tips for running a node on legacy hardware (like AMD FX series):
+- Use an SSD (Samsung 860 EVO recommended).
+- Disable Windows Fast Boot in BIOS.
+- Monitor CPU temps (Target < 65°C).
+- Stop Windows Updates to prevent loops.


### PR DESCRIPTION
I've been stress-testing a validator node on legacy hardware (AMD FX-6300). This PR adds a "Low Spec Optimization Guide" to help users maintain uptime on older builds, covering BIOS, SSD, and OS stability.