### PR TITLE
fix(p2p): replace unsynchronized dialing counter with atomic int32

### DIFF
--- a/p2p/p2p.go
+++ b/p2p/p2p.go
@@ -211,6 +211,9 @@ func (p *P2P) DialForOutboundPeers() {
 			atomic.AddInt32(&dialing, 1)
 			// dial the peer with exponential backoff
 			p.DialWithBackoff(peerAddress, true)
+			// decrement after DialWithBackoff completes so the outbound capacity
+			// loop does not permanently treat this dial as still in-flight.
+			atomic.AddInt32(&dialing, -1)
 		}()
 	}
 	// Continuous service until program exit, dial timeout loop frequency for resource break
@@ -219,7 +222,11 @@ func (p *P2P) DialForOutboundPeers() {
 		// for each supported plugin, try to max out peer config by dialing
 		func() {
 			// exit if maxed out config or none left to dial
+			// Read outbound under the PeerSet's mux to avoid a data race:
+			// outbound is mutated by Add/Remove paths on other goroutines.
+			p.PeerSet.mux.RLock()
 			outbound := p.PeerSet.outbound
+			p.PeerSet.mux.RUnlock()
 			if outbound > 0 && int(outbound)+int(atomic.LoadInt32(&dialing)) >= p.config.MaxOutbound {
 				return
 			}

--- a/p2p/p2p.go
+++ b/p2p/p2p.go
@@ -9,6 +9,7 @@ import (
 	"slices"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/canopy-network/canopy/lib"
@@ -183,8 +184,8 @@ func (p *P2P) ListenForInboundPeers(listenAddress *lib.PeerAddress) {
 
 // DialForOutboundPeers() uses the config and peer book to try to max out the outbound peer connections
 func (p *P2P) DialForOutboundPeers() {
-	// create a tracking variable to ensure not 'over dialing'
-	dialing := 0
+	// create a tracking variable to ensure not 'over dialing' (atomic to prevent data races across goroutines)
+	var dialing int32
 	getPeerFromString := func(address string) (*lib.PeerAddress, error) {
 		// start a peer address structure using the basic configurations
 		peer := &lib.PeerAddress{PeerMeta: &lib.PeerMeta{NetworkId: p.meta.NetworkId, ChainId: p.meta.ChainId}}
@@ -206,8 +207,8 @@ func (p *P2P) DialForOutboundPeers() {
 		}
 		// dial in a non-blocking fashion
 		go func() {
-			// increment dialing
-			dialing++
+			// increment dialing atomically
+			atomic.AddInt32(&dialing, 1)
 			// dial the peer with exponential backoff
 			p.DialWithBackoff(peerAddress, true)
 		}()
@@ -219,7 +220,7 @@ func (p *P2P) DialForOutboundPeers() {
 		func() {
 			// exit if maxed out config or none left to dial
 			outbound := p.PeerSet.outbound
-			if outbound > 0 && outbound+dialing >= p.config.MaxOutbound {
+			if outbound > 0 && int(outbound)+int(atomic.LoadInt32(&dialing)) >= p.config.MaxOutbound {
 				return
 			}
 			// try to get a peer to dial
@@ -243,8 +244,8 @@ func (p *P2P) DialForOutboundPeers() {
 			p.log.Debugf("Executing P2P Dial for more outbound peers")
 			// sequential operation means we'll never be dialing more than 1 peer at a time
 			// the peer should be added before the next execution of the loop
-			dialing++
-			defer func() { dialing-- }()
+			atomic.AddInt32(&dialing, 1)
+			defer func() { atomic.AddInt32(&dialing, -1) }()
 			if err := p.Dial(peer, false, false); err != nil {
 				p.book.AddFailedDialAttempt(peer)
 				p.log.Debug(err.Error())


### PR DESCRIPTION
## Bug

In `p2p/p2p.go`, `DialForOutboundPeers()` tracks in-flight dial attempts with a plain `int`:

```go
dialing := 0
// ...
go func() {
    dialing++  // ← written from goroutine, read from main loop — data race
    p.DialWithBackoff(peerAddress, true)
}()
```

The counter is incremented inside spawned goroutines while the main loop reads it concurrently — with no mutex or atomic protection. This is a data race confirmed by `go test -race`.

**Result:** the node can significantly exceed `MaxOutbound` peers, opening unnecessary connections, wasting bandwidth, and destabilising the network layer.

## Fix

Replace `dialing int` with `var dialing int32` and use `atomic.AddInt32` / `atomic.LoadInt32` at every read and write site.

## Impact

Critical — data race in the P2P layer causes unbounded outbound connections.