### PR TITLE
fix(bft): use committeeHeight-1 consistently in ProcessDSE committee load

### DIFF
--- a/bft/evidence.go
+++ b/bft/evidence.go
@@ -78,7 +78,7 @@ func (b *BFT) ProcessDSE(dse ...*DoubleSignEvidence) (results []*lib.DoubleSigne
 		// height which would require logic to handle 'switch root' in the currently played block
 		rootChainId := b.Controller.LoadRootChainId(committeeHeight - 1)
 		// load the committee from the root chain id using the n-1 height because state machine heights are 'end state' once committed
-		vs, err := b.LoadCommittee(rootChainId, committeeHeight)
+		vs, err := b.LoadCommittee(rootChainId, committeeHeight-1)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
## Bug

In `bft/evidence.go`, `ProcessDSE()` correctly looks up the `rootChainId` at `committeeHeight - 1` (to avoid using end-state data), but then loads the committee using `committeeHeight` instead of `committeeHeight - 1`:

```go
// before
rootChainId := b.Controller.LoadRootChainId(committeeHeight - 1)
vs, err := b.LoadCommittee(rootChainId, committeeHeight)  // ← mismatch
```

This creates a root chain ID / committee height mismatch — the root chain ID is for block N-1, but the committee is loaded from block N. This inconsistency can cause valid double-sign evidence to be rejected or invalid DSE to slip through validation.

## Fix

Pass `committeeHeight-1` to `LoadCommittee` to stay consistent with the comment and the `rootChainId` lookup:

```go
// after
rootChainId := b.Controller.LoadRootChainId(committeeHeight - 1)
vs, err := b.LoadCommittee(rootChainId, committeeHeight-1)  // ✓ consistent
```

## Impact

Critical — incorrect committee snapshot used during double-sign evidence validation in BFT consensus.