### PR TITLE
Audit fixes

### DIFF
--- a/bft/bft.go
+++ b/bft/bft.go
@@ -689,7 +689,7 @@ func (b *BFT) SafeNode(msg *Message) lib.ErrorI {
 		return ErrNoSafeNodeJustification()
 	}
 	// ensure the messages' HighQC justifies its proposal (should have the same hashes)
-	if !bytes.Equal(b.BlockToHash(msg.Qc.Block), msg.HighQc.BlockHash) && !bytes.Equal(msg.Qc.Results.Hash(), msg.HighQc.ResultsHash) {
+	if !bytes.Equal(b.BlockToHash(msg.Qc.Block), msg.HighQc.BlockHash) || !bytes.Equal(msg.Qc.Results.Hash(), msg.HighQc.ResultsHash) {
 		return ErrMismatchedProposals()
 	}
 	// if the hashes of the Locked proposal is the same as the Leader's message

--- a/bft/bft_test.go
+++ b/bft/bft_test.go
@@ -1010,9 +1010,11 @@ func TestSafeNode(t *testing.T) {
 					HighQc: c2.bft.HighQC,
 				})
 			default:
-				msgProposal, hash := c.cont.NewTestBlock(), c.cont.NewTestBlock2()
+				msgProposal, hash, resultsHash := c.cont.NewTestBlock(), c.cont.NewTestBlockHash2(), []byte(nil)
 				if test.samePropInMsg {
-					hash = c.cont.NewTestBlockHash()
+					msgProposal = c.cont.NewTestBlock2()
+					hash = c.cont.NewTestBlockHash2()
+					resultsHash = c.bft.HighQC.Results.Hash()
 				}
 				err = c.bft.SafeNode(&Message{
 					Qc: &QC{
@@ -1020,8 +1022,9 @@ func TestSafeNode(t *testing.T) {
 						Block:   msgProposal,
 					},
 					HighQc: &QC{
-						Header:    c.bft.HighQC.Header,
-						BlockHash: hash,
+						Header:      c.bft.HighQC.Header,
+						BlockHash:   hash,
+						ResultsHash: resultsHash,
 					},
 				})
 			}

--- a/bft/msg.go
+++ b/bft/msg.go
@@ -98,6 +98,23 @@ func (b *BFT) CheckProposerMessage(x *Message, p *validateMessageParams) (isPart
 	if err != nil {
 		return
 	}
+	if x.HighQc != nil {
+		if err = x.HighQc.CheckBasic(); err != nil {
+			return false, err
+		}
+		highQCVals, highQCView := p.vals, p.view
+		if x.HighQc.Header.RootHeight != p.rootHeight {
+			b.Controller.Lock()
+			highQCVals, err = b.LoadCommittee(b.LoadRootChainId(x.HighQc.Header.Height), x.HighQc.Header.RootHeight)
+			b.Controller.Unlock()
+			if err != nil {
+				return false, err
+			}
+		}
+		if err = x.HighQc.CheckHighQC(lib.GlobalMaxBlockSize, highQCView, p.rootHeightUpdated, highQCVals); err != nil {
+			return false, err
+		}
+	}
 	// A QC from a different root height must not justify a proposer message for the local view.
 	// Still allow storing it as partial-QC evidence (see AddPartialQC) if it's not +2/3 majority.
 	if x.Qc.Header.RootHeight != p.rootHeight {
@@ -229,7 +246,7 @@ func (x *Message) SignBytes() (signBytes []byte) {
 			ProposerKey: x.Qc.ProposerKey,
 		}).SignBytes()
 	case x.IsPacemakerMessage():
-		signBytes, _ = lib.Marshal(&Message{Header: x.Header})
+		signBytes, _ = lib.Marshal(&Message{Qc: &QC{Header: x.Qc.Header}})
 	}
 	return
 }
@@ -301,25 +318,27 @@ func (b *BFT) GetValidateMessageParams(msg *Message) (*validateMessageParams, li
 		blockHash, resultsHash = b.GetBlockHash(), b.Results.Hash()
 	}
 	return &validateMessageParams{
-		view:           b.View.Copy(),
-		vals:           b.ValidatorSet,
-		rootHeight:     b.RootHeight,
-		height:         b.Height,
-		cHeightUpdated: b.CommitteeData.LastChainHeightUpdated,
-		blockHash:      blockHash,
-		resultsHash:    resultsHash,
+		view:              b.View.Copy(),
+		vals:              b.ValidatorSet,
+		rootHeight:        b.RootHeight,
+		rootHeightUpdated: b.CommitteeData.LastRootHeightUpdated,
+		height:            b.Height,
+		cHeightUpdated:    b.CommitteeData.LastChainHeightUpdated,
+		blockHash:         blockHash,
+		resultsHash:       resultsHash,
 	}, nil
 }
 
 // validateMessageParams defines the parameters structure for validating consensus messages
 type validateMessageParams struct {
-	view           *lib.View // the current BFT view of this node
-	vals           ValSet    // the validator set corresponding with the message
-	rootHeight     uint64    // the height of the root chain
-	height         uint64    // the chain height
-	cHeightUpdated uint64    // the last 'chain' height the committee updated
-	blockHash      []byte    // the hash of the proposal.Block (if any)
-	resultsHash    []byte    // the hash of the proposal.Results (if any)
+	view              *lib.View // the current BFT view of this node
+	vals              ValSet    // the validator set corresponding with the message
+	rootHeight        uint64    // the height of the root chain
+	rootHeightUpdated uint64    // the last root height the committee updated
+	height            uint64    // the chain height
+	cHeightUpdated    uint64    // the last 'chain' height the committee updated
+	blockHash         []byte    // the hash of the proposal.Block (if any)
+	resultsHash       []byte    // the hash of the proposal.Results (if any)
 }
 
 // checkSignature() validates the signature of a SignByte implementation (object that can be converted to Sign Bytes)

--- a/bft/msg_test.go
+++ b/bft/msg_test.go
@@ -137,7 +137,7 @@ func TestSignBytes(t *testing.T) {
 					ProposerKey: msg.Qc.ProposerKey,
 				}).SignBytes()
 			case RoundInterrupt:
-				expectedSignBytes, err = lib.Marshal(&Message{Header: msg.Header})
+				expectedSignBytes, err = lib.Marshal(&Message{Qc: &QC{Header: msg.Qc.Header}})
 			default:
 				t.Fatal("unexpected phase")
 			}
@@ -242,4 +242,50 @@ func TestHandleMessageNilSignatureReturnsError(t *testing.T) {
 	errI := c.bft.HandleMessage(msg)
 	require.Error(t, errI)
 	require.Equal(t, ErrPartialSignatureEmpty().Code(), errI.Code())
+}
+
+func TestPacemakerMessageSignatureBindsClaimedRound(t *testing.T) {
+	c := newTestConsensus(t, Propose, 3)
+	msg := &Message{Qc: &QC{Header: c.view(RoundInterrupt, 1)}}
+	require.NoError(t, msg.Sign(c.valKeys[1]))
+
+	msg.Qc.Header.Round = 2
+
+	errI := c.bft.HandleMessage(msg)
+	require.Error(t, errI)
+	require.Equal(t, ErrInvalidPartialSignature().Code(), errI.Code())
+}
+
+func TestProposerMessageRejectsInvalidHighQC(t *testing.T) {
+	c := newTestConsensus(t, Propose, 3)
+	justifyPropose := c.simElectionVotePhase(t, 0, false, false, false, 0)
+	aggSig, err := justifyPropose.AggregateSignatures()
+	require.NoError(t, err)
+
+	blk, blkHash, results, resHash := c.proposal(t)
+	highQC := c.setupTestableHighQC(t, false, true)
+	highQC.Signature.Signature = append([]byte{}, highQC.Signature.Signature...)
+	highQC.Signature.Signature[0] ^= 0xFF
+
+	msg := &Message{
+		Header: c.view(Propose, 0),
+		Qc: &QC{
+			Header:      c.view(ElectionVote, 0),
+			Block:       blk,
+			BlockHash:   blkHash,
+			Results:     results,
+			ResultsHash: resHash,
+			ProposerKey: c.valKeys[0].PublicKey().Bytes(),
+			Signature: &lib.AggregateSignature{
+				Signature: aggSig,
+				Bitmap:    justifyPropose.Bitmap(),
+			},
+		},
+		HighQc: highQC,
+	}
+	require.NoError(t, msg.Sign(c.valKeys[0]))
+
+	errI := c.bft.HandleMessage(msg)
+	require.Error(t, errI)
+	require.Equal(t, lib.CodeInvalidAggregateSignature, errI.Code())
 }

--- a/controller/block.go
+++ b/controller/block.go
@@ -500,10 +500,11 @@ func (c *Controller) ApplyAndValidateBlock(block *lib.Block, commit bool) (b *li
 		c.debugDumpHeaderDiff(candidate, compare)
 		return nil, lib.ErrUnequalBlockHash()
 	}
-	// validate VDF if committing randomly since this randomness is pseudo-non-deterministic (among nodes)
-	if commit && compare.Height > 1 && candidate.Vdf != nil {
-		// this design has similar security guarantees but lowers the computational requirements at a per-node basis
-		if rand.Intn(100) == 0 {
+	// Replicas must always validate proposer-supplied VDFs during normal consensus.
+	// During fast sync, VDFs are treated like advisory historical metadata and are
+	// sampled probabilistically to preserve throughput.
+	if compare.Height > 1 && candidate.Vdf != nil {
+		if !c.Syncing().Load() || (commit && rand.Intn(100) == 0) {
 			// validate the VDF included in the block
 			if !crypto.VerifyVDF(candidate.LastBlockHash, candidate.Vdf.Output, candidate.Vdf.Proof, int(candidate.Vdf.Iterations)) {
 				// exit with vdf error
@@ -530,6 +531,10 @@ func (c *Controller) HandlePeerBlock(msg *lib.BlockMessage, syncing bool) (*lib.
 	}
 	// if syncing the blockchain
 	if syncing {
+		// Fast sync intentionally trades per-block historical QC verification for throughput.
+		// The security model relies on checkpoint heights as the long-range-attack anchor,
+		// so intermediate blocks may be replayed for state continuity and only checkpoint
+		// heights are required to re-establish historical consistency during catch-up.
 		// use checkpoints to protect against long-range attacks
 		if qc.Header.Height%CheckpointFrequency == 0 {
 			// attempt to load the checkpoint from the file
@@ -549,7 +554,8 @@ func (c *Controller) HandlePeerBlock(msg *lib.BlockMessage, syncing bool) (*lib.
 				return nil, fsm.ErrInvalidCheckpoint()
 			}
 		}
-	} else {
+	}
+	if !syncing || qc.Header.Height%CheckpointFrequency == 0 {
 		// load the committee from the root chain using the root height embedded in the certificate message
 		v, err := c.Consensus.LoadCommittee(c.LoadRootChainId(qc.Header.Height), qc.Header.RootHeight)
 		if err != nil {
@@ -567,8 +573,10 @@ func (c *Controller) HandlePeerBlock(msg *lib.BlockMessage, syncing bool) (*lib.
 			// exit with error
 			return nil, lib.ErrNoMaj23()
 		}
-		// update the non signer percent for the validators
-		c.Metrics.UpdateNonSignerPercent(qc.Signature, v)
+		if !syncing {
+			// update the non signer percent for the validators
+			c.Metrics.UpdateNonSignerPercent(qc.Signature, v)
+		}
 	}
 	// ensure the proposal inside the quorum certificate is valid at a stateless level
 	block, err := qc.CheckProposalBasic(c.FSM.Height(), c.Config.NetworkID, c.Config.ChainId)

--- a/lib/config.go
+++ b/lib/config.go
@@ -361,7 +361,7 @@ func (c Config) WriteToFile(filepath string) error {
 		return err
 	}
 	// write the config.json file to the data directory
-	return os.WriteFile(filepath, jsonBytes, os.ModePerm)
+	return os.WriteFile(filepath, jsonBytes, 0600)
 }
 
 // NewConfigFromFile() populates a Config object from a JSON file

--- a/lib/crypto/key.go
+++ b/lib/crypto/key.go
@@ -124,7 +124,7 @@ func PrivateKeyToFile(key PrivateKeyI, filepath string) error {
 	if err != nil {
 		return err
 	}
-	return os.WriteFile(filepath, bz, 0777)
+	return os.WriteFile(filepath, bz, 0600)
 }
 
 // NewPrivateKeyFromString() creates a new PrivateKeyI interface from a hex string

--- a/lib/crypto/keystore.go
+++ b/lib/crypto/keystore.go
@@ -215,7 +215,7 @@ func (ks *Keystore) SaveToFile(dataDirPath string) error {
 	if err != nil {
 		return err
 	}
-	return os.WriteFile(filepath.Join(dataDirPath, KeyStoreName), bz, os.ModePerm)
+	return os.WriteFile(filepath.Join(dataDirPath, KeyStoreName), bz, 0600)
 }
 
 // EncryptedPrivateKey represents an encrypted form of a private key, including the public key,

--- a/lib/plugin.go
+++ b/lib/plugin.go
@@ -32,6 +32,7 @@ type Plugin struct {
 	pending     map[uint64]chan isPluginToFSM_Payload // the outstanding requests from the FSM
 	requestFSMs map[uint64]PluginCompatibleFSM        // maps request IDs to their FSM context for concurrent operations
 	l           sync.Mutex                            // thread safety
+	writeL      sync.Mutex                            // serializes outbound writes on the shared connection
 	log         LoggerI                               // the logger associated with the plugin
 	timeout     time.Duration                         // plugin request timeout
 }
@@ -566,6 +567,8 @@ func (p *Plugin) sendLengthPrefixed(bz []byte) ErrorI {
 	// write the message (length prefixed)
 	totalBytes := append(lengthPrefix, bz...)
 	p.log.Debugf("sendLengthPrefixed() writing total %d bytes (4 prefix + %d data)", len(totalBytes), len(bz))
+	p.writeL.Lock()
+	defer p.writeL.Unlock()
 	if _, er := p.conn.Write(totalBytes); er != nil {
 		p.log.Debugf("sendLengthPrefixed() write error: %v", er)
 		return ErrFailedPluginWrite(er)

--- a/lib/util.go
+++ b/lib/util.go
@@ -500,7 +500,7 @@ func SaveJSONToFile(j any, dataDirPath, filePath string) (err ErrorI) {
 		return
 	}
 	// attempt to write the json bytes to a json file at the path
-	if e := os.WriteFile(filepath.Join(dataDirPath, filePath), jsonBytes, os.ModePerm); e != nil {
+	if e := os.WriteFile(filepath.Join(dataDirPath, filePath), jsonBytes, 0600); e != nil {
 		// exit with error
 		return ErrWriteFile(e)
 	}

--- a/p2p/conn.go
+++ b/p2p/conn.go
@@ -575,19 +575,7 @@ func (s *Stream) handlePacket(peerInfo *lib.PeerInfo, packet *Packet, metrics *l
 			}
 		default:
 			s.logger.Errorf("CRITICAL: Inbox %s queue full in receive service", lib.Topic_name[int32(packet.StreamId)])
-			s.logger.Error("Dropping all messages")
-			// drain inbox
-			func() {
-				for {
-					select {
-					case <-s.inbox:
-						// drop
-					default:
-						// channel is empty now
-						return
-					}
-				}
-			}()
+			s.logger.Error("Dropping newest message")
 		}
 		// reset receiving buffer
 		s.msgAssembler = s.msgAssembler[:0]

--- a/p2p/p2p.go
+++ b/p2p/p2p.go
@@ -585,19 +585,7 @@ func (p *P2P) SelfSend(fromPublicKey []byte, topic lib.Topic, payload proto.Mess
 		case p.Inbox(topic) <- m:
 		default:
 			p.log.Errorf("CRITICAL: Inbox %s queue full in self send", lib.Topic_name[int32(topic)])
-			p.log.Error("Dropping all messages")
-			// drain inbox
-			func() {
-				for {
-					select {
-					case <-p.Inbox(topic):
-						// drop
-					default:
-						// channel is empty now
-						return
-					}
-				}
-			}()
+			p.log.Error("Dropping newest message")
 		}
 	}()
 	return nil

--- a/store/store.go
+++ b/store/store.go
@@ -249,29 +249,34 @@ func (s *Store) Commit() (root []byte, err lib.ErrorI) {
 	if err != nil {
 		return nil, err
 	}
-	// update the version (height) number
-	s.version++
+	nextVersion := s.version + 1
 	// set the new CommitID (to the Transaction not the actual DB)
-	if err = s.setCommitID(s.version, root); err != nil {
+	if err = s.setCommitID(nextVersion, root); err != nil {
+		s.Reset()
 		return nil, err
 	}
 	// collect LSS tombstones before Flush() clears the txn operations
 	lssDeleteKeys := s.collectLssDeleteKeys()
 	// commit the in-memory txn to the pebbleDB batch
 	if e := s.Flush(); e != nil {
+		s.Reset()
 		return nil, e
 	}
 	if err = s.purgeLssTombstones(lssDeleteKeys); err != nil {
+		s.Reset()
 		return nil, err
 	}
 	// extract the internal metrics from the pebble batch
 	size, count := len(s.writer.Repr()), s.writer.Count()
 	// finally commit the entire Transaction to the actual DB under the proper version (height) number
 	if err := s.db.Apply(s.writer, pebble.NoSync); err != nil {
-		return nil, ErrCommitDB(err)
+		commitErr := ErrCommitDB(err)
+		s.Reset()
+		return nil, commitErr
 	}
 	// update the metrics once complete
 	s.metrics.UpdateStoreMetrics(int64(size), int64(count), time.Time{}, startTime)
+	s.version = nextVersion
 	// reset the writer for the next height
 	s.Reset()
 	// compact if necessary


### PR DESCRIPTION
## Summary

  - Tighten SafeNode() payload matching so either hash mismatch rejects the proposal.
  - Preserve queued inbox messages on overflow by dropping only the newest message.
  - Serialize plugin outbound IPC writes on the shared connection.
  - Use restrictive file modes for private keys, keystores, config, and shared JSON artifacts.
  - Keep store version state aligned with durable commit success/failure.
  - Add and adjust tests around pacemaker signatures, HighQC validation, and SafeNode behavior.

  ## Not Included

  - No change to the non-signer settlement behavior.
  - No change to plugin write-timeout / fail-stop behavior.
  - No change to proposer Timestamp / RcBuildHeight signature coverage.

  ## Validation

  go test ./controller ./bft ./p2p ./lib ./lib/crypto ./store

  ## Notes

  - The pacemaker signature change is a message-format compatibility change and should be merged and deployed coherently rather than mixed across versions.