### PR TITLE
feat: implement block subscription and enhance polling mechanisms for improved dashboard updates

### DIFF
--- a/cmd/rpc/web/explorer/env.example
+++ b/cmd/rpc/web/explorer/env.example
@@ -18,3 +18,13 @@ VITE_PUBLIC_ADMIN_RPC_URL=https://node1.canopy.us.nodefleet.net/admin/
 
 # Environment mode (development, production)
 VITE_NODE_ENV=development
+
+# Block polling interval in ms (default 2000, minimum 500).
+# A simple explorer/wallet or private deployment can keep the 2s default to
+# reduce node load; lower it (e.g. 1000) for snappier dashboard updates.
+# VITE_BLOCKS_POLL_MS=2000
+
+# Dev-only: upstream targets for the Vite proxy (/rpc-node1, /admin-node1).
+# Defaults to VITE_PUBLIC_RPC_URL / VITE_PUBLIC_ADMIN_RPC_URL when unset.
+# VITE_DEV_RPC_PROXY=http://localhost:50002
+# VITE_DEV_ADMIN_PROXY=http://localhost:50003

--- a/cmd/rpc/web/explorer/src/App.tsx
+++ b/cmd/rpc/web/explorer/src/App.tsx
@@ -16,12 +16,14 @@ import DexBatchesPage from './components/dex/DexBatchesPage'
 import StakingPage from './components/staking/StakingPage'
 import GovernancePage from './components/staking/GovernancePage'
 import SupplyPage from './components/staking/SupplyPage'
-import { useNetworkChangeHandler } from './hooks/useApi'
+import { useNetworkChangeHandler, useBlockSubscription } from './hooks/useApi'
 import ExplorerLayout from './components/layouts/ExplorerLayout'
 
 function App() {
   // Handle network changes and invalidate queries
   useNetworkChangeHandler();
+  // Detect new blocks globally and refresh dashboard queries on chain growth
+  useBlockSubscription();
 
   return (
     <Router>

--- a/cmd/rpc/web/explorer/src/hooks/useApi.ts
+++ b/cmd/rpc/web/explorer/src/hooks/useApi.ts
@@ -66,18 +66,91 @@ export const queryKeys = {
     tableData: (page: number, category: number, committee?: number) => ['tableData', page, category, committee],
 };
 
-const BLOCKS_POLL_MS = 3000;
+const BLOCKS_POLL_MS = 1000;
 
-// Lightweight hook for the latest block height (polls every 3s)
+// Backoff helper: when a polling query keeps failing, slow it down so we
+// don't hammer a degraded RPC node (and so we don't flood the browser
+// console with one [Error] line per request — those are emitted natively
+// by the browser for every 4xx/5xx and can't be silenced from JS).
+const errorAwareInterval = (baseMs: number, maxMs: number = 60000) =>
+    (query: { state: { error: unknown; fetchFailureCount: number } }) => {
+        const fails = query.state.fetchFailureCount || 0;
+        if (!query.state.error || fails <= 0) return baseMs;
+        return Math.min(baseMs * Math.pow(2, fails), maxMs);
+    };
+
+// Lightweight hook for the latest block height (polls every 3s, with backoff
+// on errors so a degraded RPC node doesn't spam the console).
 export const useLatestBlock = () => {
     return useQuery({
         queryKey: ['latestBlock'],
         queryFn: () => Blocks(1, 0),
         staleTime: 0,
-        refetchInterval: BLOCKS_POLL_MS,
+        refetchInterval: errorAwareInterval(BLOCKS_POLL_MS),
+        refetchIntervalInBackground: true,
         refetchOnWindowFocus: true,
+        refetchOnReconnect: true,
         refetchOnMount: 'always',
+        retry: false,
     });
+};
+
+// Extracts the height of the most recent block from a Blocks(1,0) response.
+const extractLatestBlockHeight = (payload: any): number => {
+    if (!payload) return 0;
+    const totalCount = payload?.totalCount ?? payload?.count;
+    if (typeof totalCount === 'number' && totalCount > 0) return totalCount;
+    const list = payload?.results || payload?.blocks || payload?.list || payload?.data;
+    const first = Array.isArray(list) && list.length > 0 ? list[0] : null;
+    return Number(first?.blockHeader?.height ?? first?.height ?? 0) || 0;
+};
+
+// Queries that must refresh whenever a new block is produced. Adding a key here
+// makes that query participate in the global "new block" invalidation pulse.
+const BLOCK_DEPENDENT_QUERY_KEYS: Array<readonly unknown[]> = [
+    ['cardData'],
+    ['allBlocksCache'],
+    ['blocks'],
+    ['recentTransactionsPreview'],
+    ['realPaginationTransactions'],
+    ['allTransactions'],
+    ['transactions'],
+    ['txsByHeight'],
+    ['pending'],
+    ['all-validators'],
+    ['all-delegators'],
+    ['validators'],
+    ['validatorsWithFilters'],
+    ['supply'],
+    ['orders'],
+    ['dexBatch'],
+    ['nextDexBatch'],
+];
+
+// Global subscription: polls the latest block height and, whenever it changes,
+// invalidates every dashboard-facing query so the UI reflects the new chain
+// state without requiring a manual page refresh.
+export const useBlockSubscription = () => {
+    const queryClient = useQueryClient();
+    const { data } = useLatestBlock();
+    const lastHeightRef = React.useRef<number>(0);
+
+    React.useEffect(() => {
+        const height = extractLatestBlockHeight(data);
+        if (height <= 0) return;
+        if (lastHeightRef.current === height) return;
+
+        const previousHeight = lastHeightRef.current;
+        lastHeightRef.current = height;
+
+        // Skip invalidation on the very first observation; queries are already
+        // fetching their initial data and we want to avoid a redundant burst.
+        if (previousHeight === 0) return;
+
+        BLOCK_DEPENDENT_QUERY_KEYS.forEach((key) => {
+            queryClient.invalidateQueries({ queryKey: key });
+        });
+    }, [data, queryClient]);
 };
 
 // Hooks for Blocks
@@ -163,11 +236,12 @@ export const useRecentTransactionsPreview = (blocks: any[] | undefined, limit: n
         queryKey: ['recentTransactionsPreview', latestBlockHeight, limit],
         queryFn: () => getRecentTransactionsPreview(limit, blocks),
         staleTime: 5000,
-        refetchInterval: 10000,
+        refetchInterval: errorAwareInterval(10000),
         refetchOnWindowFocus: true,
         refetchOnMount: 'always',
         enabled: Array.isArray(blocks) && blocks.length > 0,
         placeholderData: (previousData) => previousData,
+        retry: false,
     });
 };
 
@@ -442,10 +516,11 @@ export const useCardData = () => {
             return getCardData(previousCardData);
         },
         staleTime: 0,
-        refetchInterval: BLOCKS_POLL_MS,
+        refetchInterval: errorAwareInterval(BLOCKS_POLL_MS),
         refetchOnWindowFocus: true,
         refetchOnMount: 'always',
         placeholderData: (previousData) => previousData,
+        retry: false,
     });
 };
 
@@ -458,79 +533,49 @@ export const useTableData = (page: number, category: number, committee?: number)
     });
 };
 
-// Hook to load all blocks once and reuse the data
+// Hook to load the most recent block page and reuse the data across the app.
+// Previously this fanned out 10 parallel page fetches every 10s; with a
+// degraded upstream that produced 10 browser-emitted error lines per poll.
+// One page (10 blocks) is enough for Home, Navbar, and the dashboard tables.
 export const useAllBlocksCache = () => {
     return useQuery({
         queryKey: ['allBlocksCache'],
         queryFn: async () => {
-            const allBlocks: any[] = [];
-            const perPage = 10; // Max blocks per page from API
-            const maxPages = 10; // Maximum 10 pages (100 blocks)
+            const response = await fetch(`${rpcURL}/v1/query/blocks`, {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ perPage: 10, pageNumber: 1 }),
+            });
 
-            // Make only the required requests
-            const requests = [];
-            for (let page = 1; page <= maxPages; page++) {
-                requests.push(
-                    fetch(`${rpcURL}/v1/query/blocks`, {
-                        method: 'POST',
-                        headers: {
-                            'Content-Type': 'application/json',
-                        },
-                        body: JSON.stringify({
-                            perPage: perPage,
-                            pageNumber: page,
-                        }),
-                    })
-                );
+            if (!response.ok) {
+                throw new Error(`blocks RPC returned ${response.status}`);
             }
 
-            try {
-                // Keep updates resilient: one failed page should not freeze navbar/dashboard.
-                const settled = await Promise.allSettled(requests);
+            const data = await response.json();
+            const blocks: any[] = Array.isArray(data?.results) ? [...data.results] : [];
 
-                for (let i = 0; i < settled.length; i++) {
-                    const result = settled[i];
-                    if (result.status !== 'fulfilled') {
-                        console.error(`Failed to fetch blocks page ${i + 1}: request rejected`);
-                        continue;
-                    }
+            // Keep newest block first for Navbar and Home blocks table.
+            blocks.sort((a: any, b: any) => {
+                const ah = Number((a?.blockHeader?.height ?? a?.height) || 0);
+                const bh = Number((b?.blockHeader?.height ?? b?.height) || 0);
+                return bh - ah;
+            });
 
-                    const response = result.value;
-                    if (!response.ok) {
-                        console.error(`Failed to fetch blocks page ${i + 1}: status ${response.status}`);
-                        continue;
-                    }
-
-                    const data = await response.json();
-                    if (data.results && Array.isArray(data.results)) {
-                        allBlocks.push(...data.results);
-                    }
-                    if (typeof data.totalCount === 'number') {
-                        (allBlocks as any).totalCount = data.totalCount;
-                    }
-                }
-
-                // Always keep newest block first for Navbar and Home blocks table.
-                allBlocks.sort((a: any, b: any) => {
-                    const ah = Number((a?.blockHeader?.height ?? a?.height) || 0);
-                    const bh = Number((b?.blockHeader?.height ?? b?.height) || 0);
-                    return bh - ah;
-                });
-
-                if (allBlocks.length === 0) {
-                    throw new Error('No blocks fetched from RPC');
-                }
-
-                return allBlocks;
-            } catch (error: any) {
-                console.error(`Error fetching blocks:`, error);
-                throw new Error(`Error fetching blocks: ${error.message}`);
+            if (typeof data?.totalCount === 'number') {
+                (blocks as any).totalCount = data.totalCount;
             }
+
+            if (blocks.length === 0) {
+                throw new Error('No blocks returned from RPC');
+            }
+
+            return blocks;
         },
         staleTime: 5000,
-        refetchInterval: 10000,
+        refetchInterval: errorAwareInterval(10000),
         refetchOnWindowFocus: true,
         refetchOnMount: 'always',
+        retry: false,
     });
 };
 
@@ -704,8 +749,6 @@ export const useNetworkChangeHandler = () => {
 
     React.useEffect(() => {
         const handleApiConfigChange = (event: any) => {
-            console.log('🔄 Network changed, invalidating queries...', event.detail);
-
             // Invalidate specific queries that depend on network data
             queryClient.invalidateQueries({ queryKey: ['cardData'] });
             queryClient.invalidateQueries({ queryKey: ['blocks'] });

--- a/cmd/rpc/web/explorer/src/hooks/useApi.ts
+++ b/cmd/rpc/web/explorer/src/hooks/useApi.ts
@@ -66,7 +66,17 @@ export const queryKeys = {
     tableData: (page: number, category: number, committee?: number) => ['tableData', page, category, committee],
 };
 
-const BLOCKS_POLL_MS = 1000;
+// Block polling interval (ms). Defaults to 2s so a plain explorer/wallet —
+// especially a simple private deployment — doesn't poll the node aggressively.
+// Override with VITE_BLOCKS_POLL_MS in the environment for snappier updates.
+const DEFAULT_BLOCKS_POLL_MS = 2000;
+const MIN_BLOCKS_POLL_MS = 500;
+const BLOCKS_POLL_MS = (() => {
+    const raw = Number(import.meta.env.VITE_BLOCKS_POLL_MS);
+    return Number.isFinite(raw) && raw > 0
+        ? Math.max(MIN_BLOCKS_POLL_MS, raw)
+        : DEFAULT_BLOCKS_POLL_MS;
+})();
 
 // Backoff helper: when a polling query keeps failing, slow it down so we
 // don't hammer a degraded RPC node (and so we don't flood the browser
@@ -79,8 +89,8 @@ const errorAwareInterval = (baseMs: number, maxMs: number = 60000) =>
         return Math.min(baseMs * Math.pow(2, fails), maxMs);
     };
 
-// Lightweight hook for the latest block height (polls every 3s, with backoff
-// on errors so a degraded RPC node doesn't spam the console).
+// Lightweight hook for the latest block height (polls every BLOCKS_POLL_MS,
+// with backoff on errors so a degraded RPC node doesn't spam the console).
 export const useLatestBlock = () => {
     return useQuery({
         queryKey: ['latestBlock'],

--- a/cmd/rpc/web/explorer/src/lib/api.ts
+++ b/cmd/rpc/web/explorer/src/lib/api.ts
@@ -41,8 +41,6 @@ const updateApiConfig = (newRpcURL: string, newAdminRPCURL: string, newChainId: 
     rpcURL = normalizeBaseURL(newRpcURL);
     adminRPCURL = normalizeBaseURL(newAdminRPCURL);
     chainId = newChainId;
-    console.log('API Config Updated:', { rpcURL, adminRPCURL, chainId });
-
     // Dispatch custom event for React Query invalidation
     if (typeof window !== 'undefined') {
         window.dispatchEvent(new CustomEvent('apiConfigChanged', {
@@ -51,26 +49,29 @@ const updateApiConfig = (newRpcURL: string, newAdminRPCURL: string, newChainId: 
     }
 };
 
-// Legacy support for window.__CONFIG__ (for backward compatibility)
 if (typeof window !== "undefined") {
     if (window.__CONFIG__) {
         rpcURL = normalizeBaseURL(window.__CONFIG__.rpcURL);
         adminRPCURL = normalizeBaseURL(window.__CONFIG__.adminRPCURL);
         chainId = Number(window.__CONFIG__.chainId);
-    }
-
-    // On Netlify deployment, use same-origin proxy paths to avoid browser CORS blocks.
-    if (window.location.hostname === "canopy.nodefleet.net") {
+    } else {
+        // Always use same-origin proxy paths. In production these are served
+        // by netlify.toml redirects; in dev they are served by the vite.config
+        // server.proxy entries. This avoids CORS preflight failures and
+        // missing /rpc path prefixes regardless of VITE_PUBLIC_RPC_URL.
         rpcURL = "/rpc-node1";
         adminRPCURL = "/admin-node1";
     }
 
-    // Replace localhost with current hostname for local development
+    const hostname = window.location.hostname;
+
+    // Replace localhost with current hostname for local development of a
+    // user-provided absolute URL (only applies when window.__CONFIG__ set it).
     if (rpcURL.includes("localhost")) {
-        rpcURL = rpcURL.replace("localhost", window.location.hostname);
+        rpcURL = rpcURL.replace("localhost", hostname);
     }
     if (adminRPCURL.includes("localhost")) {
-        adminRPCURL = adminRPCURL.replace("localhost", window.location.hostname);
+        adminRPCURL = adminRPCURL.replace("localhost", hostname);
     }
 
     // Listen for network changes
@@ -79,11 +80,6 @@ if (typeof window !== "undefined") {
         updateApiConfig(network.rpcUrl, network.adminRpcUrl, network.chainId);
     });
 
-    console.log('RPC URL:', rpcURL);
-    console.log('Admin RPC URL:', adminRPCURL);
-    console.log('Chain ID:', chainId);
-} else {
-    console.log("Running in SSR mode, using environment variables");
 }
 
 // RPC PATHS
@@ -128,10 +124,7 @@ export async function POST(url: string, request: string, path: string) {
             }
             return response.json();
         })
-        .catch((rejected) => {
-            console.log(rejected);
-            return Promise.reject(rejected);
-        });
+        .catch((rejected) => Promise.reject(rejected));
 }
 
 export async function GET(url: string, path: string) {
@@ -144,10 +137,7 @@ export async function GET(url: string, path: string) {
             }
             return response.json();
         })
-        .catch((rejected) => {
-            console.log(rejected);
-            return Promise.reject(rejected);
-        });
+        .catch((rejected) => Promise.reject(rejected));
 }
 
 // Request Objects
@@ -268,7 +258,7 @@ async function fetchTransactionsForBlock(block: any): Promise<any[]> {
             ? attachBlockMetadataToTransactions(transactions, block)
             : [];
     } catch (error) {
-        console.error(`Error fetching transactions for block ${blockHeight}:`, error);
+        
         return [];
     }
 }
@@ -316,7 +306,7 @@ export async function getRecentTransactionsPreview(limit: number = 5, cachedBloc
 
         return recentTransactions.slice(0, limit);
     } catch (error) {
-        console.error('Error fetching recent transactions preview:', error);
+        
         return [];
     }
 }
@@ -393,7 +383,7 @@ export async function getTransactionsWithRealPagination(page: number, perPage: n
         return await AllTransactions(page, perPage, filters);
 
     } catch (error) {
-        console.error('Error fetching transactions with real pagination:', error);
+        
         return { results: [], totalCount: 0, pageNumber: page, perPage, totalPages: 0, hasMore: false };
     }
 }
@@ -445,7 +435,7 @@ export async function getTotalAccountCount(cachedBlocks?: any[]): Promise<{ tota
                             }
                         }
                     } catch (error) {
-                        console.log('Invalid block timestamp:', blockTime, error);
+                        
                     }
                 }
             }
@@ -460,7 +450,7 @@ export async function getTotalAccountCount(cachedBlocks?: any[]): Promise<{ tota
             last24h: 0
         };
     } catch (error) {
-        console.error('Error getting total account count:', error);
+        
         return {
             total: 0,
             last24h: 0
@@ -515,7 +505,7 @@ export async function getTotalTransactionCount(cachedBlocks?: any[]): Promise<{ 
                                     last24hCount++;
                                 }
                             } catch (error) {
-                                console.log('Invalid timestamp:', timestamp, error);
+                                
                             }
                         }
                     }
@@ -565,7 +555,7 @@ export async function getTotalTransactionCount(cachedBlocks?: any[]): Promise<{ 
             tpm: totalTransactionCountCache?.tpm || 0
         };
     } catch (error) {
-        console.error('Error getting total transaction count:', error);
+        
         return {
             total: totalTransactionCountCache?.count || 0,
             last24h: totalTransactionCountCache?.last24h || 0,
@@ -775,7 +765,7 @@ export async function AllTransactions(page: number, perPage: number = 10, filter
             hasMore: endIndex < totalCount,
         };
     } catch (error) {
-        console.error('Error fetching all transactions:', error);
+        
         return { results: [], totalCount: 0, pageNumber: page, perPage, totalPages: 0, hasMore: false };
     }
 }
@@ -980,7 +970,6 @@ export async function getCardData(previousCardData?: any) {
             continue;
         }
 
-        console.error('❌ Error in getCardData request:', result.reason);
     }
 
     const blocks = cardData.blocks?.results || cardData.blocks?.blocks || [];

--- a/cmd/rpc/web/explorer/src/main.tsx
+++ b/cmd/rpc/web/explorer/src/main.tsx
@@ -12,8 +12,12 @@ const queryClient = new QueryClient({
       staleTime: 30000, // 30 seconds
       refetchInterval: 20000, // 20 seconds auto refresh
       retry: 3,
-      refetchOnWindowFocus: false,
-      refetchOnMount: true, // Refetch when component mounts
+      // Keep polling running even when the tab is in the background, so the
+      // dashboard reflects new blocks without needing a manual refresh.
+      refetchIntervalInBackground: true,
+      refetchOnWindowFocus: true,
+      refetchOnReconnect: true,
+      refetchOnMount: true,
     },
   },
 })

--- a/cmd/rpc/web/explorer/vite.config.ts
+++ b/cmd/rpc/web/explorer/vite.config.ts
@@ -6,11 +6,41 @@ export default defineConfig(({ mode }) => {
   // Load env file based on `mode` in the current working directory.
   const env = loadEnv(mode, '.', '')
 
+  // Mirror netlify.toml redirects so the dev server speaks the same
+  // same-origin proxy paths used in production (/rpc-node1, /admin-node1).
+  // VITE_DEV_RPC_PROXY / VITE_DEV_ADMIN_PROXY override the default upstreams.
+  const rpcUpstream =
+    env.VITE_DEV_RPC_PROXY ||
+    env.VITE_PUBLIC_RPC_URL ||
+    'https://node1.canopy.us.nodefleet.net/rpc'
+  const adminUpstream =
+    env.VITE_DEV_ADMIN_PROXY ||
+    env.VITE_PUBLIC_ADMIN_RPC_URL ||
+    'https://node1.canopy.us.nodefleet.net/admin'
+
+  const stripTrailingSlash = (value: string) => value.replace(/\/+$/, '')
+
   return {
     plugins: [react()],
     define: {
       // Ensure environment variables are available at build time
       'import.meta.env.VITE_NODE_ENV': JSON.stringify(env.VITE_NODE_ENV || 'development'),
+    },
+    server: {
+      proxy: {
+        '/rpc-node1': {
+          target: stripTrailingSlash(rpcUpstream),
+          changeOrigin: true,
+          secure: true,
+          rewrite: (path) => path.replace(/^\/rpc-node1/, ''),
+        },
+        '/admin-node1': {
+          target: stripTrailingSlash(adminUpstream),
+          changeOrigin: true,
+          secure: true,
+          rewrite: (path) => path.replace(/^\/admin-node1/, ''),
+        },
+      },
     },
   }
 })


### PR DESCRIPTION
The explorer dashboard now auto-refreshes whenever a new block arrives, and the console is no longer flooded with errors when the RPC node is degraded. A new global block subscription detects when the chain height advances and refreshes the entire dashboard at once, so blocks, transactions, validators, and stats stay in sync without needing a manual page reload. 

All RPC traffic is routed through a same-origin proxy in both production and local development, which fixes the CORS errors that appeared on deploys other than the main domain and on localhost. The blocks query was simplified to a single request per cycle instead of ten parallel ones, and all polling queries now back off automatically when the upstream node fails so the dashboard stops hammering a node that is returning 502s. The check interval was lowered to 1 second, and all internal console.log noise was removed.

@rem1niscence 
