### PR TITLE
Ignore client RPC write timeouts

### DIFF
--- a/cmd/rpc/server.go
+++ b/cmd/rpc/server.go
@@ -4,9 +4,11 @@ import (
 	"bytes"
 	"embed"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"io/fs"
+	"net"
 	"net/http"
 	"os"
 	"path"
@@ -16,6 +18,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"syscall"
 	"time"
 
 	"github.com/alecthomas/units"
@@ -468,8 +471,25 @@ func write(w http.ResponseWriter, payload any, code int) {
 		return
 	}
 	if _, err := w.Write(bz); err != nil {
-		logger.Errorf("[server write()] write response failed: %v", err)
+		if !isClientWriteError(err) {
+			logger.Errorf("[server write()] write response failed: %v", err)
+		}
 	}
+}
+
+// isClientWriteError reports whether an HTTP write failed because the client disconnected.
+func isClientWriteError(err error) bool {
+	var netErr net.Error
+	if errors.As(err, &netErr) && netErr.Timeout() {
+		return true
+	}
+	if errors.Is(err, syscall.EPIPE) || errors.Is(err, syscall.ECONNRESET) {
+		return true
+	}
+	msg := strings.ToLower(err.Error())
+	return strings.Contains(msg, "broken pipe") ||
+		strings.Contains(msg, "connection reset by peer") ||
+		strings.Contains(msg, "i/o timeout")
 }
 
 // StringToCommittees converts a comma separated string of committees to uint64

--- a/cmd/rpc/server_test.go
+++ b/cmd/rpc/server_test.go
@@ -1,0 +1,54 @@
+package rpc
+
+import (
+	"errors"
+	"syscall"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+type timeoutWriteError struct{}
+
+func (timeoutWriteError) Error() string   { return "write tcp 127.0.0.1:50002: i/o timeout" }
+func (timeoutWriteError) Timeout() bool   { return true }
+func (timeoutWriteError) Temporary() bool { return false }
+
+func TestIsClientWriteError(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{
+			name: "net timeout",
+			err:  timeoutWriteError{},
+			want: true,
+		},
+		{
+			name: "broken pipe",
+			err:  syscall.EPIPE,
+			want: true,
+		},
+		{
+			name: "connection reset",
+			err:  syscall.ECONNRESET,
+			want: true,
+		},
+		{
+			name: "string timeout",
+			err:  errors.New("write tcp 172.29.0.9:50002->172.29.0.1:38824: i/o timeout"),
+			want: true,
+		},
+		{
+			name: "unexpected write failure",
+			err:  errors.New("short write"),
+			want: false,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			require.Equal(t, test.want, isClientWriteError(test.err))
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Skip error logging when an RPC response write fails because the client disconnected or timed out.
- Keep logging unexpected response write failures.
- Add focused coverage for timeout, broken pipe, and connection reset detection.

## Why

Fixes #265. High-frequency explorer and wallet polling can leave noisy timeout logs when clients disconnect before the server finishes writing the response.

## Testing

- git diff --check

Go tests were not run locally because go is not installed on this machine.