### PR TITLE
vesting dao mint

### DIFF
--- a/cmd/cli/admin.go
+++ b/cmd/cli/admin.go
@@ -47,6 +47,7 @@ func init() {
 	adminCmd.AddCommand(ksDeleteCmd)
 	adminCmd.AddCommand(ksGetCmd)
 	adminCmd.AddCommand(txSendCmd)
+	adminCmd.AddCommand(txSendVestingCmd)
 	adminCmd.AddCommand(txStakeCmd)
 	adminCmd.AddCommand(txEditStakeCmd)
 	adminCmd.AddCommand(txUnstakeCmd)
@@ -141,6 +142,26 @@ var (
 		Args:    cobra.MinimumNArgs(3),
 		Run: func(cmd *cobra.Command, args []string) {
 			writeTxResultToConsole(client.TxSend(argGetAddrOrNickname(args[0]), argGetAddr(args[1]), uint64(argToInt(args[2])), getPassword(), !sim, fee))
+		},
+	}
+
+	txSendVestingCmd = &cobra.Command{
+		Use:     "tx-send-vesting <address or nickname> <to-address> <amount> <vesting-start-height> <vesting-cliff-height> <vesting-end-height> --fee=10000 --simulate=true",
+		Short:   "send an amount to another address with a recipient vesting schedule",
+		Example: "tx-send-vesting dfd3c8dff19da7682f7fe5fde062c813b55c9eee eed6c9dff19da7682f7fe5fde062c813b42c7abc 10000 100 120 200",
+		Args:    cobra.MinimumNArgs(6),
+		Run: func(cmd *cobra.Command, args []string) {
+			writeTxResultToConsole(client.TxSendVesting(
+				argGetAddrOrNickname(args[0]),
+				argGetAddr(args[1]),
+				uint64(argToInt(args[2])),
+				uint64(argToInt(args[3])),
+				uint64(argToInt(args[4])),
+				uint64(argToInt(args[5])),
+				getPassword(),
+				!sim,
+				fee,
+			))
 		},
 	}
 

--- a/cmd/cli/admin.go
+++ b/cmd/cli/admin.go
@@ -25,6 +25,7 @@ var (
 	nick            string
 	data            string
 	fee             uint64
+	mint            bool
 	delegate        bool
 	earlyWithdrawal bool
 	sim             bool
@@ -37,6 +38,7 @@ func init() {
 	adminCmd.PersistentFlags().Uint64Var(&fee, "fee", 0, "custom fee, by default will use the minimum fee")
 	txStakeCmd.PersistentFlags().BoolVar(&delegate, "delegate", false, "delegate tokens to committee(s) only without actual validator operation")
 	txEditStakeCmd.PersistentFlags().BoolVar(&delegate, "delegate", false, "delegate tokens to committee(s) only without actual validator operation")
+	txDAOTransferCmd.PersistentFlags().BoolVar(&mint, "mint", false, "mint the transfer amount into the DAO pool before executing the treasury grant")
 	txStakeCmd.PersistentFlags().BoolVar(&earlyWithdrawal, "early-withdrawal", false, "immediately withdrawal any rewards (with penalty) directly to output address instead of auto-compounding directly to stake")
 	txEditStakeCmd.PersistentFlags().BoolVar(&earlyWithdrawal, "early-withdrawal", false, "immediately withdrawal any rewards (with penalty) directly to output address instead of auto-compounding directly to stake")
 	txCreateOrderCmd.PersistentFlags().StringVar(&data, "data", "", "data for create order")
@@ -227,11 +229,11 @@ var (
 	}
 
 	txDAOTransferCmd = &cobra.Command{
-		Use:   "tx-dao-transfer <address or nickname> <amount> <proposal-start-block> <proposal-end-block> --fee=10000 --simulate=true",
+		Use:   "tx-dao-transfer <address or nickname> <amount> <proposal-start-block> <proposal-end-block> --mint --fee=10000 --simulate=true",
 		Short: "propose a treasury subsidy - use the simulate flag to generate json only",
 		Args:  cobra.MinimumNArgs(4),
 		Run: func(cmd *cobra.Command, args []string) {
-			writeTxResultToConsole(client.TxDaoTransfer(argGetAddrOrNickname(args[0]), uint64(argToInt(args[1])), uint64(argToInt(args[2])), uint64(argToInt(args[3])), getPassword(), !sim, fee))
+			writeTxResultToConsole(client.TxDaoTransfer(argGetAddrOrNickname(args[0]), uint64(argToInt(args[1])), uint64(argToInt(args[2])), uint64(argToInt(args[3])), getPassword(), !sim, fee, mint))
 		},
 	}
 

--- a/cmd/cli/cli.go
+++ b/cmd/cli/cli.go
@@ -3,7 +3,6 @@ package cli
 import (
 	"encoding/json"
 	"errors"
-	"flag"
 	"fmt"
 	"log"
 	"os"
@@ -45,7 +44,6 @@ var (
 )
 
 func init() {
-	flag.Parse()
 	rootCmd.AddCommand(startCmd)
 	rootCmd.AddCommand(versionCmd)
 	rootCmd.AddCommand(queryCmd)

--- a/cmd/rpc/README.md
+++ b/cmd/rpc/README.md
@@ -303,7 +303,15 @@ $ curl -X POST localhost:50002/v1/query/indexer-blobs \
 **Response**:
 
 - **address**: `hex string` - the 20 byte identifier
-- **amount**: `uint64` - the balance of funds the account has
+- **amount**: `uint64` - the spendable balance of funds the account can currently withdraw
+- **totalAmount**: `uint64` - the total balance recorded for the account before vesting locks are applied
+- **spendableAmount**: `uint64` - the spendable balance of funds the account can currently withdraw
+- **vestedAmount**: `uint64` - the portion of `vestingAmount` that has vested at the queried height
+- **lockedAmount**: `uint64` - the portion of `vestingAmount` that is still locked at the queried height
+- **vestingAmount**: `uint64` - the total amount governed by the vesting schedule (omitted when zero)
+- **vestingStartHeight**: `uint64` - the block height where vesting begins (omitted when zero)
+- **vestingCliffHeight**: `uint64` - the block height where vesting first becomes spendable (omitted when zero)
+- **vestingEndHeight**: `uint64` - the block height where vesting fully completes (omitted when zero)
 
 **Example**:
 
@@ -317,7 +325,15 @@ $ curl -X POST localhost:50002/v1/query/account \
 
 > {
     "address": "0971d5d96f1533479ab1a6472fe0260df6ae732d",
-    "amount": 99990000
+    "amount": 99990000,
+    "totalAmount": 100000000,
+    "spendableAmount": 99990000,
+    "vestedAmount": 500000,
+    "lockedAmount": 10000,
+    "vestingAmount": 510000,
+    "vestingStartHeight": 900,
+    "vestingCliffHeight": 950,
+    "vestingEndHeight": 1200
   }
 ```
 
@@ -339,7 +355,15 @@ $ curl -X POST localhost:50002/v1/query/account \
 - **pageNumber**: `int` - the number of the page
 - **results**: `array` - the list of result objects
   - **address**: - `hex string` the 20 byte unique identifier of the account
-  - **amount**: - `uint64` the balance of funds the account has in micro denomination
+  - **amount**: - `uint64` the spendable balance in micro denomination
+  - **totalAmount**: - `uint64` the total recorded balance before vesting locks are applied
+  - **spendableAmount**: - `uint64` the spendable balance in micro denomination
+  - **vestedAmount**: - `uint64` the vested portion of the vesting tranche at the queried height
+  - **lockedAmount**: - `uint64` the still-locked portion of the vesting tranche at the queried height
+  - **vestingAmount**: - `uint64` the total amount on the vesting schedule, omitted when zero
+  - **vestingStartHeight**: - `uint64` the height where vesting begins, omitted when zero
+  - **vestingCliffHeight**: - `uint64` the height where vesting first becomes spendable, omitted when zero
+  - **vestingEndHeight**: - `uint64` the height where vesting fully completes, omitted when zero
 - **type**: `string` - the type of results
 - **count**: `int` - length of results
 - **totalPages**: `int` - number of pages
@@ -362,15 +386,31 @@ $ curl -X POST localhost:50002/v1/query/accounts \
     "results": [
       {
         "address": "180c9d067ce4275612896dc7ce01390329e7f101",
-        "amount": 969901
+        "amount": 969901,
+        "totalAmount": 969901,
+        "spendableAmount": 969901,
+        "vestedAmount": 0,
+        "lockedAmount": 0
       },
       {
         "address": "502c0b3d6ccd1c6f164aa5536b2ba2cb9e80c711",
-        "amount": 18239045002
+        "amount": 18239045002,
+        "totalAmount": 18239045002,
+        "spendableAmount": 18239045002,
+        "vestedAmount": 0,
+        "lockedAmount": 0
       },
       {
         "address": "551f21e333012027b81701a35023efc88b864975",
-        "amount": 130
+        "amount": 130,
+        "totalAmount": 1000,
+        "spendableAmount": 130,
+        "vestedAmount": 30,
+        "lockedAmount": 870,
+        "vestingAmount": 900,
+        "vestingStartHeight": 900,
+        "vestingCliffHeight": 950,
+        "vestingEndHeight": 1200
       }
     ],
     "type": "accounts",

--- a/cmd/rpc/admin.go
+++ b/cmd/rpc/admin.go
@@ -135,6 +135,32 @@ func (s *Server) TransactionSend(w http.ResponseWriter, r *http.Request, _ httpr
 	})
 }
 
+// TransactionSendVesting sends an amount to another address with a recipient vesting schedule.
+func (s *Server) TransactionSendVesting(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
+	s.txHandler(w, r, func(p crypto.PrivateKeyI, ptr *txRequest) (lib.TransactionI, error) {
+		toAddress, err := crypto.NewAddressFromString(ptr.Output)
+		if err != nil {
+			return nil, err
+		}
+		if err = s.getFeeFromState(ptr, fsm.MessageSendName); err != nil {
+			return nil, err
+		}
+		return fsm.NewSendTransactionWithVesting(
+			p,
+			toAddress,
+			ptr.Amount,
+			ptr.VestingStartHeight,
+			ptr.VestingCliffHeight,
+			ptr.VestingEndHeight,
+			s.config.NetworkID,
+			s.config.ChainId,
+			ptr.Fee,
+			s.controller.ChainHeight(),
+			ptr.Memo,
+		)
+	})
+}
+
 // TransactionStake stakes a validator
 func (s *Server) TransactionStake(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
 	// Call the transaction handler with a callback that creates the transaction

--- a/cmd/rpc/admin.go
+++ b/cmd/rpc/admin.go
@@ -289,7 +289,7 @@ func (s *Server) TransactionDAOTransfer(w http.ResponseWriter, r *http.Request, 
 			return nil, err
 		}
 		// Create and return the transaction to be sent
-		return fsm.NewDAOTransferTx(p, ptr.Amount, ptr.StartBlock, ptr.EndBlock, s.config.NetworkID, s.config.ChainId, ptr.Fee, s.controller.ChainHeight(), ptr.Memo)
+		return fsm.NewDAOTransferTx(p, ptr.Amount, ptr.StartBlock, ptr.EndBlock, s.config.NetworkID, s.config.ChainId, ptr.Fee, s.controller.ChainHeight(), ptr.Mint, ptr.Memo)
 	})
 }
 

--- a/cmd/rpc/client.go
+++ b/cmd/rpc/client.go
@@ -169,8 +169,8 @@ func (c *Client) TransactionsByRecipient(address string, params lib.PageParams) 
 	return
 }
 
-func (c *Client) Account(height uint64, address string) (p *fsm.Account, err lib.ErrorI) {
-	p = new(fsm.Account)
+func (c *Client) Account(height uint64, address string) (p *AccountView, err lib.ErrorI) {
+	p = new(AccountView)
 	err = c.heightAndAddressRequest(AccountRouteName, height, address, p)
 	return
 }

--- a/cmd/rpc/client.go
+++ b/cmd/rpc/client.go
@@ -564,6 +564,27 @@ func (c *Client) TxSend(from AddrOrNickname, rec string, amt uint64, pwd string,
 	return c.transactionRequest(TxSendRouteName, txReq, submit)
 }
 
+func (c *Client) TxSendVesting(from AddrOrNickname, rec string, amt, vestingStartHeight, vestingCliffHeight, vestingEndHeight uint64, pwd string, submit bool, optFee uint64) (hash *string, tx json.RawMessage, e lib.ErrorI) {
+	txReq := txSendVesting{
+		Fee:                optFee,
+		Amount:             amt,
+		Output:             rec,
+		VestingStartHeight: vestingStartHeight,
+		VestingCliffHeight: vestingCliffHeight,
+		VestingEndHeight:   vestingEndHeight,
+		Submit:             submit,
+		Password:           pwd,
+	}
+
+	var err lib.ErrorI
+	txReq.fromFields, err = getFrom(from.Address, from.Nickname)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return c.transactionRequest(TxSendVestingRouteName, txReq, submit)
+}
+
 func (c *Client) TxStake(addrOrNick AddrOrNickname, netAddr string, amt uint64, committees, output string, signer AddrOrNickname, delegate, earlyWithdrawal bool, pwd string, submit bool, optFee uint64) (hash *string, tx json.RawMessage, e lib.ErrorI) {
 	return c.txStake(addrOrNick, netAddr, amt, committees, output, delegate, earlyWithdrawal, signer, pwd, submit, false, optFee)
 }

--- a/cmd/rpc/client.go
+++ b/cmd/rpc/client.go
@@ -630,12 +630,13 @@ func (c *Client) TxChangeParam(from AddrOrNickname, pSpace, pKey, pValue string,
 }
 
 func (c *Client) TxDaoTransfer(from AddrOrNickname, amt, startBlk, endBlk uint64,
-	pwd string, submit bool, optFee uint64) (hash *string, tx json.RawMessage, e lib.ErrorI) {
+	pwd string, submit bool, optFee uint64, mint bool) (hash *string, tx json.RawMessage, e lib.ErrorI) {
 	txReq := txDaoTransfer{
 		Fee:      optFee,
 		Submit:   submit,
 		Password: pwd,
 		Amount:   amt,
+		Mint:     mint,
 		txChangeParamRequest: txChangeParamRequest{
 			StartBlock: startBlk,
 			EndBlock:   endBlk,

--- a/cmd/rpc/eth.go
+++ b/cmd/rpc/eth.go
@@ -254,7 +254,7 @@ func (s *Server) EthGetBalance(args []any) (result any, err error) {
 	// create a read-only state for the block tag
 	_ = s.readOnlyState(height, func(state *fsm.StateMachine) (e lib.ErrorI) {
 		// get the balance for the address
-		balance, e := state.GetAccountBalance(address)
+		balance, e := state.GetAccountSpendableBalance(address)
 		if e != nil {
 			return
 		}
@@ -478,7 +478,7 @@ func (s *Server) EthCall(args []any) (any, error) {
 			var balance uint64
 			switch toHex {
 			case fsm.CNPYContractAddress:
-				balance, e = state.GetAccountBalance(address)
+				balance, e = state.GetAccountSpendableBalance(address)
 				if e != nil {
 					return e
 				}
@@ -503,7 +503,7 @@ func (s *Server) EthCall(args []any) (any, error) {
 			if e != nil {
 				return e
 			}
-			balance, e := state.GetAccountBalance(fromAddress)
+			balance, e := state.GetAccountSpendableBalance(fromAddress)
 			if e != nil {
 				return e
 			}

--- a/cmd/rpc/query.go
+++ b/cmd/rpc/query.go
@@ -739,13 +739,26 @@ func (s *Server) heightAndAddressParams(w http.ResponseWriter, r *http.Request, 
 	})
 }
 
-func spendableAccountView(sm *fsm.StateMachine, account *fsm.Account) *fsm.Account {
+func spendableAccountView(sm *fsm.StateMachine, account *fsm.Account) *AccountView {
 	if account == nil {
 		return nil
 	}
-	view := *account
-	view.Amount = sm.AccountSpendableAmount(account)
-	return &view
+	total := account.Amount
+	spendable := sm.AccountSpendableAmount(account)
+	vested := sm.AccountVestedAmount(account)
+	locked := sm.AccountLockedAmount(account)
+	return &AccountView{
+		Address:            account.Address,
+		Amount:             spendable,
+		TotalAmount:        total,
+		SpendableAmount:    spendable,
+		VestedAmount:       vested,
+		LockedAmount:       locked,
+		VestingAmount:      account.VestingAmount,
+		VestingStartHeight: account.VestingStartHeight,
+		VestingCliffHeight: account.VestingCliffHeight,
+		VestingEndHeight:   account.VestingEndHeight,
+	}
 }
 
 func spendableAccountPageView(sm *fsm.StateMachine, page *lib.Page) *lib.Page {
@@ -757,7 +770,7 @@ func spendableAccountPageView(sm *fsm.StateMachine, page *lib.Page) *lib.Page {
 	if !ok || accounts == nil {
 		return &view
 	}
-	result := make(fsm.AccountPage, 0, len(*accounts))
+	result := make(AccountViewPage, 0, len(*accounts))
 	for _, account := range *accounts {
 		result = append(result, spendableAccountView(sm, account))
 	}

--- a/cmd/rpc/query.go
+++ b/cmd/rpc/query.go
@@ -61,7 +61,11 @@ func (s *Server) Height(w http.ResponseWriter, _ *http.Request, _ httprouter.Par
 func (s *Server) Account(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
 	// Invoke helper with the HTTP request, response writer and an inline callback
 	s.heightAndAddressParams(w, r, func(s *fsm.StateMachine, a lib.HexBytes) (interface{}, lib.ErrorI) {
-		return s.GetAccount(crypto.NewAddressFromBytes(a))
+		account, err := s.GetAccount(crypto.NewAddressFromBytes(a))
+		if err != nil {
+			return nil, err
+		}
+		return spendableAccountView(s, account), nil
 	})
 }
 
@@ -69,7 +73,11 @@ func (s *Server) Account(w http.ResponseWriter, r *http.Request, _ httprouter.Pa
 func (s *Server) Accounts(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
 	// Invoke helper with the HTTP request, response writer and an inline callback
 	s.heightPaginated(w, r, func(s *fsm.StateMachine, p *paginatedHeightRequest) (interface{}, lib.ErrorI) {
-		return s.GetAccountsPaginated(p.PageParams)
+		page, err := s.GetAccountsPaginated(p.PageParams)
+		if err != nil {
+			return nil, err
+		}
+		return spendableAccountPageView(s, page), nil
 	})
 }
 
@@ -729,6 +737,32 @@ func (s *Server) heightAndAddressParams(w http.ResponseWriter, r *http.Request, 
 		write(w, p, http.StatusOK)
 		return
 	})
+}
+
+func spendableAccountView(sm *fsm.StateMachine, account *fsm.Account) *fsm.Account {
+	if account == nil {
+		return nil
+	}
+	view := *account
+	view.Amount = sm.AccountSpendableAmount(account)
+	return &view
+}
+
+func spendableAccountPageView(sm *fsm.StateMachine, page *lib.Page) *lib.Page {
+	if page == nil {
+		return nil
+	}
+	view := *page
+	accounts, ok := page.Results.(*fsm.AccountPage)
+	if !ok || accounts == nil {
+		return &view
+	}
+	result := make(fsm.AccountPage, 0, len(*accounts))
+	for _, account := range *accounts {
+		result = append(result, spendableAccountView(sm, account))
+	}
+	view.Results = &result
+	return &view
 }
 
 // heightAndIdParams is a helper function to execute a callback with a state machine and ID as parameters

--- a/cmd/rpc/query_test.go
+++ b/cmd/rpc/query_test.go
@@ -93,7 +93,7 @@ func TestIndexerBlobsCached_RetainsOnlyLatestFullSnapshot(t *testing.T) {
 	require.NotEmpty(t, entry4.deltaBytes)
 }
 
-func TestAccountQueryReturnsSpendableAmount(t *testing.T) {
+func TestAccountQueryReturnsVestingBreakdown(t *testing.T) {
 	server := newTestIndexerBlobServer(t)
 	sm := server.controller.FSM
 	address := crypto.NewAddress(bytes.Repeat([]byte{0x33}, crypto.AddressSize))
@@ -118,16 +118,21 @@ func TestAccountQueryReturnsSpendableAmount(t *testing.T) {
 	server.Account(rec, req, nil)
 
 	require.Equal(t, http.StatusOK, rec.Code)
-	var got fsm.Account
+	var got AccountView
 	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &got))
+	require.Equal(t, address.Bytes(), []byte(got.Address))
 	require.Equal(t, uint64(110), got.Amount)
+	require.Equal(t, uint64(150), got.TotalAmount)
+	require.Equal(t, uint64(110), got.SpendableAmount)
+	require.Equal(t, uint64(60), got.VestedAmount)
+	require.Equal(t, uint64(40), got.LockedAmount)
 	require.Equal(t, uint64(100), got.VestingAmount)
 	require.Equal(t, uint64(1), got.VestingStartHeight)
 	require.Equal(t, uint64(2), got.VestingCliffHeight)
 	require.Equal(t, uint64(6), got.VestingEndHeight)
 }
 
-func TestAccountsQueryReturnsSpendableAmounts(t *testing.T) {
+func TestAccountsQueryReturnsVestingBreakdowns(t *testing.T) {
 	server := newTestIndexerBlobServer(t)
 	sm := server.controller.FSM
 	liquid := crypto.NewAddress(bytes.Repeat([]byte{0x44}, crypto.AddressSize))
@@ -153,27 +158,28 @@ func TestAccountsQueryReturnsSpendableAmounts(t *testing.T) {
 
 	require.Equal(t, http.StatusOK, rec.Code)
 	var got struct {
-		Results []fsm.Account `json:"results"`
+		Results []AccountView `json:"results"`
 	}
 	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &got))
 	require.NotEmpty(t, got.Results)
 
-	amounts := make(map[string]uint64, len(got.Results))
+	amounts := make(map[string]AccountView, len(got.Results))
 	for _, account := range got.Results {
-		amounts[crypto.NewAddressFromBytes(account.Address).String()] = account.Amount
+		amounts[crypto.NewAddressFromBytes(account.Address).String()] = account
 	}
-	require.Equal(t, uint64(25), amounts[liquid.String()])
-	require.Equal(t, uint64(110), amounts[vested.String()])
+	require.Equal(t, uint64(25), amounts[liquid.String()].Amount)
+	require.Equal(t, uint64(25), amounts[liquid.String()].TotalAmount)
+	require.Equal(t, uint64(25), amounts[liquid.String()].SpendableAmount)
+	require.Zero(t, amounts[liquid.String()].VestedAmount)
+	require.Zero(t, amounts[liquid.String()].LockedAmount)
 
-	var vestedAccount *fsm.Account
-	for i := range got.Results {
-		account := got.Results[i]
-		if crypto.NewAddressFromBytes(account.Address).String() == vested.String() {
-			vestedAccount = &account
-			break
-		}
-	}
-	require.NotNil(t, vestedAccount)
+	vestedAccount, ok := amounts[vested.String()]
+	require.True(t, ok)
+	require.Equal(t, uint64(110), vestedAccount.Amount)
+	require.Equal(t, uint64(150), vestedAccount.TotalAmount)
+	require.Equal(t, uint64(110), vestedAccount.SpendableAmount)
+	require.Equal(t, uint64(60), vestedAccount.VestedAmount)
+	require.Equal(t, uint64(40), vestedAccount.LockedAmount)
 	require.Equal(t, uint64(100), vestedAccount.VestingAmount)
 	require.Equal(t, uint64(1), vestedAccount.VestingStartHeight)
 	require.Equal(t, uint64(2), vestedAccount.VestingCliffHeight)

--- a/cmd/rpc/query_test.go
+++ b/cmd/rpc/query_test.go
@@ -2,6 +2,7 @@ package rpc
 
 import (
 	"bytes"
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"reflect"
@@ -90,6 +91,93 @@ func TestIndexerBlobsCached_RetainsOnlyLatestFullSnapshot(t *testing.T) {
 	require.NotNil(t, entry4.current)
 	require.NotNil(t, entry4.deltaBlobs)
 	require.NotEmpty(t, entry4.deltaBytes)
+}
+
+func TestAccountQueryReturnsSpendableAmount(t *testing.T) {
+	server := newTestIndexerBlobServer(t)
+	sm := server.controller.FSM
+	address := crypto.NewAddress(bytes.Repeat([]byte{0x33}, crypto.AddressSize))
+
+	require.NoError(t, sm.SetAccount(&fsm.Account{
+		Address:            address.Bytes(),
+		Amount:             150,
+		VestingAmount:      100,
+		VestingStartHeight: 1,
+		VestingCliffHeight: 2,
+		VestingEndHeight:   6,
+	}))
+	_, err := sm.Store().(lib.StoreI).Commit()
+	require.NoError(t, err)
+	setFSMHeight(t, sm, sm.Store().(lib.StoreI).Version())
+
+	req := httptest.NewRequest(http.MethodPost, AccountRoutePath, bytes.NewBufferString(
+		`{"height":0,"address":"`+address.String()+`"}`,
+	))
+	rec := httptest.NewRecorder()
+
+	server.Account(rec, req, nil)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	var got fsm.Account
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &got))
+	require.Equal(t, uint64(110), got.Amount)
+	require.Equal(t, uint64(100), got.VestingAmount)
+	require.Equal(t, uint64(1), got.VestingStartHeight)
+	require.Equal(t, uint64(2), got.VestingCliffHeight)
+	require.Equal(t, uint64(6), got.VestingEndHeight)
+}
+
+func TestAccountsQueryReturnsSpendableAmounts(t *testing.T) {
+	server := newTestIndexerBlobServer(t)
+	sm := server.controller.FSM
+	liquid := crypto.NewAddress(bytes.Repeat([]byte{0x44}, crypto.AddressSize))
+	vested := crypto.NewAddress(bytes.Repeat([]byte{0x55}, crypto.AddressSize))
+
+	require.NoError(t, sm.SetAccount(&fsm.Account{Address: liquid.Bytes(), Amount: 25}))
+	require.NoError(t, sm.SetAccount(&fsm.Account{
+		Address:            vested.Bytes(),
+		Amount:             150,
+		VestingAmount:      100,
+		VestingStartHeight: 1,
+		VestingCliffHeight: 2,
+		VestingEndHeight:   6,
+	}))
+	_, err := sm.Store().(lib.StoreI).Commit()
+	require.NoError(t, err)
+	setFSMHeight(t, sm, sm.Store().(lib.StoreI).Version())
+
+	req := httptest.NewRequest(http.MethodPost, AccountsRoutePath, bytes.NewBufferString(`{"height":0,"pageNumber":1,"perPage":20}`))
+	rec := httptest.NewRecorder()
+
+	server.Accounts(rec, req, nil)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	var got struct {
+		Results []fsm.Account `json:"results"`
+	}
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &got))
+	require.NotEmpty(t, got.Results)
+
+	amounts := make(map[string]uint64, len(got.Results))
+	for _, account := range got.Results {
+		amounts[crypto.NewAddressFromBytes(account.Address).String()] = account.Amount
+	}
+	require.Equal(t, uint64(25), amounts[liquid.String()])
+	require.Equal(t, uint64(110), amounts[vested.String()])
+
+	var vestedAccount *fsm.Account
+	for i := range got.Results {
+		account := got.Results[i]
+		if crypto.NewAddressFromBytes(account.Address).String() == vested.String() {
+			vestedAccount = &account
+			break
+		}
+	}
+	require.NotNil(t, vestedAccount)
+	require.Equal(t, uint64(100), vestedAccount.VestingAmount)
+	require.Equal(t, uint64(1), vestedAccount.VestingStartHeight)
+	require.Equal(t, uint64(2), vestedAccount.VestingCliffHeight)
+	require.Equal(t, uint64(6), vestedAccount.VestingEndHeight)
 }
 
 func newTestIndexerBlobServer(t *testing.T) *Server {

--- a/cmd/rpc/routes.go
+++ b/cmd/rpc/routes.go
@@ -74,6 +74,7 @@ const (
 	KeystoreDeleteRoutePath    = "/v1/admin/keystore-delete"
 	KeystoreGetRoutePath       = "/v1/admin/keystore-get"
 	TxSendRoutePath            = "/v1/admin/tx-send"
+	TxSendVestingRoutePath     = "/v1/admin/tx-send-vesting"
 	TxStakeRoutePath           = "/v1/admin/tx-stake"
 	TxEditStakeRoutePath       = "/v1/admin/tx-edit-stake"
 	TxUnstakeRoutePath         = "/v1/admin/tx-unstake"
@@ -172,6 +173,7 @@ const (
 	KeystoreDeleteRouteName         = "keystore-delete"
 	KeystoreGetRouteName            = "keystore-get"
 	TxSendRouteName                 = "tx-send"
+	TxSendVestingRouteName          = "tx-send-vesting"
 	TxStakeRouteName                = "tx-stake"
 	TxUnstakeRouteName              = "tx-unstake"
 	TxEditStakeRouteName            = "tx-edit-stake"
@@ -273,6 +275,7 @@ var routePaths = routes{
 	KeystoreDeleteRouteName:         {Method: http.MethodPost, Path: KeystoreDeleteRoutePath},
 	KeystoreGetRouteName:            {Method: http.MethodPost, Path: KeystoreGetRoutePath},
 	TxSendRouteName:                 {Method: http.MethodPost, Path: TxSendRoutePath},
+	TxSendVestingRouteName:          {Method: http.MethodPost, Path: TxSendVestingRoutePath},
 	TxStakeRouteName:                {Method: http.MethodPost, Path: TxStakeRoutePath},
 	TxEditOrderRouteName:            {Method: http.MethodPost, Path: TxEditOrderRoutePath},
 	TxUnstakeRouteName:              {Method: http.MethodPost, Path: TxUnstakeRoutePath},
@@ -390,6 +393,7 @@ func createAdminRouter(s *Server) *httprouter.Router {
 		KeystoreDeleteRouteName:         s.KeystoreDelete,
 		KeystoreGetRouteName:            s.KeystoreGetKeyGroup,
 		TxSendRouteName:                 s.TransactionSend,
+		TxSendVestingRouteName:          s.TransactionSendVesting,
 		TxStakeRouteName:                s.TransactionStake,
 		TxEditStakeRouteName:            s.TransactionEditStake,
 		TxUnstakeRouteName:              s.TransactionUnstake,

--- a/cmd/rpc/types.go
+++ b/cmd/rpc/types.go
@@ -228,6 +228,7 @@ type txChangeParam struct {
 type txDaoTransfer struct {
 	Fee      uint64 `json:"fee"`
 	Amount   uint64 `json:"amount"`
+	Mint     bool   `json:"mint"`
 	Submit   bool   `json:"submit"`
 	Password string `json:"password"`
 	fromFields
@@ -380,6 +381,7 @@ type txRequest struct {
 	OpCode             lib.HexBytes    `json:"opCode"`
 	Data               lib.HexBytes    `json:"data"`
 	Fee                uint64          `json:"fee"`
+	Mint               bool            `json:"mint"`
 	Delegate           bool            `json:"delegate"`
 	EarlyWithdrawal    bool            `json:"earlyWithdrawal"`
 	Submit             bool            `json:"submit"`

--- a/cmd/rpc/types.go
+++ b/cmd/rpc/types.go
@@ -171,6 +171,31 @@ type economicParameterResponse struct {
 }
 
 // =====================================================
+// Query Response Types
+// =====================================================
+type AccountView struct {
+	Address            lib.HexBytes `json:"address"`
+	Amount             uint64       `json:"amount"`
+	TotalAmount        uint64       `json:"totalAmount,omitempty"`
+	SpendableAmount    uint64       `json:"spendableAmount,omitempty"`
+	VestedAmount       uint64       `json:"vestedAmount,omitempty"`
+	LockedAmount       uint64       `json:"lockedAmount,omitempty"`
+	VestingAmount      uint64       `json:"vestingAmount,omitempty"`
+	VestingStartHeight uint64       `json:"vestingStartHeight,omitempty"`
+	VestingCliffHeight uint64       `json:"vestingCliffHeight,omitempty"`
+	VestingEndHeight   uint64       `json:"vestingEndHeight,omitempty"`
+}
+
+type AccountViewPage []*AccountView
+
+// AccountViewPage satisfies the Page interface.
+func (p *AccountViewPage) New() lib.Pageable { return &AccountViewPage{} }
+
+func init() {
+	lib.RegisteredPageables[fsm.AccountsPageName] = new(AccountViewPage)
+}
+
+// =====================================================
 // Transaction Request Types
 // =====================================================
 type txSend struct {

--- a/cmd/rpc/types.go
+++ b/cmd/rpc/types.go
@@ -182,6 +182,18 @@ type txSend struct {
 	fromFields
 }
 
+type txSendVesting struct {
+	Fee                uint64 `json:"fee"`
+	Amount             uint64 `json:"amount"`
+	Output             string `json:"output"`
+	VestingStartHeight uint64 `json:"vestingStartHeight"`
+	VestingCliffHeight uint64 `json:"vestingCliffHeight"`
+	VestingEndHeight   uint64 `json:"vestingEndHeight"`
+	Submit             bool   `json:"submit"`
+	Password           string `json:"password"`
+	fromFields
+}
+
 type txAddress struct {
 	Fee uint64 `json:"fee"`
 	fromFields
@@ -358,25 +370,28 @@ type signerFields struct {
 
 // txRequest is used server side to unmarshall all transaction requests
 type txRequest struct {
-	Amount          uint64          `json:"amount"`
-	PubKey          string          `json:"pubKey"`
-	NetAddress      string          `json:"netAddress"`
-	Output          string          `json:"output"`
-	OpCode          lib.HexBytes    `json:"opCode"`
-	Data            lib.HexBytes    `json:"data"`
-	Fee             uint64          `json:"fee"`
-	Delegate        bool            `json:"delegate"`
-	EarlyWithdrawal bool            `json:"earlyWithdrawal"`
-	Submit          bool            `json:"submit"`
-	ReceiveAmount   uint64          `json:"receiveAmount"`
-	ReceiveAddress  lib.HexBytes    `json:"receiveAddress"`
-	Percent         uint64          `json:"percent"`
-	OrderId         string          `json:"orderId"`
-	Memo            string          `json:"memo"`
-	PollJSON        json.RawMessage `json:"pollJSON"`
-	PollApprove     bool            `json:"pollApprove"`
-	Signer          lib.HexBytes    `json:"signer"`
-	SignerNickname  string          `json:"signerNickname"`
+	Amount             uint64          `json:"amount"`
+	VestingStartHeight uint64          `json:"vestingStartHeight"`
+	VestingCliffHeight uint64          `json:"vestingCliffHeight"`
+	VestingEndHeight   uint64          `json:"vestingEndHeight"`
+	PubKey             string          `json:"pubKey"`
+	NetAddress         string          `json:"netAddress"`
+	Output             string          `json:"output"`
+	OpCode             lib.HexBytes    `json:"opCode"`
+	Data               lib.HexBytes    `json:"data"`
+	Fee                uint64          `json:"fee"`
+	Delegate           bool            `json:"delegate"`
+	EarlyWithdrawal    bool            `json:"earlyWithdrawal"`
+	Submit             bool            `json:"submit"`
+	ReceiveAmount      uint64          `json:"receiveAmount"`
+	ReceiveAddress     lib.HexBytes    `json:"receiveAddress"`
+	Percent            uint64          `json:"percent"`
+	OrderId            string          `json:"orderId"`
+	Memo               string          `json:"memo"`
+	PollJSON           json.RawMessage `json:"pollJSON"`
+	PollApprove        bool            `json:"pollApprove"`
+	Signer             lib.HexBytes    `json:"signer"`
+	SignerNickname     string          `json:"signerNickname"`
 	addressRequest
 	nicknameRequest
 	passwordRequest

--- a/cmd/rpc/web/explorer/src/components/account/AccountDetailHeader.tsx
+++ b/cmd/rpc/web/explorer/src/components/account/AccountDetailHeader.tsx
@@ -8,6 +8,14 @@ import { cnpyDetailFormat, toCNPY } from '../../lib/utils'
 interface Account {
     address: string
     amount: number
+    totalAmount?: number
+    spendableAmount?: number
+    vestedAmount?: number
+    lockedAmount?: number
+    vestingAmount?: number
+    vestingStartHeight?: number
+    vestingCliffHeight?: number
+    vestingEndHeight?: number
 }
 
 interface AccountDetailHeaderProps {
@@ -21,6 +29,12 @@ const CopySymbol = ({ copied }: { copied: boolean }) => {
 
 const AccountDetailHeader: React.FC<AccountDetailHeaderProps> = ({ account }) => {
     const [copied, setCopied] = useState(false)
+    const totalAmount = account.totalAmount ?? account.amount
+    const spendableAmount = account.spendableAmount ?? account.amount
+    const vestedAmount = account.vestedAmount ?? 0
+    const lockedAmount = account.lockedAmount ?? 0
+    const vestingAmount = account.vestingAmount ?? 0
+    const hasVesting = vestingAmount > 0 || vestedAmount > 0 || lockedAmount > 0
 
     const copyToClipboard = async () => {
         try {
@@ -93,6 +107,52 @@ const AccountDetailHeader: React.FC<AccountDetailHeaderProps> = ({ account }) =>
                         </p>
                     </div>
                 </div>
+
+                {hasVesting && (
+                    <>
+                        <div className="mt-6 grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
+                            {[
+                                { label: 'Total', value: totalAmount },
+                                { label: 'Spendable', value: spendableAmount },
+                                { label: 'Locked', value: lockedAmount },
+                                { label: 'Vested', value: vestedAmount },
+                            ].map((item) => (
+                                <div key={item.label} className="rounded-xl border border-white/8 bg-white/[0.03] p-4">
+                                    <div className="text-[11px] uppercase tracking-[0.18em] text-white/45">
+                                        {item.label}
+                                    </div>
+                                    <div className="mt-2 text-sm font-medium text-white tabular-nums">
+                                        <AnimatedNumber value={toCNPY(item.value)} format={cnpyDetailFormat} className="text-white" />
+                                        <span className="ml-1 text-white/55">CNPY</span>
+                                    </div>
+                                </div>
+                            ))}
+                        </div>
+
+                        <div className="mt-4 flex flex-wrap gap-2 text-xs text-white/60">
+                            {vestingAmount > 0 && (
+                                <span className="rounded-full border border-white/10 bg-white/[0.03] px-3 py-1">
+                                    Vesting tranche: {toCNPY(vestingAmount).toLocaleString(undefined, { maximumFractionDigits: 4 })} CNPY
+                                </span>
+                            )}
+                            {account.vestingStartHeight ? (
+                                <span className="rounded-full border border-white/10 bg-white/[0.03] px-3 py-1">
+                                    Start: {account.vestingStartHeight.toLocaleString()}
+                                </span>
+                            ) : null}
+                            {account.vestingCliffHeight ? (
+                                <span className="rounded-full border border-white/10 bg-white/[0.03] px-3 py-1">
+                                    Cliff: {account.vestingCliffHeight.toLocaleString()}
+                                </span>
+                            ) : null}
+                            {account.vestingEndHeight ? (
+                                <span className="rounded-full border border-white/10 bg-white/[0.03] px-3 py-1">
+                                    End: {account.vestingEndHeight.toLocaleString()}
+                                </span>
+                            ) : null}
+                        </div>
+                    </>
+                )}
             </motion.div>
         </div>
     )

--- a/cmd/rpc/web/explorer/src/components/account/AccountsPage.tsx
+++ b/cmd/rpc/web/explorer/src/components/account/AccountsPage.tsx
@@ -20,7 +20,7 @@ const AccountsPage: React.FC = () => {
     const { data: accountsData, isLoading, error } = useAccounts(currentPage, pageSize)
     const accounts = accountsData?.results || []
     const largestBalance = React.useMemo(
-        () => toCNPY(accounts.reduce((max: number, account: { amount?: number; totalAmount?: number }) => Math.max(max, Number(account.totalAmount ?? account.amount || 0)), 0)),
+        () => toCNPY(accounts.reduce((max: number, account: { amount?: number; totalAmount?: number }) => Math.max(max, Number(account.totalAmount ?? account.amount ?? 0)), 0)),
         [accounts],
     )
     const overviewCards = [

--- a/cmd/rpc/web/explorer/src/components/account/AccountsPage.tsx
+++ b/cmd/rpc/web/explorer/src/components/account/AccountsPage.tsx
@@ -20,7 +20,7 @@ const AccountsPage: React.FC = () => {
     const { data: accountsData, isLoading, error } = useAccounts(currentPage, pageSize)
     const accounts = accountsData?.results || []
     const largestBalance = React.useMemo(
-        () => toCNPY(accounts.reduce((max: number, account: { amount?: number }) => Math.max(max, Number(account.amount || 0)), 0)),
+        () => toCNPY(accounts.reduce((max: number, account: { amount?: number; totalAmount?: number }) => Math.max(max, Number(account.totalAmount ?? account.amount || 0)), 0)),
         [accounts],
     )
     const overviewCards = [

--- a/cmd/rpc/web/explorer/src/components/account/AccountsTable.tsx
+++ b/cmd/rpc/web/explorer/src/components/account/AccountsTable.tsx
@@ -10,6 +10,9 @@ import CopyableIdentifier from '../ui/CopyableIdentifier'
 interface Account {
     address: string
     amount: number
+    lockedAmount?: number
+    vestedAmount?: number
+    vestingAmount?: number
 }
 
 interface AccountsTableProps {
@@ -141,10 +144,22 @@ const AccountsTable: React.FC<AccountsTableProps> = ({
                                         className={desktopRowCellClass}
                                         style={{ borderTopRightRadius: '10px', borderBottomRightRadius: '10px' }}
                                     >
-                                        <span className="text-sm text-white tabular-nums">
-                                            <AnimatedNumber value={toCNPY(account.amount)} format={{ maximumFractionDigits: 4 }} className="text-white" />
-                                            <span className="ml-1 text-white/50">CNPY</span>
-                                        </span>
+                                        <div className="space-y-1">
+                                            <span className="text-sm text-white tabular-nums">
+                                                <AnimatedNumber value={toCNPY(account.amount)} format={{ maximumFractionDigits: 4 }} className="text-white" />
+                                                <span className="ml-1 text-white/50">CNPY</span>
+                                            </span>
+                                            {(Number(account.lockedAmount || 0) > 0 || Number(account.vestedAmount || 0) > 0) && (
+                                                <div className="flex flex-wrap gap-2 text-[11px] text-white/45">
+                                                    {Number(account.lockedAmount || 0) > 0 && (
+                                                        <span>Locked {toCNPY(Number(account.lockedAmount || 0)).toLocaleString(undefined, { maximumFractionDigits: 4 })}</span>
+                                                    )}
+                                                    {Number(account.vestedAmount || 0) > 0 && (
+                                                        <span>Vested {toCNPY(Number(account.vestedAmount || 0)).toLocaleString(undefined, { maximumFractionDigits: 4 })}</span>
+                                                    )}
+                                                </div>
+                                            )}
+                                        </div>
                                     </td>
                                 </tr>
                             ))

--- a/cmd/rpc/web/explorer/src/types/api.ts
+++ b/cmd/rpc/web/explorer/src/types/api.ts
@@ -27,6 +27,14 @@ export interface Transaction {
 export interface Account {
     address: string;
     amount: number;
+    totalAmount: number;
+    spendableAmount: number;
+    vestedAmount: number;
+    lockedAmount: number;
+    vestingAmount?: number;
+    vestingStartHeight?: number;
+    vestingCliffHeight?: number;
+    vestingEndHeight?: number;
 }
 
 export interface Validator {

--- a/cmd/rpc/web/wallet/public/plugin/canopy/chain.json
+++ b/cmd/rpc/web/wallet/public/plugin/canopy/chain.json
@@ -43,7 +43,15 @@
           "height": "number"
         },
         "response": {
-          "amount": "number"
+          "amount": "number",
+          "totalAmount": "number",
+          "spendableAmount": "number",
+          "vestedAmount": "number",
+          "lockedAmount": "number",
+          "vestingAmount": "number",
+          "vestingStartHeight": "number",
+          "vestingCliffHeight": "number",
+          "vestingEndHeight": "number"
         }
       },
       "selector": ""

--- a/cmd/rpc/web/wallet/public/plugin/canopy/chain.json.template
+++ b/cmd/rpc/web/wallet/public/plugin/canopy/chain.json.template
@@ -24,7 +24,17 @@
     "account": {
       "source": { "base": "rpc", "path": "/v1/query/account", "method": "POST" },
       "body": { "height": 0, "address": "{{account.address}}" },
-      "coerce": { "body": { "height": "number" }, "response": { "amount": "number" } },
+      "coerce": { "body": { "height": "number" }, "response": {
+        "amount": "number",
+        "totalAmount": "number",
+        "spendableAmount": "number",
+        "vestedAmount": "number",
+        "lockedAmount": "number",
+        "vestingAmount": "number",
+        "vestingStartHeight": "number",
+        "vestingCliffHeight": "number",
+        "vestingEndHeight": "number"
+      } },
       "selector": ""
     },
     "accountByHeight": {

--- a/cmd/rpc/web/wallet/src/app/pages/Accounts.tsx
+++ b/cmd/rpc/web/wallet/src/app/pages/Accounts.tsx
@@ -47,6 +47,7 @@ export const Accounts = () => {
   const {
     totalBalance,
     totalLiquid,
+    totalLocked,
     totalStaked,
     balances,
     stakingData,
@@ -88,13 +89,22 @@ export const Accounts = () => {
   const getAccountSymbol = (index: number) => getCanopySymbol(index);
 
   const getRealTotal = (address: string) => {
-    const liquid = balances.find(b => b.address === address)?.amount ?? 0;
+    const balance = balances.find(b => b.address === address);
+    const liquid = balance?.spendableAmount ?? balance?.amount ?? 0;
+    const locked = balance?.lockedAmount ?? 0;
+    const vested = balance?.vestedAmount ?? 0;
+    const vestingAmount = balance?.vestingAmount ?? 0;
+    const accountTotal = balance?.totalAmount ?? liquid + locked;
     const staked = stakingData.find(s => s.address === address)?.staked ?? 0;
-    return { liquid, staked, total: liquid + staked };
+    return { liquid, locked, vested, vestingAmount, staked, total: accountTotal + staked };
   };
 
   const getStatusInfo = (address: string) => {
+    const locked = balances.find(b => b.address === address)?.lockedAmount ?? 0;
     const staked = stakingData.find(s => s.address === address)?.staked ?? 0;
+    if (locked > 0) {
+      return { label: "Vesting", cls: WALLET_BADGE_TONE };
+    }
     return staked > 0
       ? { label: "Staked",  cls: WALLET_BADGE_TONE }
       : { label: "Liquid",  cls: WALLET_BADGE_TONE };
@@ -102,7 +112,7 @@ export const Accounts = () => {
 
   const processedAddresses = useMemo(() => accounts
     .map((account, index) => {
-      const { liquid, staked, total } = getRealTotal(account.address);
+      const { liquid, locked, vested, vestingAmount, staked, total } = getRealTotal(account.address);
       const { label: statusLabel, cls: statusCls } = getStatusInfo(account.address);
       const symbolSrc = getAccountSymbol(index);
       return {
@@ -113,6 +123,9 @@ export const Accounts = () => {
         publicKey:        account.publicKey || "",
         total,
         liquid,
+        locked,
+        vested,
+        vestingAmount,
         staked,
         stakedPct:        total > 0 ? (staked / total) * 100 : 0,
         liquidPct:        total > 0 ? (liquid / total) * 100 : 0,
@@ -291,6 +304,13 @@ export const Accounts = () => {
               <span className="text-foreground/70">{fmt(totalLiquid)}</span>
               <span className="text-muted-foreground/50">liquid</span>
             </div>
+            {totalLocked > 0 && (
+              <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
+                <span className="w-1.5 h-1.5 rounded-full bg-amber-400/70 flex-shrink-0" />
+                <span className="text-foreground/70">{fmt(totalLocked)}</span>
+                <span className="text-muted-foreground/50">locked</span>
+              </div>
+            )}
           </div>
         </motion.div>
 
@@ -455,10 +475,17 @@ export const Accounts = () => {
 
                     {/* Total */}
                     <td className={desktopRowCellClass}>
-                      <span className="text-sm text-foreground tabular-nums">
-                        {fmt(addr.total)}
-                      </span>
-                      <span className="text-xs text-muted-foreground/50 ml-1">{symbol}</span>
+                      <div>
+                        <span className="text-sm text-foreground tabular-nums">
+                          {fmt(addr.total)}
+                        </span>
+                        <span className="text-xs text-muted-foreground/50 ml-1">{symbol}</span>
+                        {addr.locked > 0 && (
+                          <div className="mt-1 text-[11px] text-amber-300/80">
+                            Locked {fmt(addr.locked)} {symbol}
+                          </div>
+                        )}
+                      </div>
                     </td>
 
                     {/* Staked */}
@@ -474,6 +501,11 @@ export const Accounts = () => {
                       <div>
                         <span className="text-sm text-foreground tabular-nums">{fmt(addr.liquid)}</span>
                         <span className="text-xs text-muted-foreground/50 ml-1">{symbol}</span>
+                        {addr.vested > 0 && (
+                          <div className="mt-1 text-[11px] text-muted-foreground">
+                            Vested {fmt(addr.vested)} {symbol}
+                          </div>
+                        )}
                       </div>
                     </td>
 

--- a/cmd/rpc/web/wallet/src/components/dashboard/AllAddressesCard.tsx
+++ b/cmd/rpc/web/wallet/src/components/dashboard/AllAddressesCard.tsx
@@ -19,6 +19,7 @@ interface AddressData {
     fullAddress: string;
     nickname: string;
     totalValue: string;
+    lockedValue?: string;
 }
 
 const AddressRow = React.memo<{
@@ -41,6 +42,9 @@ const AddressRow = React.memo<{
             <CopyableIdentifier value={address.fullAddress} label="Address" className="mt-0.5 max-w-full text-xs text-muted-foreground/60">
                 {address.address}
             </CopyableIdentifier>
+            {address.lockedValue && (
+                <div className="mt-1 text-[11px] text-amber-300/75">{address.lockedValue} locked</div>
+            )}
         </div>
 
         <div className="ml-auto flex items-center gap-2.5 flex-shrink-0">
@@ -84,13 +88,17 @@ export const AllAddressesCard = React.memo(() => {
 
     const processedAddresses = useMemo((): AddressData[] =>
         accounts.map(account => {
-            const balance = balances.find(b => b.address === account.address)?.amount || 0;
+            const balance = balances.find(b => b.address === account.address);
+            const spendable = balance?.spendableAmount ?? balance?.amount ?? 0;
+            const locked = balance?.lockedAmount ?? 0;
+            const total = balance?.totalAmount ?? spendable + locked;
             return {
                 id: account.address,
                 address: shortAddr(account.address),
                 fullAddress: account.address,
                 nickname: account.nickname || 'Unnamed',
-                totalValue: formatBalance(balance),
+                totalValue: formatBalance(total),
+                lockedValue: locked > 0 ? formatBalance(locked) : undefined,
             };
         }),
         [accounts, balances, formatBalance]

--- a/cmd/rpc/web/wallet/src/hooks/useAccountData.ts
+++ b/cmd/rpc/web/wallet/src/hooks/useAccountData.ts
@@ -8,6 +8,11 @@ import { useAccountsList } from "@/app/providers/AccountsProvider"
 interface AccountBalance {
     address: string
     amount: number
+    totalAmount: number
+    spendableAmount: number
+    vestedAmount: number
+    lockedAmount: number
+    vestingAmount: number
     nickname?: string
 }
 
@@ -40,6 +45,8 @@ export function useAccountData() {
     const lastGoodDataRef = useRef<{
         totalBalance: number
         totalLiquid: number
+        totalLocked: number
+        totalVested: number
         totalStaked: number
         balances: AccountBalance[]
         stakingData: StakingData[]
@@ -58,6 +65,8 @@ export function useAccountData() {
             const result = {
                 totalBalance: 0,
                 totalLiquid: 0,
+                totalLocked: 0,
+                totalVested: 0,
                 totalStaked: 0,
                 balances: [] as AccountBalance[],
                 stakingData: [] as StakingData[]
@@ -71,12 +80,35 @@ export function useAccountData() {
                         accounts.map(async (acc): Promise<AccountBalance> => {
                             try {
                                 const res = await dsFetch<number | any>('account', { account: { address: acc.address } })
-                                const val = typeof res === 'number'
-                                    ? res
-                                    : Number(parseMaybeJson(res)?.amount ?? 0)
-                                return { address: acc.address, amount: val || 0, nickname: acc.nickname }
+                                const parsed = typeof res === 'number'
+                                    ? { amount: res }
+                                    : parseMaybeJson(res) ?? {}
+                                const spendable = Number(parsed?.spendableAmount ?? parsed?.amount ?? 0)
+                                const total = Number(parsed?.totalAmount ?? spendable)
+                                const vested = Number(parsed?.vestedAmount ?? 0)
+                                const locked = Number(parsed?.lockedAmount ?? 0)
+                                const vesting = Number(parsed?.vestingAmount ?? 0)
+                                return {
+                                    address: acc.address,
+                                    amount: spendable || 0,
+                                    totalAmount: total || 0,
+                                    spendableAmount: spendable || 0,
+                                    vestedAmount: vested || 0,
+                                    lockedAmount: locked || 0,
+                                    vestingAmount: vesting || 0,
+                                    nickname: acc.nickname,
+                                }
                             } catch {
-                                return { address: acc.address, amount: 0, nickname: acc.nickname }
+                                return {
+                                    address: acc.address,
+                                    amount: 0,
+                                    totalAmount: 0,
+                                    spendableAmount: 0,
+                                    vestedAmount: 0,
+                                    lockedAmount: 0,
+                                    vestingAmount: 0,
+                                    nickname: acc.nickname,
+                                }
                             }
                         })
                     )
@@ -91,6 +123,8 @@ export function useAccountData() {
             // Process balances
             result.balances = balancesResult
             result.totalLiquid = balancesResult.reduce((s, b) => s + (b.amount || 0), 0)
+            result.totalLocked = balancesResult.reduce((s, b) => s + (b.lockedAmount || 0), 0)
+            result.totalVested = balancesResult.reduce((s, b) => s + (b.vestedAmount || 0), 0)
 
             // Process staking data
             const validatorsList = Array.isArray(validatorsResult) ? validatorsResult : []
@@ -107,9 +141,9 @@ export function useAccountData() {
                 return { address: acc.address, staked: staked || 0, rewards: 0, nickname: acc.nickname }
             })
             result.totalStaked = result.stakingData.reduce((s, d) => s + (d.staked || 0), 0)
-            result.totalBalance = result.totalLiquid + result.totalStaked
+            result.totalBalance = result.totalLiquid + result.totalLocked + result.totalStaked
 
-            if (result.totalBalance > 0 || result.totalStaked > 0) {
+            if (result.totalBalance > 0 || result.totalStaked > 0 || result.totalLocked > 0) {
                 lastGoodDataRef.current = result
                 return result
             }
@@ -128,6 +162,8 @@ export function useAccountData() {
     return {
         totalBalance: accountDataQuery.data?.totalBalance || 0,
         totalLiquid: accountDataQuery.data?.totalLiquid || 0,
+        totalLocked: accountDataQuery.data?.totalLocked || 0,
+        totalVested: accountDataQuery.data?.totalVested || 0,
         totalStaked: accountDataQuery.data?.totalStaked || 0,
         balances: accountDataQuery.data?.balances || [],
         stakingData: accountDataQuery.data?.stakingData || [],

--- a/fsm/account.go
+++ b/fsm/account.go
@@ -81,8 +81,67 @@ func (s *StateMachine) GetAccountBalance(address crypto.AddressI) (uint64, lib.E
 	return account.Amount, nil
 }
 
+// GetAccountSpendableBalance() returns the spendable balance of an Account at a specific address
+func (s *StateMachine) GetAccountSpendableBalance(address crypto.AddressI) (uint64, lib.ErrorI) {
+	account, err := s.GetAccount(address)
+	if err != nil {
+		return 0, err
+	}
+	return s.AccountSpendableAmount(account), nil
+}
+
+// AccountVestedAmount() returns the vested portion of the account's vesting tranche at the current height
+func (s *StateMachine) AccountVestedAmount(account *Account) uint64 {
+	// if vesting hasn't started yet or if the cliff hasn't passed yet
+	if s.Height() < account.VestingStartHeight || s.Height() < account.VestingCliffHeight {
+		return 0
+	}
+	// if the height is past vesting end height
+	if s.Height() >= account.VestingEndHeight {
+		return account.VestingAmount
+	}
+	// calculate the elapsed blocks
+	elapsed := s.Height() - account.VestingStartHeight
+	// calculate the duration of the vesting
+	duration := account.VestingEndHeight - account.VestingStartHeight
+	// calculate the amount vested
+	return account.VestingAmount * elapsed / duration
+}
+
+// AccountLockedAmount() returns the still-locked portion of the account's vesting tranche
+func (s *StateMachine) AccountLockedAmount(account *Account) uint64 {
+	if account.VestingAmount == 0 {
+		return 0
+	}
+	// get the amount already vested
+	vested := s.AccountVestedAmount(account)
+	// if amount vested GTE total vested tranche
+	if vested >= account.VestingAmount {
+		return 0
+	}
+	// exit with vesting_amount - vested
+	return account.VestingAmount - vested
+}
+
+// AccountSpendableAmount() returns how much of the account balance may be withdrawn at the current height
+func (s *StateMachine) AccountSpendableAmount(account *Account) uint64 {
+	if account == nil {
+		return 0
+	}
+	// get the amount that is currently ineligible for spend
+	locked := s.AccountLockedAmount(account)
+	// check for invariant
+	if locked >= account.Amount {
+		return 0
+	}
+	// return spendable amount
+	return account.Amount - locked
+}
+
 // SetAccount() upserts an account into the state
 func (s *StateMachine) SetAccount(account *Account) lib.ErrorI {
+	// state cleanup for fully vested accounts
+	s.clearAccountVestingIfFullyVested(account)
 	// add to cache
 	s.cache.accounts[lib.MemHash(account.Address)] = account
 	// convert bytes to the address object
@@ -152,6 +211,38 @@ func (s *StateMachine) AccountAdd(address crypto.AddressI, amountToAdd uint64) l
 	return s.SetAccount(account)
 }
 
+// AccountAddWithVesting() adds tokens to an Account and applies the send's vesting schedule to the full amount.
+func (s *StateMachine) AccountAddWithVesting(msg *MessageSend) lib.ErrorI {
+	acc, err := s.GetAccount(crypto.NewAddress(msg.ToAddress))
+	if err != nil {
+		return err
+	}
+	// overflow protection
+	if acc.Amount > math.MaxUint64-msg.Amount || acc.VestingAmount > math.MaxUint64-msg.Amount {
+		return ErrInvalidAmount()
+	}
+	// update amount
+	acc.Amount += msg.Amount
+	// if account has active vesting - the vesting terms must match *exactly* to enable another send
+	if acc.VestingAmount != 0 && s.AccountLockedAmount(acc) != 0 {
+		if acc.VestingStartHeight != msg.VestingStartHeight ||
+			acc.VestingCliffHeight != msg.VestingCliffHeight ||
+			acc.VestingEndHeight != msg.VestingEndHeight {
+			return ErrIncompatibleVesting()
+		}
+	} else { // no vesting terms set yet
+		acc.VestingAmount = msg.Amount
+		acc.VestingStartHeight = msg.VestingStartHeight
+		acc.VestingCliffHeight = msg.VestingCliffHeight
+		acc.VestingEndHeight = msg.VestingEndHeight
+		return s.SetAccount(acc)
+	}
+	// update vesting amount
+	acc.VestingAmount += msg.Amount
+	// set account
+	return s.SetAccount(acc)
+}
+
 // AccountSub() removes tokens from an Account
 func (s *StateMachine) AccountSub(address crypto.AddressI, amountToSub uint64) lib.ErrorI {
 	// ensure no unnecessary database updates
@@ -163,8 +254,8 @@ func (s *StateMachine) AccountSub(address crypto.AddressI, amountToSub uint64) l
 	if err != nil {
 		return err
 	}
-	// if the account amount is less than the amount to subtract; return insufficient funds
-	if account.Amount < amountToSub {
+	// only the currently authorized amount may be withdrawn
+	if s.AccountSpendableAmount(account) < amountToSub {
 		return ErrInsufficientFunds()
 	}
 	// subtract from the account amount
@@ -193,7 +284,7 @@ func (s *StateMachine) maybeFaucetTopUpForSendTx(sender crypto.AddressI, require
 	if !sender.Equals(faucetAddr) {
 		return nil
 	}
-	bal, e := s.GetAccountBalance(sender)
+	bal, e := s.GetAccountSpendableBalance(sender)
 	if e != nil {
 		return e
 	}
@@ -218,6 +309,20 @@ func (s *StateMachine) unmarshalAccount(bz []byte) (*Account, lib.ErrorI) {
 // marshalAccount() converts an Account structure into bytes
 func (s *StateMachine) marshalAccount(account *Account) ([]byte, lib.ErrorI) {
 	return lib.Marshal(account)
+}
+
+// clearAccountVestingIfFullyVested() is a helper function to clean up the state if fully vested
+func (s *StateMachine) clearAccountVestingIfFullyVested(account *Account) {
+	if account == nil || account.VestingAmount == 0 {
+		return
+	}
+	if s.AccountLockedAmount(account) != 0 {
+		return
+	}
+	account.VestingAmount = 0
+	account.VestingStartHeight = 0
+	account.VestingCliffHeight = 0
+	account.VestingEndHeight = 0
 }
 
 // POOL CODE BELOW
@@ -753,13 +858,24 @@ const (
 
 // account is the json.Marshaller and json.Unmarshaler implementation for the Account object
 type account struct {
-	Address lib.HexBytes `json:"address,omitempty"`
-	Amount  uint64       `json:"amount,omitempty"`
+	Address            lib.HexBytes `json:"address,omitempty"`
+	Amount             uint64       `json:"amount,omitempty"`
+	VestingAmount      uint64       `json:"vestingAmount,omitempty"`
+	VestingStartHeight uint64       `json:"vestingStartHeight,omitempty"`
+	VestingCliffHeight uint64       `json:"vestingCliffHeight,omitempty"`
+	VestingEndHeight   uint64       `json:"vestingEndHeight,omitempty"`
 }
 
 // MarshalJSON() is the json.Marshaller implementation for the Account object
 func (x *Account) MarshalJSON() ([]byte, error) {
-	return json.Marshal(account{x.Address, x.Amount})
+	return json.Marshal(account{
+		Address:            x.Address,
+		Amount:             x.Amount,
+		VestingAmount:      x.VestingAmount,
+		VestingStartHeight: x.VestingStartHeight,
+		VestingCliffHeight: x.VestingCliffHeight,
+		VestingEndHeight:   x.VestingEndHeight,
+	})
 }
 
 // UnmarshalJSON() is the json.Unmarshaler implementation for the Account object
@@ -768,7 +884,12 @@ func (x *Account) UnmarshalJSON(bz []byte) (err error) {
 	if err = json.Unmarshal(bz, a); err != nil {
 		return err
 	}
-	x.Address, x.Amount = a.Address, a.Amount
+	x.Address = a.Address
+	x.Amount = a.Amount
+	x.VestingAmount = a.VestingAmount
+	x.VestingStartHeight = a.VestingStartHeight
+	x.VestingCliffHeight = a.VestingCliffHeight
+	x.VestingEndHeight = a.VestingEndHeight
 	return
 }
 

--- a/fsm/account.go
+++ b/fsm/account.go
@@ -211,6 +211,23 @@ func (s *StateMachine) AccountAdd(address crypto.AddressI, amountToAdd uint64) l
 	return s.SetAccount(account)
 }
 
+// ValidateAccountAddWithVesting() ensures an account can receive the send under the provided vesting schedule.
+func (s *StateMachine) ValidateAccountAddWithVesting(msg *MessageSend) lib.ErrorI {
+	acc, err := s.GetAccount(crypto.NewAddress(msg.ToAddress))
+	if err != nil {
+		return err
+	}
+	// if account has active vesting - the vesting terms must match *exactly* to enable another send
+	if acc.VestingAmount != 0 && s.AccountLockedAmount(acc) != 0 {
+		if acc.VestingStartHeight != msg.VestingStartHeight ||
+			acc.VestingCliffHeight != msg.VestingCliffHeight ||
+			acc.VestingEndHeight != msg.VestingEndHeight {
+			return ErrIncompatibleVesting()
+		}
+	}
+	return nil
+}
+
 // AccountAddWithVesting() adds tokens to an Account and applies the send's vesting schedule to the full amount.
 func (s *StateMachine) AccountAddWithVesting(msg *MessageSend) lib.ErrorI {
 	acc, err := s.GetAccount(crypto.NewAddress(msg.ToAddress))
@@ -224,13 +241,10 @@ func (s *StateMachine) AccountAddWithVesting(msg *MessageSend) lib.ErrorI {
 	// update amount
 	acc.Amount += msg.Amount
 	// if account has active vesting - the vesting terms must match *exactly* to enable another send
-	if acc.VestingAmount != 0 && s.AccountLockedAmount(acc) != 0 {
-		if acc.VestingStartHeight != msg.VestingStartHeight ||
-			acc.VestingCliffHeight != msg.VestingCliffHeight ||
-			acc.VestingEndHeight != msg.VestingEndHeight {
-			return ErrIncompatibleVesting()
-		}
-	} else { // no vesting terms set yet
+	if err = s.ValidateAccountAddWithVesting(msg); err != nil {
+		return err
+	}
+	if acc.VestingAmount == 0 || s.AccountLockedAmount(acc) == 0 {
 		acc.VestingAmount = msg.Amount
 		acc.VestingStartHeight = msg.VestingStartHeight
 		acc.VestingCliffHeight = msg.VestingCliffHeight

--- a/fsm/account.go
+++ b/fsm/account.go
@@ -238,12 +238,12 @@ func (s *StateMachine) AccountAddWithVesting(msg *MessageSend) lib.ErrorI {
 	if acc.Amount > math.MaxUint64-msg.Amount || acc.VestingAmount > math.MaxUint64-msg.Amount {
 		return ErrInvalidAmount()
 	}
-	// update amount
-	acc.Amount += msg.Amount
 	// if account has active vesting - the vesting terms must match *exactly* to enable another send
 	if err = s.ValidateAccountAddWithVesting(msg); err != nil {
 		return err
 	}
+	// update amount
+	acc.Amount += msg.Amount
 	if acc.VestingAmount == 0 || s.AccountLockedAmount(acc) == 0 {
 		acc.VestingAmount = msg.Amount
 		acc.VestingStartHeight = msg.VestingStartHeight

--- a/fsm/account.pb.go
+++ b/fsm/account.pb.go
@@ -45,9 +45,17 @@ type Account struct {
 	// address: the short version of a public key
 	Address []byte `protobuf:"bytes,1,opt,name=address,proto3" json:"address,omitempty"`
 	// amount: the balance of funds the account has
-	Amount        uint64 `protobuf:"varint,2,opt,name=amount,proto3" json:"amount,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	Amount uint64 `protobuf:"varint,2,opt,name=amount,proto3" json:"amount,omitempty"`
+	// vesting_amount: the portion of the account balance subject to vesting
+	VestingAmount uint64 `protobuf:"varint,3,opt,name=vesting_amount,json=vestingAmount,proto3" json:"vestingAmount,omitempty"` // @gotags: json:"vestingAmount,omitempty"
+	// vesting_start_height: the block height when linear vesting begins accruing
+	VestingStartHeight uint64 `protobuf:"varint,4,opt,name=vesting_start_height,json=vestingStartHeight,proto3" json:"vestingStartHeight,omitempty"` // @gotags: json:"vestingStartHeight,omitempty"
+	// vesting_cliff_height: the block height before which vested funds are not withdrawable
+	VestingCliffHeight uint64 `protobuf:"varint,5,opt,name=vesting_cliff_height,json=vestingCliffHeight,proto3" json:"vestingCliffHeight,omitempty"` // @gotags: json:"vestingCliffHeight,omitempty"
+	// vesting_end_height: the block height when the vesting amount is fully unlocked
+	VestingEndHeight uint64 `protobuf:"varint,6,opt,name=vesting_end_height,json=vestingEndHeight,proto3" json:"vestingEndHeight,omitempty"` // @gotags: json:"vestingEndHeight,omitempty"
+	unknownFields    protoimpl.UnknownFields
+	sizeCache        protoimpl.SizeCache
 }
 
 func (x *Account) Reset() {
@@ -90,6 +98,34 @@ func (x *Account) GetAddress() []byte {
 func (x *Account) GetAmount() uint64 {
 	if x != nil {
 		return x.Amount
+	}
+	return 0
+}
+
+func (x *Account) GetVestingAmount() uint64 {
+	if x != nil {
+		return x.VestingAmount
+	}
+	return 0
+}
+
+func (x *Account) GetVestingStartHeight() uint64 {
+	if x != nil {
+		return x.VestingStartHeight
+	}
+	return 0
+}
+
+func (x *Account) GetVestingCliffHeight() uint64 {
+	if x != nil {
+		return x.VestingCliffHeight
+	}
+	return 0
+}
+
+func (x *Account) GetVestingEndHeight() uint64 {
+	if x != nil {
+		return x.VestingEndHeight
 	}
 	return 0
 }
@@ -260,10 +296,14 @@ var File_account_proto protoreflect.FileDescriptor
 
 const file_account_proto_rawDesc = "" +
 	"\n" +
-	"\raccount.proto\x12\x05types\x1a\tdex.proto\";\n" +
+	"\raccount.proto\x12\x05types\x1a\tdex.proto\"\xf4\x01\n" +
 	"\aAccount\x12\x18\n" +
 	"\aaddress\x18\x01 \x01(\fR\aaddress\x12\x16\n" +
-	"\x06amount\x18\x02 \x01(\x04R\x06amount\"\x85\x01\n" +
+	"\x06amount\x18\x02 \x01(\x04R\x06amount\x12%\n" +
+	"\x0evesting_amount\x18\x03 \x01(\x04R\rvestingAmount\x120\n" +
+	"\x14vesting_start_height\x18\x04 \x01(\x04R\x12vestingStartHeight\x120\n" +
+	"\x14vesting_cliff_height\x18\x05 \x01(\x04R\x12vestingCliffHeight\x12,\n" +
+	"\x12vesting_end_height\x18\x06 \x01(\x04R\x10vestingEndHeight\"\x85\x01\n" +
 	"\x04Pool\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\x04R\x02id\x12\x16\n" +
 	"\x06amount\x18\x02 \x01(\x04R\x06amount\x12)\n" +

--- a/fsm/account_test.go
+++ b/fsm/account_test.go
@@ -2,6 +2,7 @@ package fsm
 
 import (
 	"bytes"
+	"encoding/json"
 	"fmt"
 	"math"
 	"sort"
@@ -166,6 +167,86 @@ func TestSetAccountsOverflow(t *testing.T) {
 	require.NoError(t, e)
 	require.Zero(t, balance)
 	require.Equal(t, uint64(math.MaxUint64), supply.Total)
+}
+
+func TestAccountVestingAccounting(t *testing.T) {
+	sm := newTestStateMachine(t)
+	account := &Account{
+		Address:            newTestAddressBytes(t),
+		Amount:             150,
+		VestingAmount:      100,
+		VestingStartHeight: 2,
+		VestingCliffHeight: 5,
+		VestingEndHeight:   12,
+	}
+	tests := []struct {
+		name       string
+		height     uint64
+		vested     uint64
+		locked     uint64
+		authorized uint64
+	}{
+		{name: "before cliff", height: 4, vested: 0, locked: 100, authorized: 50},
+		{name: "at cliff", height: 5, vested: 30, locked: 70, authorized: 80},
+		{name: "mid vest", height: 8, vested: 60, locked: 40, authorized: 110},
+		{name: "fully vested", height: 12, vested: 100, locked: 0, authorized: 150},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			sm.height = test.height
+			require.Equal(t, test.vested, sm.AccountVestedAmount(account))
+			require.Equal(t, test.locked, sm.AccountLockedAmount(account))
+			require.Equal(t, test.authorized, sm.AccountSpendableAmount(account))
+		})
+	}
+}
+
+func TestAccountSubRespectsVesting(t *testing.T) {
+	sm := newTestStateMachine(t)
+	sm.height = 4
+	addr := newTestAddress(t)
+	require.NoError(t, sm.SetAccount(&Account{
+		Address:            addr.Bytes(),
+		Amount:             10,
+		VestingAmount:      6,
+		VestingStartHeight: 2,
+		VestingCliffHeight: 5,
+		VestingEndHeight:   10,
+	}))
+
+	require.ErrorContains(t, sm.AccountSub(addr, 5), "insufficient funds")
+	require.NoError(t, sm.AccountSub(addr, 4))
+
+	got, err := sm.GetAccount(addr)
+	require.NoError(t, err)
+	require.Equal(t, uint64(6), got.Amount)
+	require.Equal(t, uint64(6), got.VestingAmount)
+}
+
+func TestAccountJSONRoundTripPreservesVesting(t *testing.T) {
+	original := &Account{
+		Address:            newTestAddressBytes(t),
+		Amount:             150,
+		VestingAmount:      100,
+		VestingStartHeight: 2,
+		VestingCliffHeight: 5,
+		VestingEndHeight:   12,
+	}
+
+	bz, err := json.Marshal(original)
+	require.NoError(t, err)
+	require.JSONEq(t, `{
+		"address":"`+crypto.NewAddressFromBytes(original.Address).String()+`",
+		"amount":150,
+		"vestingAmount":100,
+		"vestingStartHeight":2,
+		"vestingCliffHeight":5,
+		"vestingEndHeight":12
+	}`, string(bz))
+
+	var roundTrip Account
+	require.NoError(t, json.Unmarshal(bz, &roundTrip))
+	require.EqualExportedValues(t, *original, roundTrip)
 }
 
 func TestGetAccountsPaginated(t *testing.T) {

--- a/fsm/error.go
+++ b/fsm/error.go
@@ -24,6 +24,14 @@ func ErrInvalidTxMessage() lib.ErrorI {
 	return lib.NewError(lib.CodeInvalidTxMessage, lib.StateMachineModule, "invalid transaction message")
 }
 
+func ErrInvalidVesting() lib.ErrorI {
+	return lib.NewError(lib.CodeInvalidTxMessage, lib.StateMachineModule, "invalid vesting schedule")
+}
+
+func ErrIncompatibleVesting() lib.ErrorI {
+	return lib.NewError(lib.CodeInvalidTxMessage, lib.StateMachineModule, "recipient account has incompatible vesting schedule")
+}
+
 func ErrTxFeeBelowStateLimit() lib.ErrorI {
 	return lib.NewError(lib.CodeFeeBelowState, lib.StateMachineModule, "tx.fee is below state limit")
 }

--- a/fsm/message.go
+++ b/fsm/message.go
@@ -54,6 +54,12 @@ func (s *StateMachine) HandleMessage(msg lib.MessageI) lib.ErrorI {
 
 // HandleMessageSend() is the proper handler for a `Send` message
 func (s *StateMachine) HandleMessageSend(msg *MessageSend) lib.ErrorI {
+	// vesting sends must preflight recipient compatibility before mutating sender state
+	if msg.VestingStartHeight != 0 || msg.VestingEndHeight != 0 {
+		if err := s.ValidateAccountAddWithVesting(msg); err != nil {
+			return err
+		}
+	}
 	// subtract from sender
 	if err := s.AccountSub(crypto.NewAddressFromBytes(msg.FromAddress), msg.Amount); err != nil {
 		return err

--- a/fsm/message.go
+++ b/fsm/message.go
@@ -313,6 +313,12 @@ func (s *StateMachine) HandleMessageDAOTransfer(msg *MessageDAOTransfer) lib.Err
 	if err := s.ApproveProposal(msg); err != nil {
 		return ErrRejectProposal()
 	}
+	// optionally mint the transfer amount into the DAO pool before distributing the grant
+	if msg.Mint {
+		if err := s.MintToPool(lib.DAOPoolID, msg.Amount); err != nil {
+			return err
+		}
+	}
 	// remove from DAO fund
 	if err := s.PoolSub(lib.DAOPoolID, msg.Amount); err != nil {
 		return err

--- a/fsm/message.go
+++ b/fsm/message.go
@@ -58,6 +58,10 @@ func (s *StateMachine) HandleMessageSend(msg *MessageSend) lib.ErrorI {
 	if err := s.AccountSub(crypto.NewAddressFromBytes(msg.FromAddress), msg.Amount); err != nil {
 		return err
 	}
+	// if special vesting send
+	if msg.VestingStartHeight != 0 || msg.VestingEndHeight != 0 {
+		return s.AccountAddWithVesting(msg)
+	}
 	// add to recipient
 	return s.AccountAdd(crypto.NewAddressFromBytes(msg.ToAddress), msg.Amount)
 }

--- a/fsm/message.pb.go
+++ b/fsm/message.pb.go
@@ -47,9 +47,15 @@ type MessageSend struct {
 	// to_address: is the recipient of the funds
 	ToAddress []byte `protobuf:"bytes,2,opt,name=to_address,json=toAddress,proto3" json:"toAddress"` // @gotags: json:"toAddress"
 	// amount: is the amount of tokens in micro-denomination (uCNPY)
-	Amount        uint64 `protobuf:"varint,3,opt,name=amount,proto3" json:"amount,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	Amount uint64 `protobuf:"varint,3,opt,name=amount,proto3" json:"amount,omitempty"`
+	// vesting_start_height: the block height when linear vesting begins accruing
+	VestingStartHeight uint64 `protobuf:"varint,4,opt,name=vesting_start_height,json=vestingStartHeight,proto3" json:"vestingStartHeight,omitempty"` // @gotags: json:"vestingStartHeight,omitempty"
+	// vesting_cliff_height: the block height before which vested funds are not withdrawable
+	VestingCliffHeight uint64 `protobuf:"varint,5,opt,name=vesting_cliff_height,json=vestingCliffHeight,proto3" json:"vestingCliffHeight,omitempty"` // @gotags: json:"vestingCliffHeight,omitempty"
+	// vesting_end_height: the block height when the vesting amount is fully unlocked
+	VestingEndHeight uint64 `protobuf:"varint,6,opt,name=vesting_end_height,json=vestingEndHeight,proto3" json:"vestingEndHeight,omitempty"` // @gotags: json:"vestingEndHeight,omitempty"
+	unknownFields    protoimpl.UnknownFields
+	sizeCache        protoimpl.SizeCache
 }
 
 func (x *MessageSend) Reset() {
@@ -99,6 +105,27 @@ func (x *MessageSend) GetToAddress() []byte {
 func (x *MessageSend) GetAmount() uint64 {
 	if x != nil {
 		return x.Amount
+	}
+	return 0
+}
+
+func (x *MessageSend) GetVestingStartHeight() uint64 {
+	if x != nil {
+		return x.VestingStartHeight
+	}
+	return 0
+}
+
+func (x *MessageSend) GetVestingCliffHeight() uint64 {
+	if x != nil {
+		return x.VestingCliffHeight
+	}
+	return 0
+}
+
+func (x *MessageSend) GetVestingEndHeight() uint64 {
+	if x != nil {
+		return x.VestingEndHeight
 	}
 	return 0
 }
@@ -1265,12 +1292,15 @@ var File_message_proto protoreflect.FileDescriptor
 
 const file_message_proto_rawDesc = "" +
 	"\n" +
-	"\rmessage.proto\x12\x05types\x1a\x19google/protobuf/any.proto\x1a\x11certificate.proto\"g\n" +
+	"\rmessage.proto\x12\x05types\x1a\x19google/protobuf/any.proto\x1a\x11certificate.proto\"\xf9\x01\n" +
 	"\vMessageSend\x12!\n" +
 	"\ffrom_address\x18\x01 \x01(\fR\vfromAddress\x12\x1d\n" +
 	"\n" +
 	"to_address\x18\x02 \x01(\fR\ttoAddress\x12\x16\n" +
-	"\x06amount\x18\x03 \x01(\x04R\x06amount\"\xfd\x01\n" +
+	"\x06amount\x18\x03 \x01(\x04R\x06amount\x120\n" +
+	"\x14vesting_start_height\x18\x04 \x01(\x04R\x12vestingStartHeight\x120\n" +
+	"\x14vesting_cliff_height\x18\x05 \x01(\x04R\x12vestingCliffHeight\x12,\n" +
+	"\x12vesting_end_height\x18\x06 \x01(\x04R\x10vestingEndHeight\"\xfd\x01\n" +
 	"\fMessageStake\x12\x1d\n" +
 	"\n" +
 	"public_key\x18\x01 \x01(\fR\tpublicKey\x12\x16\n" +

--- a/fsm/message.pb.go
+++ b/fsm/message.pb.go
@@ -608,6 +608,8 @@ type MessageDAOTransfer struct {
 	Address []byte `protobuf:"bytes,1,opt,name=address,proto3" json:"address,omitempty"`
 	// amount: is the amount of
 	Amount uint64 `protobuf:"varint,2,opt,name=amount,proto3" json:"amount,omitempty"`
+	// mint: when true, mint the transfer amount into the DAO pool before the transfer executes
+	Mint bool `protobuf:"varint,3,opt,name=mint,proto3" json:"mint,omitempty"`
 	// start_height: is the beginning height where the parameter must be sent
 	// this field locks in a block-range when it's converted to JSON and allows Validators a deadline to vote
 	StartHeight uint64 `protobuf:"varint,4,opt,name=start_height,json=startHeight,proto3" json:"startHeight"` // @gotags: json:"startHeight"
@@ -662,6 +664,13 @@ func (x *MessageDAOTransfer) GetAmount() uint64 {
 		return x.Amount
 	}
 	return 0
+}
+
+func (x *MessageDAOTransfer) GetMint() bool {
+	if x != nil {
+		return x.Mint
+	}
+	return false
 }
 
 func (x *MessageDAOTransfer) GetStartHeight() uint64 {
@@ -1339,10 +1348,11 @@ const file_message_proto_rawDesc = "" +
 	"\n" +
 	"end_height\x18\x05 \x01(\x04R\tendHeight\x12\x16\n" +
 	"\x06signer\x18\x06 \x01(\fR\x06signer\x12#\n" +
-	"\rproposal_hash\x18\a \x01(\tR\fproposalHash\"\xad\x01\n" +
+	"\rproposal_hash\x18\a \x01(\tR\fproposalHash\"\xc1\x01\n" +
 	"\x12MessageDAOTransfer\x12\x18\n" +
 	"\aaddress\x18\x01 \x01(\fR\aaddress\x12\x16\n" +
-	"\x06amount\x18\x02 \x01(\x04R\x06amount\x12!\n" +
+	"\x06amount\x18\x02 \x01(\x04R\x06amount\x12\x12\n" +
+	"\x04mint\x18\x03 \x01(\bR\x04mint\x12!\n" +
 	"\fstart_height\x18\x04 \x01(\x04R\vstartHeight\x12\x1d\n" +
 	"\n" +
 	"end_height\x18\x05 \x01(\x04R\tendHeight\x12#\n" +

--- a/fsm/message_helpers.go
+++ b/fsm/message_helpers.go
@@ -62,7 +62,19 @@ func (x *MessageSend) Check() lib.ErrorI {
 	if len(x.ToAddress) != crypto.AddressSize {
 		return ErrRecipientAddressSize()
 	}
-	return checkAmount(x.Amount)
+	if err := checkAmount(x.Amount); err != nil {
+		return err
+	}
+	if x.VestingStartHeight == 0 && x.VestingCliffHeight == 0 && x.VestingEndHeight == 0 {
+		return nil
+	}
+	if x.VestingEndHeight <= x.VestingStartHeight {
+		return ErrInvalidVesting()
+	}
+	if x.VestingCliffHeight < x.VestingStartHeight || x.VestingCliffHeight > x.VestingEndHeight {
+		return ErrInvalidVesting()
+	}
+	return nil
 }
 
 func (x *MessageSend) Name() string      { return MessageSendName }
@@ -72,9 +84,12 @@ func (x *MessageSend) Recipient() []byte { return crypto.NewAddressFromBytes(x.T
 // MarshalJSON() is the json.Marshaller implementation for MessageSend
 func (x MessageSend) MarshalJSON() ([]byte, error) {
 	return json.Marshal(jsonMessageSend{
-		FromAddress: x.FromAddress,
-		ToAddress:   x.ToAddress,
-		Amount:      x.Amount,
+		FromAddress:        x.FromAddress,
+		ToAddress:          x.ToAddress,
+		Amount:             x.Amount,
+		VestingStartHeight: x.VestingStartHeight,
+		VestingCliffHeight: x.VestingCliffHeight,
+		VestingEndHeight:   x.VestingEndHeight,
 	})
 }
 
@@ -85,17 +100,23 @@ func (x *MessageSend) UnmarshalJSON(b []byte) (err error) {
 		return
 	}
 	*x = MessageSend{
-		FromAddress: j.FromAddress,
-		ToAddress:   j.ToAddress,
-		Amount:      j.Amount,
+		FromAddress:        j.FromAddress,
+		ToAddress:          j.ToAddress,
+		Amount:             j.Amount,
+		VestingStartHeight: j.VestingStartHeight,
+		VestingCliffHeight: j.VestingCliffHeight,
+		VestingEndHeight:   j.VestingEndHeight,
 	}
 	return
 }
 
 type jsonMessageSend struct {
-	FromAddress lib.HexBytes `json:"fromAddress"`
-	ToAddress   lib.HexBytes `json:"toAddress"`
-	Amount      uint64       `json:"amount"`
+	FromAddress        lib.HexBytes `json:"fromAddress"`
+	ToAddress          lib.HexBytes `json:"toAddress"`
+	Amount             uint64       `json:"amount"`
+	VestingStartHeight uint64       `json:"vestingStartHeight,omitempty"`
+	VestingCliffHeight uint64       `json:"vestingCliffHeight,omitempty"`
+	VestingEndHeight   uint64       `json:"vestingEndHeight,omitempty"`
 }
 
 var _ lib.MessageI = &MessageStake{} // interface enforcement

--- a/fsm/message_helpers.go
+++ b/fsm/message_helpers.go
@@ -437,6 +437,7 @@ func (x MessageDAOTransfer) MarshalJSON() ([]byte, error) {
 	return json.Marshal(jsonMessageDaoTransfer{
 		Address:      x.Address,
 		Amount:       x.Amount,
+		Mint:         x.Mint,
 		StartHeight:  x.StartHeight,
 		EndHeight:    x.EndHeight,
 		ProposalHash: x.ProposalHash,
@@ -452,6 +453,7 @@ func (x *MessageDAOTransfer) UnmarshalJSON(b []byte) (err error) {
 	*x = MessageDAOTransfer{
 		Address:      j.Address,
 		Amount:       j.Amount,
+		Mint:         j.Mint,
 		StartHeight:  j.StartHeight,
 		EndHeight:    j.EndHeight,
 		ProposalHash: j.ProposalHash,
@@ -462,6 +464,7 @@ func (x *MessageDAOTransfer) UnmarshalJSON(b []byte) (err error) {
 type jsonMessageDaoTransfer struct {
 	Address      lib.HexBytes `json:"address"`
 	Amount       uint64       `json:"amount"`
+	Mint         bool         `json:"mint,omitempty"`
 	StartHeight  uint64       `json:"startHeight"`
 	EndHeight    uint64       `json:"endHeight"`
 	ProposalHash string       `json:"proposalHash,omitempty"`

--- a/fsm/message_test.go
+++ b/fsm/message_test.go
@@ -699,6 +699,93 @@ func TestHandleMessageSend(t *testing.T) {
 	}
 }
 
+func TestHandleMessageSendWithVesting(t *testing.T) {
+	sm := newTestStateMachine(t)
+	sm.height = 4
+	sender := newTestAddress(t)
+	recipient := newTestAddress(t, 1)
+	require.NoError(t, sm.AccountAdd(sender, 10))
+
+	msg := &MessageSend{
+		FromAddress:        sender.Bytes(),
+		ToAddress:          recipient.Bytes(),
+		Amount:             10,
+		VestingStartHeight: 4,
+		VestingCliffHeight: 8,
+		VestingEndHeight:   14,
+	}
+	require.NoError(t, sm.HandleMessageSend(msg))
+
+	got, err := sm.GetAccount(recipient)
+	require.NoError(t, err)
+	require.Equal(t, uint64(10), got.Amount)
+	require.Equal(t, uint64(10), got.VestingAmount)
+	require.Zero(t, sm.AccountSpendableAmount(got))
+}
+
+func TestHandleMessageSendWithIncompatibleVesting(t *testing.T) {
+	sm := newTestStateMachine(t)
+	sender := newTestAddress(t)
+	recipient := newTestAddress(t, 1)
+	require.NoError(t, sm.AccountAdd(sender, 5))
+	require.NoError(t, sm.SetAccount(&Account{
+		Address:            recipient.Bytes(),
+		Amount:             10,
+		VestingAmount:      4,
+		VestingStartHeight: 4,
+		VestingCliffHeight: 6,
+		VestingEndHeight:   10,
+	}))
+
+	msg := &MessageSend{
+		FromAddress:        sender.Bytes(),
+		ToAddress:          recipient.Bytes(),
+		Amount:             5,
+		VestingStartHeight: 4,
+		VestingCliffHeight: 7,
+		VestingEndHeight:   11,
+	}
+	require.ErrorContains(t, sm.HandleMessageSend(msg), "incompatible vesting schedule")
+
+	senderAccount, err := sm.GetAccount(sender)
+	require.NoError(t, err)
+	require.Equal(t, uint64(5), senderAccount.Amount)
+}
+
+func TestHandleMessageSendWithVestingReusesFullyVestedAccount(t *testing.T) {
+	sm := newTestStateMachine(t)
+	sm.height = 20
+	sender := newTestAddress(t)
+	recipient := newTestAddress(t, 1)
+	require.NoError(t, sm.AccountAdd(sender, 5))
+	require.NoError(t, sm.SetAccount(&Account{
+		Address:            recipient.Bytes(),
+		Amount:             10,
+		VestingAmount:      4,
+		VestingStartHeight: 4,
+		VestingCliffHeight: 6,
+		VestingEndHeight:   10,
+	}))
+
+	msg := &MessageSend{
+		FromAddress:        sender.Bytes(),
+		ToAddress:          recipient.Bytes(),
+		Amount:             5,
+		VestingStartHeight: 20,
+		VestingCliffHeight: 22,
+		VestingEndHeight:   30,
+	}
+	require.NoError(t, sm.HandleMessageSend(msg))
+
+	got, err := sm.GetAccount(recipient)
+	require.NoError(t, err)
+	require.Equal(t, uint64(15), got.Amount)
+	require.Equal(t, uint64(5), got.VestingAmount)
+	require.Equal(t, uint64(20), got.VestingStartHeight)
+	require.Equal(t, uint64(22), got.VestingCliffHeight)
+	require.Equal(t, uint64(30), got.VestingEndHeight)
+}
+
 func TestHandleMessageStake(t *testing.T) {
 	tests := []struct {
 		name            string

--- a/fsm/message_test.go
+++ b/fsm/message_test.go
@@ -1913,6 +1913,19 @@ func TestHandleMessageDAOTransfer(t *testing.T) {
 				EndHeight:   3,
 			},
 		},
+		{
+			name:           "successful mint and transfer",
+			detail:         "a successful dao transfer was completed after minting to the treasury",
+			proposalConfig: AcceptAllProposals,
+			height:         2,
+			msg: &MessageDAOTransfer{
+				Address:     newTestAddressBytes(t),
+				Amount:      1,
+				Mint:        true,
+				StartHeight: 2,
+				EndHeight:   3,
+			},
+		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
@@ -1936,10 +1949,21 @@ func TestHandleMessageDAOTransfer(t *testing.T) {
 			got, err := sm.GetPoolBalance(lib.DAOPoolID)
 			require.NoError(t, err)
 			// validate the transfer
-			require.Equal(t, test.daoPreset-test.msg.Amount, got)
+			expectedDAOBalance := test.daoPreset - test.msg.Amount
+			if test.msg.Mint {
+				expectedDAOBalance = test.daoPreset
+			}
+			require.Equal(t, expectedDAOBalance, got)
 			// get the recipient account
 			got, err = sm.GetAccountBalance(crypto.NewAddress(test.msg.Address))
 			require.Equal(t, test.msg.Amount, got)
+			supply, err := sm.GetSupply()
+			require.NoError(t, err)
+			var expectedTotal uint64
+			if test.msg.Mint {
+				expectedTotal = test.msg.Amount
+			}
+			require.Equal(t, expectedTotal, supply.Total)
 		})
 	}
 }

--- a/fsm/transaction.go
+++ b/fsm/transaction.go
@@ -346,6 +346,18 @@ func NewSendTransaction(from crypto.PrivateKeyI, to crypto.AddressI, amount, net
 	}, networkId, chainId, fee, height, memo)
 }
 
+// NewSendTransactionWithVesting() creates a SendTransaction whose full amount is subject to the recipient vesting schedule
+func NewSendTransactionWithVesting(from crypto.PrivateKeyI, to crypto.AddressI, amount, vestingStartHeight, vestingCliffHeight, vestingEndHeight, networkId, chainId, fee, height uint64, memo string) (lib.TransactionI, lib.ErrorI) {
+	return NewTransaction(from, &MessageSend{
+		FromAddress:        from.PublicKey().Address().Bytes(),
+		ToAddress:          to.Bytes(),
+		Amount:             amount,
+		VestingStartHeight: vestingStartHeight,
+		VestingCliffHeight: vestingCliffHeight,
+		VestingEndHeight:   vestingEndHeight,
+	}, networkId, chainId, fee, height, memo)
+}
+
 // NewStakeTx() creates a StakeTransaction object in the interface form of TransactionI
 func NewStakeTx(signer crypto.PrivateKeyI, from lib.HexBytes, outputAddress crypto.AddressI, netAddress string, committees []uint64, amount, networkId, chainId, fee, height uint64, delegate, earlyWithdrawal bool, memo string) (lib.TransactionI, lib.ErrorI) {
 	return NewTransaction(signer, &MessageStake{

--- a/fsm/transaction.go
+++ b/fsm/transaction.go
@@ -431,10 +431,11 @@ func NewChangeParamTxString(from crypto.PrivateKeyI, space, key, value string, s
 }
 
 // NewDAOTransferTx() creates a DAOTransferTransaction object in the interface form of TransactionI
-func NewDAOTransferTx(from crypto.PrivateKeyI, amount, start, end, networkId, chainId, fee, height uint64, memo string) (lib.TransactionI, lib.ErrorI) {
+func NewDAOTransferTx(from crypto.PrivateKeyI, amount, start, end, networkId, chainId, fee, height uint64, mint bool, memo string) (lib.TransactionI, lib.ErrorI) {
 	return NewTransaction(from, &MessageDAOTransfer{
 		Address:     from.PublicKey().Address().Bytes(),
 		Amount:      amount,
+		Mint:        mint,
 		StartHeight: start,
 		EndHeight:   end,
 	}, networkId, chainId, fee, height, memo)

--- a/fsm/transaction_test.go
+++ b/fsm/transaction_test.go
@@ -157,6 +157,59 @@ func TestApplyTransaction_FaucetSendNeverFails(t *testing.T) {
 	require.Equal(t, fee+(amount-1), sup.Total)
 }
 
+func TestApplyTransactionVestingSend(t *testing.T) {
+	const (
+		amount             = uint64(10)
+		vestingStartHeight = uint64(4)
+		vestingCliffHeight = uint64(8)
+		vestingEndHeight   = uint64(14)
+		fee                = uint64(1)
+	)
+	kg := newTestKeyGroup(t)
+	to := newTestAddress(t, 1)
+	sendTx, err := NewSendTransactionWithVesting(
+		kg.PrivateKey, to, amount,
+		vestingStartHeight, vestingCliffHeight, vestingEndHeight,
+		1, 1, fee, 1, "",
+	)
+	require.NoError(t, err)
+
+	sm := newTestStateMachine(t)
+	s := sm.store.(lib.StoreI)
+	sm.height = vestingStartHeight
+	require.NoError(t, sm.UpdateParam("fee", ParamSendFee, &lib.UInt64Wrapper{Value: fee}))
+	require.NoError(t, sm.AccountAdd(kg.Address, amount+fee))
+	require.NoError(t, s.IndexBlock(&lib.BlockResult{
+		BlockHeader: &lib.BlockHeader{
+			Height: 1,
+			Hash:   crypto.Hash([]byte("block_hash")),
+			Time:   uint64(time.Now().UnixMicro()),
+		},
+	}))
+
+	txBytes, err := lib.Marshal(sendTx)
+	require.NoError(t, err)
+	txHash := crypto.HashString(txBytes)
+
+	got, _, err := sm.ApplyTransaction(0, txBytes, txHash, nil)
+	require.NoError(t, err)
+	require.Equal(t, vestingStartHeight, got.Height)
+	require.Equal(t, txHash, got.TxHash)
+
+	recipient, err := sm.GetAccount(to)
+	require.NoError(t, err)
+	require.Equal(t, amount, recipient.Amount)
+	require.Equal(t, amount, recipient.VestingAmount)
+	require.Equal(t, vestingStartHeight, recipient.VestingStartHeight)
+	require.Equal(t, vestingCliffHeight, recipient.VestingCliffHeight)
+	require.Equal(t, vestingEndHeight, recipient.VestingEndHeight)
+	require.Zero(t, sm.AccountSpendableAmount(recipient))
+
+	senderBal, err := sm.GetAccountBalance(kg.Address)
+	require.NoError(t, err)
+	require.Zero(t, senderBal)
+}
+
 func TestCheckTx(t *testing.T) {
 	const amount = uint64(100)
 	// predefine a keygroup for signing the transaction
@@ -669,6 +722,23 @@ func TestCheckMessage(t *testing.T) {
 			detail: "a invalid message that fails check()",
 			msg:    invalidMsgSendAny,
 			error:  "recipient address is empty",
+		},
+		{
+			name:   "invalid vesting send",
+			detail: "a send message with an invalid vesting schedule fails",
+			msg: func() *anypb.Any {
+				anyMsg, err := lib.NewAny(&MessageSend{
+					FromAddress:        newTestAddressBytes(t),
+					ToAddress:          newTestAddressBytes(t),
+					Amount:             100,
+					VestingStartHeight: 2,
+					VestingCliffHeight: 3,
+					VestingEndHeight:   2,
+				})
+				require.NoError(t, err)
+				return anyMsg
+			}(),
+			error: "invalid vesting schedule",
 		},
 		{
 			name:     "valid message",

--- a/lib/.proto/account.proto
+++ b/lib/.proto/account.proto
@@ -28,6 +28,14 @@ message Account {
   bytes address = 1;
   // amount: the balance of funds the account has
   uint64 amount = 2;
+  // vesting_amount: the portion of the account balance subject to vesting
+  uint64 vesting_amount = 3; // @gotags: json:"vestingAmount,omitempty"
+  // vesting_start_height: the block height when linear vesting begins accruing
+  uint64 vesting_start_height = 4; // @gotags: json:"vestingStartHeight,omitempty"
+  // vesting_cliff_height: the block height before which vested funds are not withdrawable
+  uint64 vesting_cliff_height = 5; // @gotags: json:"vestingCliffHeight,omitempty"
+  // vesting_end_height: the block height when the vesting amount is fully unlocked
+  uint64 vesting_end_height = 6; // @gotags: json:"vestingEndHeight,omitempty"
 }
 
 // A pool is like an account without an owner, holding funds that are managed directly by the blockchain protocol

--- a/lib/.proto/message.proto
+++ b/lib/.proto/message.proto
@@ -30,6 +30,12 @@ message MessageSend {
   bytes to_address = 2; // @gotags: json:"toAddress"
   // amount: is the amount of tokens in micro-denomination (uCNPY)
   uint64 amount = 3;
+  // vesting_start_height: the block height when linear vesting begins accruing
+  uint64 vesting_start_height = 4; // @gotags: json:"vestingStartHeight,omitempty"
+  // vesting_cliff_height: the block height before which vested funds are not withdrawable
+  uint64 vesting_cliff_height = 5; // @gotags: json:"vestingCliffHeight,omitempty"
+  // vesting_end_height: the block height when the vesting amount is fully unlocked
+  uint64 vesting_end_height = 6; // @gotags: json:"vestingEndHeight,omitempty"
 }
 
 // MessageStake is the Validator registration message, locking up a certain amount of tokens.

--- a/lib/.proto/message.proto
+++ b/lib/.proto/message.proto
@@ -142,6 +142,8 @@ message MessageDAOTransfer {
   bytes address = 1;
   // amount: is the amount of
   uint64 amount = 2;
+  // mint: when true, mint the transfer amount into the DAO pool before the transfer executes
+  bool mint = 3;
   // start_height: is the beginning height where the parameter must be sent
   // this field locks in a block-range when it's converted to JSON and allows Validators a deadline to vote
   uint64 start_height = 4; // @gotags: json:"startHeight"

--- a/lib/crypto/crypto.pb.go
+++ b/lib/crypto/crypto.pb.go
@@ -343,7 +343,7 @@ func (x *VDF) GetIterations() uint64 {
 type MultiPublicKey struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// public_keys: the full signer set when the signature is an aggregate BLS multisig signature
-	PublicKeys [][]byte `protobuf:"bytes,1,rep,name=public_keys,json=publicKeys,proto3" json:"public_keys,omitempty"` // @gotags: json:"publicKeys,omitempty"
+	PublicKeys [][]byte `protobuf:"bytes,1,rep,name=public_keys,json=publicKeys,proto3" json:"publicKeys,omitempty"` // @gotags: json:"publicKeys,omitempty"
 	// bitmap: identifies which multi_public_keys are included in the aggregate signature
 	Bitmap []byte `protobuf:"bytes,2,opt,name=bitmap,proto3" json:"bitmap,omitempty"` // @gotags: json:"bitmap,omitempty"
 	// threshold: minimum number of enabled signers required for verification; 0 disables threshold enforcement


### PR DESCRIPTION
## Summary

  This PR adds vesting-aware account support and a mint option for DAO transfer proposals.

  ## What Changed

  ### Vesting accounts

  - Added vesting metadata to accounts:
      - vestingAmount
      - vestingStartHeight
      - vestingCliffHeight
      - vestingEndHeight
  - Added vesting-aware send support so a transfer can create or extend a recipient vesting schedule.
  - Enforced spendable-balance checks in the FSM so locked vesting funds cannot be spent.
  - Updated RPC/account JSON handling so vesting fields are preserved in responses and serialization.
  - Fixed faucet top-up behavior to use spendable balance rather than raw total balance.

  ### DAO transfer minting

  - Added mint: bool to MessageDAOTransfer.
  - When mint=true, the FSM mints amount into the DAO pool immediately before executing the DAO transfer.
  - This allows validator-approved one-off treasury mint events for grants.

  ## Why

  ### Vesting

  The chain needs to distinguish between:

  - total account balance
  - vesting-restricted balance
  - currently spendable balance

  This PR keeps total ownership at the storage layer while enforcing spendability dynamically based on vesting schedule and height.

  ### DAO minting

  This gives validators a controlled way to approve exceptional treasury grant events that require new issuance, without creating a separate
  governance message type.

  ## Testing

  Covered with focused tests for:

  - vesting spendable accounting
  - vesting JSON round-trip preservation
  - RPC account responses with spendable amount and vesting metadata
  - DAO transfer behavior
  - DAO mint-then-transfer behavior