### PR TITLE
Make JSON file writes atomic

### DIFF
--- a/lib/config.go
+++ b/lib/config.go
@@ -360,8 +360,8 @@ func (c Config) WriteToFile(filepath string) error {
 		// exit with error
 		return err
 	}
-	// write the config.json file to the data directory
-	return os.WriteFile(filepath, jsonBytes, os.ModePerm)
+	// atomically write the config.json file to the data directory
+	return WriteFileAtomic(filepath, jsonBytes, os.ModePerm)
 }
 
 // NewConfigFromFile() populates a Config object from a JSON file

--- a/lib/util.go
+++ b/lib/util.go
@@ -499,13 +499,71 @@ func SaveJSONToFile(j any, dataDirPath, filePath string) (err ErrorI) {
 		// exit with error
 		return
 	}
-	// attempt to write the json bytes to a json file at the path
-	if e := os.WriteFile(filepath.Join(dataDirPath, filePath), jsonBytes, os.ModePerm); e != nil {
+	// attempt to atomically write the json bytes to a json file at the path
+	if e := WriteFileAtomic(filepath.Join(dataDirPath, filePath), jsonBytes, os.ModePerm); e != nil {
 		// exit with error
 		return ErrWriteFile(e)
 	}
 	// exit
 	return
+}
+
+// WriteFileAtomic replaces a file using a temporary file in the same directory.
+func WriteFileAtomic(filePath string, bz []byte, perm os.FileMode) (err error) {
+	// create all necessary directories
+	if err = os.MkdirAll(filepath.Dir(filePath), os.ModePerm); err != nil {
+		// exit with error
+		return
+	}
+	// create a temporary file next to the destination file
+	tempFile, err := os.CreateTemp(filepath.Dir(filePath), "."+filepath.Base(filePath)+".tmp-*")
+	// if an error occurred during file creation
+	if err != nil {
+		// exit with error
+		return
+	}
+	// track the temporary file path for cleanup
+	tempPath := tempFile.Name()
+	// remove the temporary file on failure
+	defer func() {
+		// if an error occurred before the rename, remove the temporary file
+		if err != nil {
+			_ = os.Remove(tempPath)
+		}
+	}()
+	// write all bytes to the temporary file
+	if _, err = tempFile.Write(bz); err != nil {
+		// close before returning so Windows can remove the temporary file
+		_ = tempFile.Close()
+		// exit with error
+		return
+	}
+	// apply the requested permissions before the rename
+	if err = tempFile.Chmod(perm); err != nil {
+		// close before returning so Windows can remove the temporary file
+		_ = tempFile.Close()
+		// exit with error
+		return
+	}
+	// flush the temporary file to disk before replacing the destination
+	if err = tempFile.Sync(); err != nil {
+		// close before returning so Windows can remove the temporary file
+		_ = tempFile.Close()
+		// exit with error
+		return
+	}
+	// close the temporary file before renaming it
+	if err = tempFile.Close(); err != nil {
+		// exit with error
+		return
+	}
+	// atomically replace the destination file with the temporary file
+	if err = os.Rename(tempPath, filePath); err != nil {
+		// exit with error
+		return
+	}
+	// exit
+	return nil
 }
 
 // NewAny() converts a proto.Message into an anypb.Any type

--- a/lib/util_test.go
+++ b/lib/util_test.go
@@ -1,12 +1,16 @@
 package lib
 
 import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
 	"github.com/canopy-network/canopy/lib/crypto"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/encoding/protowire"
 	"google.golang.org/protobuf/types/known/anypb"
-	"testing"
-	"time"
 )
 
 // NOTE: pages are covered in the FSM module
@@ -479,6 +483,32 @@ func TestStopTimer(t *testing.T) {
 		// timer channel was drained successfully
 	default:
 	}
+}
+
+func TestWriteFileAtomicReplacesFile(t *testing.T) {
+	dir := t.TempDir()
+	filePath := filepath.Join(dir, "config.json")
+	require.NoError(t, os.WriteFile(filePath, []byte("old"), 0600))
+
+	require.NoError(t, WriteFileAtomic(filePath, []byte("new"), 0600))
+
+	got, err := os.ReadFile(filePath)
+	require.NoError(t, err)
+	require.Equal(t, "new", string(got))
+	tempFiles, err := filepath.Glob(filepath.Join(dir, ".config.json.tmp-*"))
+	require.NoError(t, err)
+	require.Empty(t, tempFiles)
+}
+
+func TestWriteFileAtomicCreatesParentDirectories(t *testing.T) {
+	dir := t.TempDir()
+	filePath := filepath.Join(dir, "nested", "book.json")
+
+	require.NoError(t, WriteFileAtomic(filePath, []byte(`{"book":[]}`), 0600))
+
+	got, err := os.ReadFile(filePath)
+	require.NoError(t, err)
+	require.True(t, strings.Contains(string(got), `"book"`))
 }
 
 func TestUnmarshalRejectsUnknownBlockFields(t *testing.T) {

--- a/p2p/book.go
+++ b/p2p/book.go
@@ -8,7 +8,6 @@ import (
 	"math/rand"
 	"os"
 	"path"
-	"path/filepath"
 	"slices"
 	"sync"
 	"time"
@@ -406,11 +405,7 @@ func (p *PeerBook) WriteToFile() error {
 	if err != nil {
 		return err
 	}
-	// create all necessary directories
-	if err = os.MkdirAll(filepath.Dir(p.path), os.ModePerm); err != nil {
-		return err
-	}
-	return os.WriteFile(p.path, configBz, os.ModePerm)
+	return lib.WriteFileAtomic(p.path, configBz, os.ModePerm)
 }
 
 // SaveRoutine() periodically saves the book to a json file


### PR DESCRIPTION
## Summary

- Add an atomic file-write helper that writes through a temporary file in the destination directory before renaming it into place.
- Use the helper for shared JSON persistence, config writes, and peer-book writes.
- Add focused coverage for replacement behavior and parent directory creation.

## Why

Fixes #189. A crash or interrupted write could leave persisted JSON files such as the peer book truncated, causing startup failures when the file was read again.

## Testing

- git diff --check

Go tests were not run locally because go is not installed on this machine.