### PR TITLE
feat: make values to not flick

### DIFF
--- a/cmd/rpc/web/explorer/src/components/Home/Stages.tsx
+++ b/cmd/rpc/web/explorer/src/components/Home/Stages.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import { motion } from 'framer-motion'
 import { useCardData } from '../../hooks/useApi'
+import { usePersistentNumber } from '../../hooks/usePersistentNumber'
 import { getTotalTransactionCount, getTotalAccountCount, Validators, ValidatorsWithFilters } from '../../lib/api'
 import { convertNumber, toCNPY } from '../../lib/utils'
 import AnimatedNumber from '../AnimatedNumber'
@@ -11,6 +12,7 @@ interface StageCardProps {
     data: string
     icon: React.ReactNode
     metric: string
+    loading?: boolean
 }
 
 const stageCardSubtitleClass = 'explorer-overview-card-subvalue'
@@ -18,7 +20,11 @@ const stageCardSubtitleClass = 'explorer-overview-card-subvalue'
 const Stages = () => {
     const { data: cardData } = useCardData()
 
-    const latestBlockHeight: number = React.useMemo(() => {
+    // Candidate values are derived straight from cardData. They are `null`
+    // whenever cardData isn't available yet so the persistent hooks below keep
+    // showing the last known value instead of flickering to zero.
+    const latestBlockHeightCandidate: number | null = React.useMemo(() => {
+        if (!cardData) return null
         const list = (cardData as any)?.blocks
         const totalCount = list?.totalCount || list?.count
         if (typeof totalCount === 'number' && totalCount > 0) return totalCount
@@ -42,14 +48,16 @@ const Stages = () => {
     }, [cardData])
 
 
-    const totalSupplyCNPY: number = React.useMemo(() => {
+    const totalSupplyCandidate: number | null = React.useMemo(() => {
+        if (!cardData) return null
         const s = (cardData as any)?.supply || {}
         // new format: total in uCNPY
         const total = s.total ?? s.totalSupply ?? s.total_cnpy ?? s.totalCNPY ?? 0
         return toCNPY(Number(total) || 0)
     }, [cardData])
 
-    const totalStakeCNPY: number = React.useMemo(() => {
+    const totalStakeCandidate: number | null = React.useMemo(() => {
+        if (!cardData) return null
         const s = (cardData as any)?.supply || {}
         // prefer supply.staked; fallback to pool.bondedTokens
         const st = s.staked ?? 0
@@ -59,7 +67,8 @@ const Stages = () => {
         return toCNPY(Number(bonded) || 0)
     }, [cardData])
 
-    const liquidSupplyCNPY: number = React.useMemo(() => {
+    const liquidSupplyCandidate: number | null = React.useMemo(() => {
+        if (!cardData) return null
         const s = (cardData as any)?.supply || {}
         const total = Number(s.total ?? 0)
         const staked = Number(s.staked ?? 0)
@@ -69,115 +78,140 @@ const Stages = () => {
         return toCNPY(Number(liquid) || 0)
     }, [cardData])
 
-    const [totalAccounts, setTotalAccounts] = React.useState(0)
-    const [totalTxs, setTotalTxs] = React.useState(0)
-    const [totalValidating, setTotalValidating] = React.useState(0)
-    const [totalDelegating, setTotalDelegating] = React.useState(0)
-    const [isLoadingStats, setIsLoadingStats] = React.useState(true)
+    // Async stats stay `null` until a fetch succeeds. We never reset them to a
+    // value on failure, so a transient RPC error can't blank the cards.
+    const [totalAccountsCandidate, setTotalAccountsCandidate] = React.useState<number | null>(null)
+    const [totalTxsCandidate, setTotalTxsCandidate] = React.useState<number | null>(null)
+    const [totalValidatingCandidate, setTotalValidatingCandidate] = React.useState<number | null>(null)
+    const [totalDelegatingCandidate, setTotalDelegatingCandidate] = React.useState<number | null>(null)
 
     React.useEffect(() => {
+        if (!cardData) return
+
+        let cancelled = false
+
         const fetchStats = async () => {
-            try {
-                setIsLoadingStats(true)
-
-                if (totalTxsFromBlock !== null) {
-                    setTotalTxs(totalTxsFromBlock)
-                } else {
-                    const hasRealTransactions = cardData?.hasRealTransactions ?? true
-                    if (hasRealTransactions) {
+            if (totalTxsFromBlock !== null) {
+                if (!cancelled) setTotalTxsCandidate(totalTxsFromBlock)
+            } else {
+                const hasRealTransactions = cardData?.hasRealTransactions ?? true
+                if (hasRealTransactions) {
+                    try {
                         const txStats = await getTotalTransactionCount()
-                        setTotalTxs(txStats.total)
-                    } else {
-                        setTotalTxs(0)
+                        if (!cancelled) setTotalTxsCandidate(txStats.total)
+                    } catch (error) {
+                        console.error('Error fetching transaction stats:', error)
                     }
+                } else if (!cancelled) {
+                    setTotalTxsCandidate(0)
                 }
+            }
 
-                try {
-                    const accountStats = await getTotalAccountCount()
-                    setTotalAccounts(accountStats.total)
-                } catch (error) {
-                    console.error('Error fetching account stats:', error)
-                }
+            try {
+                const accountStats = await getTotalAccountCount()
+                if (!cancelled) setTotalAccountsCandidate(accountStats.total)
+            } catch (error) {
+                console.error('Error fetching account stats:', error)
+            }
 
-                try {
-                    const [validatorsStats, delegatorsStats] = await Promise.all([
-                        Validators(1, 0),
-                        ValidatorsWithFilters(1, 0, 0, 1, 0, 1),
-                    ])
+            try {
+                const [validatorsStats, delegatorsStats] = await Promise.all([
+                    Validators(1, 0),
+                    ValidatorsWithFilters(1, 0, 0, 1, 0, 1),
+                ])
 
-                    const totalValidatorsCount = Number(validatorsStats?.totalCount ?? validatorsStats?.count ?? 0)
-                    const totalDelegatorsCount = Number(delegatorsStats?.totalCount ?? delegatorsStats?.count ?? 0)
+                const totalValidatorsCount = Number(validatorsStats?.totalCount ?? validatorsStats?.count ?? 0)
+                const totalDelegatorsCount = Number(delegatorsStats?.totalCount ?? delegatorsStats?.count ?? 0)
 
-                    setTotalDelegating(totalDelegatorsCount)
-                    setTotalValidating(Math.max(0, totalValidatorsCount - totalDelegatorsCount))
-                } catch (error) {
-                    console.error('Error fetching validator stats:', error)
+                if (!cancelled) {
+                    setTotalDelegatingCandidate(totalDelegatorsCount)
+                    setTotalValidatingCandidate(Math.max(0, totalValidatorsCount - totalDelegatorsCount))
                 }
             } catch (error) {
-                console.error('Error fetching stats:', error)
-            } finally {
-                setIsLoadingStats(false)
+                console.error('Error fetching validator stats:', error)
             }
         }
 
-        if (cardData) {
-            fetchStats()
+        fetchStats()
+
+        return () => {
+            cancelled = true
         }
     }, [cardData, totalTxsFromBlock])
+
+    // Sticky values: hydrated from localStorage on mount (so a page refresh
+    // shows the previous numbers immediately) and only ever updated with fresh,
+    // valid data. This eliminates the flicker-to-zero on refresh and on polls.
+    const latestBlockHeight = usePersistentNumber('blockHeight', latestBlockHeightCandidate)
+    const totalSupplyCNPY = usePersistentNumber('totalSupply', totalSupplyCandidate)
+    const totalStakeCNPY = usePersistentNumber('totalStake', totalStakeCandidate)
+    const liquidSupplyCNPY = usePersistentNumber('liquidSupply', liquidSupplyCandidate)
+    const totalAccounts = usePersistentNumber('totalAccounts', totalAccountsCandidate)
+    const totalTxs = usePersistentNumber('totalTxs', totalTxsCandidate)
+    const totalValidating = usePersistentNumber('totalValidating', totalValidatingCandidate)
+    const totalDelegating = usePersistentNumber('totalDelegating', totalDelegatingCandidate)
 
     const stages: StageCardProps[] = [
         {
             title: 'Blocks',
-            data: latestBlockHeight.toString(),
+            data: latestBlockHeight.value.toString(),
+            loading: !latestBlockHeight.hasValue,
             subtitle: <p className={stageCardSubtitleClass}>Heights</p>,
             icon: <i className="fa-solid fa-cube"></i>,
             metric: 'blocks',
         },
         {
             title: 'Total Supply',
-            data: convertNumber(totalSupplyCNPY),
+            data: convertNumber(totalSupplyCNPY.value),
+            loading: !totalSupplyCNPY.hasValue,
             subtitle: <p className={stageCardSubtitleClass}>CNPY</p>,
             icon: <i className="fa-solid fa-wallet"></i>,
             metric: 'totalSupply',
         },
         {
             title: 'Liquid Supply',
-            data: convertNumber(liquidSupplyCNPY),
+            data: convertNumber(liquidSupplyCNPY.value),
+            loading: !liquidSupplyCNPY.hasValue,
             subtitle: <p className={stageCardSubtitleClass}>CNPY</p>,
             icon: <i className="fa-solid fa-droplet"></i>,
             metric: 'liquidSupply',
         },
         {
             title: 'Total Stake',
-            data: convertNumber(totalStakeCNPY),
+            data: convertNumber(totalStakeCNPY.value),
+            loading: !totalStakeCNPY.hasValue,
             subtitle: <p className={stageCardSubtitleClass}>CNPY</p>,
             icon: <i className="fa-solid fa-lock"></i>,
             metric: 'totalStake',
         },
         {
             title: 'Total Validating',
-            data: isLoadingStats ? 'Loading...' : convertNumber(totalValidating),
+            data: convertNumber(totalValidating.value),
+            loading: !totalValidating.hasValue,
             subtitle: <p className={stageCardSubtitleClass}>Validators</p>,
             icon: <i className="fa-solid fa-shield-halved"></i>,
             metric: 'totalValidating',
         },
         {
             title: 'Total Delegating',
-            data: isLoadingStats ? 'Loading...' : convertNumber(totalDelegating),
+            data: convertNumber(totalDelegating.value),
+            loading: !totalDelegating.hasValue,
             subtitle: <p className={stageCardSubtitleClass}>Delegators</p>,
             icon: <i className="fa-solid fa-coins"></i>,
             metric: 'totalDelegating',
         },
         {
             title: 'Total Accounts',
-            data: isLoadingStats ? 'Loading...' : convertNumber(totalAccounts),
+            data: convertNumber(totalAccounts.value),
+            loading: !totalAccounts.hasValue,
             icon: <i className="fa-solid fa-users"></i>,
             metric: 'accounts',
             subtitle: <p className={stageCardSubtitleClass}>Indexed accounts</p>,
         },
         {
             title: 'Total Txs',
-            data: isLoadingStats ? 'Loading...' : convertNumber(totalTxs),
+            data: convertNumber(totalTxs.value),
+            loading: !totalTxs.hasValue,
             icon: <i className="fa-solid fa-arrow-right-arrow-left"></i>,
             metric: 'txs',
             subtitle: <p className={stageCardSubtitleClass}>Confirmed txs</p>,
@@ -224,7 +258,9 @@ const Stages = () => {
 
                         <div className="mt-2 min-h-[2.5rem]">
                             <div className="explorer-overview-card-value">
-                                {(() => {
+                                {stage.loading ? (
+                                    <span className="text-white/40">Loading…</span>
+                                ) : (() => {
                                     const { number, prefix, suffix } = parseNumberFromString(stage.data)
                                     return (
                                         <>

--- a/cmd/rpc/web/explorer/src/components/StatValue.tsx
+++ b/cmd/rpc/web/explorer/src/components/StatValue.tsx
@@ -1,0 +1,19 @@
+import React from 'react'
+import type { PersistentNumber } from '../hooks/usePersistentNumber'
+
+interface StatValueProps {
+    stat: PersistentNumber
+    format?: (value: number) => string
+}
+
+/**
+ * Renders a persistent stat value, showing "Loading…" until the first real
+ * value is observed (instead of a misleading 0) and keeping the last known
+ * value during refetches. Pairs with `usePersistentNumber`.
+ */
+const StatValue: React.FC<StatValueProps> = ({ stat, format }) => {
+    if (!stat.hasValue) return <span className="text-white/40">Loading…</span>
+    return <>{format ? format(stat.value) : stat.value.toLocaleString()}</>
+}
+
+export default StatValue

--- a/cmd/rpc/web/explorer/src/components/StatValue.tsx
+++ b/cmd/rpc/web/explorer/src/components/StatValue.tsx
@@ -4,6 +4,7 @@ import type { PersistentNumber } from '../hooks/usePersistentNumber'
 interface StatValueProps {
     stat: PersistentNumber
     format?: (value: number) => string
+    loading?: boolean
 }
 
 /**
@@ -11,8 +12,8 @@ interface StatValueProps {
  * value is observed (instead of a misleading 0) and keeping the last known
  * value during refetches. Pairs with `usePersistentNumber`.
  */
-const StatValue: React.FC<StatValueProps> = ({ stat, format }) => {
-    if (!stat.hasValue) return <span className="text-white/40">Loading…</span>
+const StatValue: React.FC<StatValueProps> = ({ stat, format, loading }) => {
+    if (loading || !stat.hasValue) return <span className="text-white/40">Loading…</span>
     return <>{format ? format(stat.value) : stat.value.toLocaleString()}</>
 }
 

--- a/cmd/rpc/web/explorer/src/components/account/AccountsPage.tsx
+++ b/cmd/rpc/web/explorer/src/components/account/AccountsPage.tsx
@@ -39,13 +39,13 @@ const AccountsPage: React.FC = () => {
         },
         {
             title: 'Visible Accounts',
-            value: <StatValue stat={visibleAccounts} />,
+            value: <StatValue stat={visibleAccounts} loading={isLoading} />,
             subValue: 'Current page',
             icon: 'fa-solid fa-list',
         },
         {
             title: 'Largest Balance',
-            value: <StatValue stat={largestBalanceStat} format={(n) => n.toLocaleString(undefined, { maximumFractionDigits: 2 })} />,
+            value: <StatValue stat={largestBalanceStat} loading={isLoading} format={(n) => n.toLocaleString(undefined, { maximumFractionDigits: 2 })} />,
             subValue: 'CNPY',
             icon: 'fa-solid fa-trophy',
         },

--- a/cmd/rpc/web/explorer/src/components/account/AccountsPage.tsx
+++ b/cmd/rpc/web/explorer/src/components/account/AccountsPage.tsx
@@ -4,6 +4,8 @@ import AccountsTable from './AccountsTable'
 import { useAccounts } from '../../hooks/useApi'
 import accountsTexts from '../../data/accounts.json'
 import ExplorerOverviewCards from '../ExplorerOverviewCards'
+import StatValue from '../StatValue'
+import { usePersistentNumber } from '../../hooks/usePersistentNumber'
 import { toCNPY } from '../../lib/utils'
 
 const LiveIndicator = () => (
@@ -23,22 +25,27 @@ const AccountsPage: React.FC = () => {
         () => toCNPY(accounts.reduce((max: number, account: { amount?: number; totalAmount?: number }) => Math.max(max, Number(account.totalAmount ?? account.amount ?? 0)), 0)),
         [accounts],
     )
+
+    const indexedAccounts = usePersistentNumber('accounts:indexed', accountsData ? Number(accountsData.totalCount ?? 0) : null)
+    const visibleAccounts = usePersistentNumber('accounts:visible', accountsData ? accounts.length : null)
+    const largestBalanceStat = usePersistentNumber('accounts:largestBalance', accountsData ? largestBalance : null)
+
     const overviewCards = [
         {
             title: 'Indexed Accounts',
-            value: (accountsData?.totalCount || 0).toLocaleString(),
+            value: <StatValue stat={indexedAccounts} />,
             subValue: 'Explorer index',
             icon: 'fa-solid fa-wallet',
         },
         {
             title: 'Visible Accounts',
-            value: accounts.length.toLocaleString(),
+            value: <StatValue stat={visibleAccounts} />,
             subValue: 'Current page',
             icon: 'fa-solid fa-list',
         },
         {
             title: 'Largest Balance',
-            value: largestBalance.toLocaleString(undefined, { maximumFractionDigits: 2 }),
+            value: <StatValue stat={largestBalanceStat} format={(n) => n.toLocaleString(undefined, { maximumFractionDigits: 2 })} />,
             subValue: 'CNPY',
             icon: 'fa-solid fa-trophy',
         },

--- a/cmd/rpc/web/explorer/src/components/block/BlocksPage.tsx
+++ b/cmd/rpc/web/explorer/src/components/block/BlocksPage.tsx
@@ -100,19 +100,19 @@ const BlocksPage: React.FC = () => {
     const overviewCards = [
         {
             title: 'Latest Height',
-            value: <StatValue stat={latestHeightStat} />,
+            value: <StatValue stat={latestHeightStat} loading={isLoading} />,
             subValue: 'Current page',
             icon: 'fa-solid fa-mountain-city',
         },
         {
             title: 'Page Transactions',
-            value: <StatValue stat={pageTransactionsStat} />,
+            value: <StatValue stat={pageTransactionsStat} loading={isLoading} />,
             subValue: 'Visible rows',
             icon: 'fa-solid fa-arrow-right-arrow-left',
         },
         {
             title: 'Average Size',
-            value: <StatValue stat={averageSizeStat} format={(n) => `${n.toFixed(2)} KB`} />,
+            value: <StatValue stat={averageSizeStat} loading={isLoading} format={(n) => `${n.toFixed(2)} KB`} />,
             subValue: 'Page average',
             icon: 'fa-solid fa-weight-hanging',
         },

--- a/cmd/rpc/web/explorer/src/components/block/BlocksPage.tsx
+++ b/cmd/rpc/web/explorer/src/components/block/BlocksPage.tsx
@@ -4,6 +4,8 @@ import BlocksTable from './BlocksTable'
 import { useBlocks } from '../../hooks/useApi'
 import blocksTexts from '../../data/blocks.json'
 import ExplorerOverviewCards from '../ExplorerOverviewCards'
+import StatValue from '../StatValue'
+import { usePersistentNumber } from '../../hooks/usePersistentNumber'
 
 interface Block {
     height: number
@@ -91,22 +93,26 @@ const BlocksPage: React.FC = () => {
         const totalSize = sizedBlocks.reduce((sum, block) => sum + (block.size || 0), 0)
         return totalSize / sizedBlocks.length / 1024
     }, [paginatedBlocks])
+    const latestHeightStat = usePersistentNumber('blocks:latestHeight', blocksData ? latestHeight : null)
+    const pageTransactionsStat = usePersistentNumber('blocks:pageTransactions', blocksData ? pageTransactionCount : null)
+    const averageSizeStat = usePersistentNumber('blocks:averageSizeKb', blocksData ? averageBlockSizeKb : null)
+
     const overviewCards = [
         {
             title: 'Latest Height',
-            value: latestHeight.toLocaleString(),
+            value: <StatValue stat={latestHeightStat} />,
             subValue: 'Current page',
             icon: 'fa-solid fa-mountain-city',
         },
         {
             title: 'Page Transactions',
-            value: pageTransactionCount.toLocaleString(),
+            value: <StatValue stat={pageTransactionsStat} />,
             subValue: 'Visible rows',
             icon: 'fa-solid fa-arrow-right-arrow-left',
         },
         {
             title: 'Average Size',
-            value: `${averageBlockSizeKb.toFixed(2)} KB`,
+            value: <StatValue stat={averageSizeStat} format={(n) => `${n.toFixed(2)} KB`} />,
             subValue: 'Page average',
             icon: 'fa-solid fa-weight-hanging',
         },

--- a/cmd/rpc/web/explorer/src/components/staking/StakingPage.tsx
+++ b/cmd/rpc/web/explorer/src/components/staking/StakingPage.tsx
@@ -3,10 +3,12 @@ import { motion } from 'framer-motion'
 import ValidatorsTable from '../validator/ValidatorsTable'
 import { useAllDelegators, useAllValidators, useParams as useChainParams } from '../../hooks/useApi'
 import ExplorerOverviewCards from '../ExplorerOverviewCards'
+import StatValue from '../StatValue'
+import { usePersistentNumber } from '../../hooks/usePersistentNumber'
 
 interface OverviewCardProps {
     title: string
-    value: string | number
+    value: React.ReactNode
     subValue?: string
     icon: string
 }
@@ -231,28 +233,33 @@ const StakingPage: React.FC = () => {
         }
     }, [allStakers])
 
+    const validatorsStat = usePersistentNumber('staking:validators', isLoading ? null : stats.validators)
+    const delegatorsStat = usePersistentNumber('staking:delegators', isLoading ? null : stats.delegators)
+    const pausedStat = usePersistentNumber('staking:paused', isLoading ? null : stats.paused)
+    const totalStakersStat = usePersistentNumber('staking:total', isLoading ? null : stats.total)
+
     const overviewCards: OverviewCardProps[] = [
         {
             title: 'Validators',
-            value: stats.validators.toLocaleString(),
+            value: <StatValue stat={validatorsStat} />,
             subValue: 'Active validators',
             icon: 'fa-solid fa-shield-halved',
         },
         {
             title: 'Delegators',
-            value: stats.delegators.toLocaleString(),
+            value: <StatValue stat={delegatorsStat} />,
             subValue: 'Active delegators',
             icon: 'fa-solid fa-users',
         },
         {
             title: 'Paused',
-            value: stats.paused.toLocaleString(),
+            value: <StatValue stat={pausedStat} />,
             subValue: 'Paused validators',
             icon: 'fa-solid fa-pause',
         },
         {
             title: 'Total Stakers',
-            value: stats.total.toLocaleString(),
+            value: <StatValue stat={totalStakersStat} />,
             subValue: 'All stakeholders',
             icon: 'fa-solid fa-network-wired',
         },

--- a/cmd/rpc/web/explorer/src/components/staking/SupplyView.tsx
+++ b/cmd/rpc/web/explorer/src/components/staking/SupplyView.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import { motion } from 'framer-motion'
 import { useCardData } from '../../hooks/useApi'
+import { usePersistentNumber } from '../../hooks/usePersistentNumber'
 import AnimatedNumber from '../AnimatedNumber'
 import stakingTexts from '../../data/staking.json'
 import { toCNPY } from '../../lib/utils'
@@ -9,14 +10,17 @@ import ExplorerOverviewCards from '../ExplorerOverviewCards'
 const SupplyView: React.FC = () => {
     const { data: cardData } = useCardData()
 
-    // Calculate supply metrics
-    const totalSupplyCNPY = React.useMemo(() => {
+    // Candidates are `null` until cardData arrives so the persistent hooks keep
+    // the last known values instead of dropping to zero on refresh/refetch.
+    const totalSupplyCandidate = React.useMemo(() => {
+        if (!cardData) return null
         const s = (cardData as any)?.supply || {}
         const total = s.total ?? s.totalSupply ?? s.total_cnpy ?? s.totalCNPY ?? 0
         return toCNPY(Number(total))
     }, [cardData])
 
-    const stakedSupplyCNPY = React.useMemo(() => {
+    const stakedSupplyCandidate = React.useMemo(() => {
+        if (!cardData) return null
         const s = (cardData as any)?.supply || {}
         const st = s.staked ?? 0
         if (st) return toCNPY(Number(st))
@@ -25,7 +29,8 @@ const SupplyView: React.FC = () => {
         return toCNPY(Number(bonded))
     }, [cardData])
 
-    const liquidSupplyCNPY = React.useMemo(() => {
+    const liquidSupplyCandidate = React.useMemo(() => {
+        if (!cardData) return null
         const s = (cardData as any)?.supply || {}
         const total = Number(s.total ?? 0)
         const staked = Number(s.staked ?? 0)
@@ -33,6 +38,20 @@ const SupplyView: React.FC = () => {
         const liquid = s.circulating ?? s.liquidSupply ?? s.liquid ?? 0
         return toCNPY(Number(liquid))
     }, [cardData])
+
+    const totalSupply = usePersistentNumber('totalSupply', totalSupplyCandidate)
+    const stakedSupply = usePersistentNumber('totalStake', stakedSupplyCandidate)
+    const liquidSupply = usePersistentNumber('liquidSupply', liquidSupplyCandidate)
+
+    const totalSupplyCNPY = totalSupply.value
+    const stakedSupplyCNPY = stakedSupply.value
+    const liquidSupplyCNPY = liquidSupply.value
+
+    // First-ever load (no cached value yet) → show "Loading…" instead of 0.
+    const isSupplyLoading = !totalSupply.hasValue
+    const isStakedLoading = !stakedSupply.hasValue
+    const isLiquidLoading = !liquidSupply.hasValue
+    const LoadingValue = () => <span className="text-white/40">Loading…</span>
 
     const stakingRatio = React.useMemo(() => {
         if (totalSupplyCNPY <= 0) return 0
@@ -47,7 +66,9 @@ const SupplyView: React.FC = () => {
     const supplyMetrics = [
         {
             title: 'Total',
-            value: (
+            value: isSupplyLoading ? (
+                <LoadingValue />
+            ) : (
                 <AnimatedNumber
                     value={totalSupplyCNPY}
                     format={{ minimumFractionDigits: 2, maximumFractionDigits: 2 }}
@@ -59,7 +80,9 @@ const SupplyView: React.FC = () => {
         },
         {
             title: 'Staked',
-            value: (
+            value: isStakedLoading ? (
+                <LoadingValue />
+            ) : (
                 <AnimatedNumber
                     value={stakedSupplyCNPY}
                     format={{ minimumFractionDigits: 2, maximumFractionDigits: 2 }}
@@ -71,7 +94,9 @@ const SupplyView: React.FC = () => {
         },
         {
             title: 'Liquid',
-            value: (
+            value: isLiquidLoading ? (
+                <LoadingValue />
+            ) : (
                 <AnimatedNumber
                     value={liquidSupplyCNPY}
                     format={{ minimumFractionDigits: 2, maximumFractionDigits: 2 }}
@@ -83,7 +108,9 @@ const SupplyView: React.FC = () => {
         },
         {
             title: 'Staking Ratio',
-            value: (
+            value: isSupplyLoading || isStakedLoading ? (
+                <LoadingValue />
+            ) : (
                 <AnimatedNumber
                     value={stakingRatio}
                     format={{ minimumFractionDigits: 2, maximumFractionDigits: 2 }}
@@ -165,31 +192,43 @@ const SupplyView: React.FC = () => {
                         <div className="flex justify-between items-center">
                             <span className="text-gray-400">Total</span>
                             <span className="text-white font-medium">
-                                <AnimatedNumber
-                                    value={totalSupplyCNPY}
-                                    format={{ maximumFractionDigits: 0 }}
-                                    className="text-white"
-                                /> CNPY
+                                {isSupplyLoading ? <LoadingValue /> : (
+                                    <>
+                                        <AnimatedNumber
+                                            value={totalSupplyCNPY}
+                                            format={{ maximumFractionDigits: 0 }}
+                                            className="text-white"
+                                        /> CNPY
+                                    </>
+                                )}
                             </span>
                         </div>
                         <div className="flex justify-between items-center">
                             <span className="text-gray-400">Staked</span>
                             <span className="font-medium text-[#35cd48]">
-                                <AnimatedNumber
-                                    value={stakedSupplyCNPY}
-                                    format={{ maximumFractionDigits: 0 }}
-                                    className="text-[#35cd48]"
-                                /> CNPY
+                                {isStakedLoading ? <LoadingValue /> : (
+                                    <>
+                                        <AnimatedNumber
+                                            value={stakedSupplyCNPY}
+                                            format={{ maximumFractionDigits: 0 }}
+                                            className="text-[#35cd48]"
+                                        /> CNPY
+                                    </>
+                                )}
                             </span>
                         </div>
                         <div className="flex justify-between items-center">
                             <span className="text-gray-400">Liquid</span>
                             <span className="font-medium text-[#216cd0]">
-                                <AnimatedNumber
-                                    value={liquidSupplyCNPY}
-                                    format={{ maximumFractionDigits: 0 }}
-                                    className="text-[#216cd0]"
-                                /> CNPY
+                                {isLiquidLoading ? <LoadingValue /> : (
+                                    <>
+                                        <AnimatedNumber
+                                            value={liquidSupplyCNPY}
+                                            format={{ maximumFractionDigits: 0 }}
+                                            className="text-[#216cd0]"
+                                        /> CNPY
+                                    </>
+                                )}
                             </span>
                         </div>
                     </div>

--- a/cmd/rpc/web/explorer/src/components/token-swaps/TokenSwapsPage.tsx
+++ b/cmd/rpc/web/explorer/src/components/token-swaps/TokenSwapsPage.tsx
@@ -7,6 +7,8 @@ import RecentSwapsTable from './RecentSwapsTable';
 import { useOrders } from '../../hooks/useApi'
 import { formatDecimalWithSubscript, formatLocaleNumber, toCNPY } from '../../lib/utils';
 import ExplorerOverviewCards from '../ExplorerOverviewCards';
+import StatValue from '../StatValue';
+import { usePersistentNumber } from '../../hooks/usePersistentNumber';
 
 interface Order {
     id: string;
@@ -97,38 +99,44 @@ const TokenSwapsPage: React.FC = () => {
         return Array.from(set).sort((a, b) => a - b);
     }, [swaps]);
 
-    const overviewCards = useMemo(() => {
-        const activeCount = swaps.filter((swap) => swap.status === 'Active').length;
-        const lockedCount = swaps.filter((swap) => swap.status === 'Locked').length;
-        const totalVolume = swaps.reduce((sum, swap) => sum + swap.amountRaw, 0);
+    const swapCounts = useMemo(() => ({
+        orders: swaps.length,
+        active: swaps.filter((swap) => swap.status === 'Active').length,
+        locked: swaps.filter((swap) => swap.status === 'Locked').length,
+        volume: swaps.reduce((sum, swap) => sum + swap.amountRaw, 0),
+    }), [swaps]);
 
-        return [
-            {
-                title: 'Orders',
-                value: swaps.length.toLocaleString(),
-                subValue: 'Open book',
-                icon: 'fa-solid fa-book',
-            },
-            {
-                title: 'Active',
-                value: activeCount.toLocaleString(),
-                subValue: 'Open orders',
-                icon: 'fa-solid fa-unlock',
-            },
-            {
-                title: 'Locked',
-                value: lockedCount.toLocaleString(),
-                subValue: 'Buyer locked',
-                icon: 'fa-solid fa-lock',
-            },
-            {
-                title: 'Open Volume',
-                value: totalVolume.toLocaleString(undefined, { maximumFractionDigits: 2 }),
-                subValue: 'CNPY',
-                icon: 'fa-solid fa-chart-column',
-            },
-        ];
-    }, [swaps]);
+    const ordersStat = usePersistentNumber('swaps:orders', ordersData ? swapCounts.orders : null);
+    const activeStat = usePersistentNumber('swaps:active', ordersData ? swapCounts.active : null);
+    const lockedStat = usePersistentNumber('swaps:locked', ordersData ? swapCounts.locked : null);
+    const volumeStat = usePersistentNumber('swaps:volume', ordersData ? swapCounts.volume : null);
+
+    const overviewCards = [
+        {
+            title: 'Orders',
+            value: <StatValue stat={ordersStat} />,
+            subValue: 'Open book',
+            icon: 'fa-solid fa-book',
+        },
+        {
+            title: 'Active',
+            value: <StatValue stat={activeStat} />,
+            subValue: 'Open orders',
+            icon: 'fa-solid fa-unlock',
+        },
+        {
+            title: 'Locked',
+            value: <StatValue stat={lockedStat} />,
+            subValue: 'Buyer locked',
+            icon: 'fa-solid fa-lock',
+        },
+        {
+            title: 'Open Volume',
+            value: <StatValue stat={volumeStat} format={(n) => n.toLocaleString(undefined, { maximumFractionDigits: 2 })} />,
+            subValue: 'CNPY',
+            icon: 'fa-solid fa-chart-column',
+        },
+    ];
 
     const filteredSwaps = useMemo(() => {
         let result = swaps;

--- a/cmd/rpc/web/explorer/src/components/transaction/TransactionsPage.tsx
+++ b/cmd/rpc/web/explorer/src/components/transaction/TransactionsPage.tsx
@@ -122,13 +122,13 @@ const TransactionsPage: React.FC = () => {
         },
         {
             title: 'Confirmed',
-            value: <StatValue stat={confirmedPageTxns} />,
+            value: <StatValue stat={confirmedPageTxns} loading={isTransactionsLoading} />,
             subValue: 'Current page',
             icon: 'fa-solid fa-circle-check',
         },
         {
             title: 'Visible Transactions',
-            value: <StatValue stat={visiblePageTxns} />,
+            value: <StatValue stat={visiblePageTxns} loading={isTransactionsLoading} />,
             subValue: 'Current page',
             icon: 'fa-solid fa-arrow-right-arrow-left',
         },

--- a/cmd/rpc/web/explorer/src/components/transaction/TransactionsPage.tsx
+++ b/cmd/rpc/web/explorer/src/components/transaction/TransactionsPage.tsx
@@ -5,6 +5,8 @@ import { usePending, useTransactionsWithRealPagination } from '../../hooks/useAp
 import { extractAmountMicro } from '../../lib/utils'
 import transactionsTexts from '../../data/transactions.json'
 import ExplorerOverviewCards from '../ExplorerOverviewCards'
+import StatValue from '../StatValue'
+import { usePersistentNumber } from '../../hooks/usePersistentNumber'
 
 type ActiveTab = 'confirmed' | 'pending'
 
@@ -100,28 +102,33 @@ const TransactionsPage: React.FC = () => {
     const totalConfirmed = Number((transactionsData as Record<string, unknown> | undefined)?.totalCount ?? 0)
     const totalPending = Number((pendingData as Record<string, unknown> | undefined)?.totalCount ?? 0)
 
+    const indexedTxns = usePersistentNumber('txns:indexed', transactionsData ? totalConfirmed : null)
+    const pendingTxns = usePersistentNumber('txns:pending', pendingData ? totalPending : null)
+    const confirmedPageTxns = usePersistentNumber('txns:confirmedPage', transactionsData ? normalizeConfirmedTransactions.length : null)
+    const visiblePageTxns = usePersistentNumber('txns:visiblePage', transactionsData ? normalizeConfirmedTransactions.length : null)
+
     const overviewCards = [
         {
             title: 'Indexed Transactions',
-            value: totalConfirmed.toLocaleString(),
+            value: <StatValue stat={indexedTxns} />,
             subValue: 'Confirmed total',
             icon: 'fa-solid fa-cubes',
         },
         {
             title: 'Pending',
-            value: totalPending.toLocaleString(),
+            value: <StatValue stat={pendingTxns} />,
             subValue: 'Awaiting block',
             icon: 'fa-solid fa-clock',
         },
         {
             title: 'Confirmed',
-            value: normalizeConfirmedTransactions.length.toLocaleString(),
+            value: <StatValue stat={confirmedPageTxns} />,
             subValue: 'Current page',
             icon: 'fa-solid fa-circle-check',
         },
         {
             title: 'Visible Transactions',
-            value: normalizeConfirmedTransactions.length.toLocaleString(),
+            value: <StatValue stat={visiblePageTxns} />,
             subValue: 'Current page',
             icon: 'fa-solid fa-arrow-right-arrow-left',
         },

--- a/cmd/rpc/web/explorer/src/hooks/usePersistentNumber.ts
+++ b/cmd/rpc/web/explorer/src/hooks/usePersistentNumber.ts
@@ -1,0 +1,69 @@
+import React from 'react'
+import { rpcURL } from '../lib/api'
+
+const STORAGE_PREFIX = 'explorer:stat:'
+
+const readStored = (storageKey: string): number | null => {
+    if (typeof window === 'undefined') return null
+    try {
+        const raw = window.localStorage.getItem(storageKey)
+        if (raw == null) return null
+        const parsed = Number(raw)
+        return Number.isFinite(parsed) ? parsed : null
+    } catch {
+        return null
+    }
+}
+
+export interface PersistentNumber {
+    /** Last known good value (0 until the first value is available). */
+    value: number
+    /**
+     * Whether a real value has been observed yet (either hydrated from
+     * localStorage on a previous visit, or fetched this session). When false,
+     * the caller should render a loading state instead of `value` (which is 0).
+     */
+    hasValue: boolean
+}
+
+/**
+ * Keeps the last known good value for a stat so the UI never flickers back to
+ * zero while data is being (re)fetched.
+ *
+ * - Initializes from localStorage so the previous value is shown immediately
+ *   after a full page reload, then updates once fresh data arrives.
+ * - Only updates when `candidate` is a finite number. Pass `null`/`undefined`
+ *   while data is missing/loading to retain the previous value.
+ * - Reports `hasValue: false` until the very first real value is seen, so the
+ *   first-ever load can show "Loading…" instead of a misleading 0.
+ *
+ * The storage key is namespaced per RPC endpoint so switching networks doesn't
+ * briefly show another network's numbers.
+ */
+export function usePersistentNumber(key: string, candidate: number | null | undefined): PersistentNumber {
+    const storageKey = `${STORAGE_PREFIX}${rpcURL}:${key}`
+
+    const [state, setState] = React.useState<PersistentNumber>(() => {
+        const stored = readStored(storageKey)
+        return stored != null ? { value: stored, hasValue: true } : { value: 0, hasValue: false }
+    })
+
+    // When the network (storageKey) changes, re-hydrate from the stored value
+    // for that network instead of keeping the previous network's number.
+    React.useEffect(() => {
+        const stored = readStored(storageKey)
+        setState(stored != null ? { value: stored, hasValue: true } : { value: 0, hasValue: false })
+    }, [storageKey])
+
+    React.useEffect(() => {
+        if (candidate == null || !Number.isFinite(candidate)) return
+        setState({ value: candidate, hasValue: true })
+        try {
+            window.localStorage.setItem(storageKey, String(candidate))
+        } catch {
+            // Ignore write failures (private mode / quota exceeded).
+        }
+    }, [candidate, storageKey])
+
+    return state
+}

--- a/cmd/rpc/web/explorer/src/hooks/usePersistentNumber.ts
+++ b/cmd/rpc/web/explorer/src/hooks/usePersistentNumber.ts
@@ -48,6 +48,8 @@ export function usePersistentNumber(key: string, candidate: number | null | unde
         return stored != null ? { value: stored, hasValue: true } : { value: 0, hasValue: false }
     })
 
+    const prevStorageKey = React.useRef(storageKey)
+
     // When the network (storageKey) changes, re-hydrate from the stored value
     // for that network instead of keeping the previous network's number.
     React.useEffect(() => {
@@ -56,6 +58,12 @@ export function usePersistentNumber(key: string, candidate: number | null | unde
     }, [storageKey])
 
     React.useEffect(() => {
+        // On a network switch `candidate` may still hold the previous network's
+        // value, so skip the write to avoid persisting it under the new key.
+        if (prevStorageKey.current !== storageKey) {
+            prevStorageKey.current = storageKey
+            return
+        }
         if (candidate == null || !Number.isFinite(candidate)) return
         setState({ value: candidate, hasValue: true })
         try {


### PR DESCRIPTION
## Fix flickering stat values in the block explorer overview

### Problem
In `cmd/rpc/web/explorer`, the overview stat cards (Home "Overview" and the Staking "Supply" view) flickered to `0`:

- **On refresh:** every stat dropped to `0` for a moment after a page reload, then animated back up once the network responded.
- **During normal use:** values intermittently spun down to `0` and recovered while polling.

### Root cause
- `Stages.tsx` called `setIsLoadingStats(true)` at the start of *every* refetch. Because `cardData` polls every ~2s, the async stats (Validating, Delegating, Accounts, Txs) repeatedly rendered `"Loading..."`, which got parsed as `0`, so `AnimatedNumber` animated all the way down and back up.
- There was no cross-reload persistence. On a fresh page load, `cardData` starts `undefined` and the local counters start at `0`, so the cards showed `0` until the RPC responded.
- `cardData`-derived values fell back to `0` whenever `cardData` was momentarily missing.

### Changes
- **New hook `src/hooks/usePersistentNumber.ts`** — a "sticky" value hook that:
  - hydrates its initial value from `localStorage` (namespaced per RPC endpoint), so a refresh shows the previous numbers immediately;
  - only updates when given a finite number — passing `null`/`undefined` (no data yet, or a failed fetch) retains the last known value;
  - reports `hasValue: false` until the first real value is observed, so a genuine first-ever load can show `Loading…` instead of a misleading `0`.
- **`Home/Stages.tsx`**
  - Removed the per-poll `isLoadingStats` reset (the main source of the flicker).
  - cardData-derived values now resolve to `null` (not `0`) when `cardData` is absent.
  - The async stats fetch only writes results on success (guarded against races with a `cancelled` flag) and never resets to `0` on error.
  - All 8 stats render through `usePersistentNumber`; cards show `Loading…` on first load instead of `0`.
- **`staking/SupplyView.tsx`** — applied the same sticky-value + `Loading…` treatment to Total / Staked / Liquid supply (metric cards and the "Supply Statistics" rows).

### Result
- **First-ever visit:** shows `Loading…` until data arrives — never a misleading `0`.
- **Refresh:** shows the previously cached value immediately, then updates in place once fresh data loads.
- **Normal polling:** values stay put and only animate when a real new value arrives — no more flicking to `0`.
- Switching networks doesn't briefly show another network's numbers (storage is namespaced per RPC endpoint).