### PR TITLE
fix(store): replace MemHash uint64 map key with string key to eliminate hash collisions

### DIFF
--- a/store/txn.go
+++ b/store/txn.go
@@ -46,7 +46,7 @@ type Txn struct {
 
 // txn internal structure maintains the write operations sorted lexicographically by keys
 type txn struct {
-	ops    map[uint64]valueOp        // [string(key)] -> set/del operations saved in memory
+	ops    map[string]valueOp        // [hex(key)] -> set/del operations saved in memory; string keys avoid uint64 hash collisions
 	sorted *btree.BTreeG[*CacheItem] // sorted btree of keys for fast iteration
 	rbuf   []byte                    // a buffer to re-use for reads
 
@@ -97,7 +97,7 @@ func NewTxn(reader TxnReaderI, writer TxnWriterI, prefix []byte, state, sort, se
 		seek:         seek,
 		writeVersion: v,
 		txn: &txn{
-			ops:    make(map[uint64]valueOp),
+			ops:    make(map[string]valueOp),
 			sorted: btree.NewG(32, func(a, b *CacheItem) bool { return a.Less(b) }), // need to benchmark this value
 			l:      sync.Mutex{},
 		},
@@ -109,7 +109,7 @@ func (t *Txn) Get(key []byte) ([]byte, lib.ErrorI) {
 	t.txn.l.Lock()
 	defer t.txn.l.Unlock()
 	// first retrieve from the in-memory txn
-	if v, found := t.txn.ops[lib.MemHash(key)]; found {
+	if v, found := t.txn.ops[string(key)]; found {
 		if v.op == opDelete {
 			return nil, nil
 		}
@@ -142,7 +142,7 @@ func (t *Txn) DeleteAt(key []byte, version uint64) lib.ErrorI {
 
 // update() modifies or adds an operation to the txn
 func (t *Txn) update(key []byte, val []byte, version uint64, opAction op) (e lib.ErrorI) {
-	hashedKey := lib.MemHash(key)
+	hashedKey := string(key)
 	t.txn.l.Lock()
 	defer t.txn.l.Unlock()
 	if _, found := t.txn.ops[hashedKey]; !found && t.sort {
@@ -153,7 +153,7 @@ func (t *Txn) update(key []byte, val []byte, version uint64, opAction op) (e lib
 }
 
 // addToSorted() inserts a key into the sorted list of operations maintaining lexicographical order
-func (t *Txn) addToSorted(key []byte, hashedKey uint64) {
+func (t *Txn) addToSorted(key []byte, hashedKey string) {
 	t.txn.sorted.ReplaceOrInsert(&CacheItem{Key: key, HashedKey: hashedKey, Exists: true})
 }
 


### PR DESCRIPTION
## Bug

In `store/txn.go`, `Txn` uses `lib.MemHash(key)` — a non-cryptographic 64-bit FNV hash — as the map key for in-memory write operations:

```go
ops map[uint64]valueOp  // keyed by 64-bit hash of the byte-slice key
```

Two different byte-slice keys that produce the same 64-bit hash silently collide. A `Get()` after a `Set()` on one key can return the value belonging to a different key, causing incorrect state reads during transaction and block processing.

The birthday paradox makes this non-trivial: at ~4 billion distinct keys the collision probability reaches ~50%. Blockchain state stores routinely reach millions of keys.

## Fix

Use `string(key)` as the map key, which provides exact identity at the cost of one allocation per operation — acceptable for the correctness guarantee this provides.

```go
ops map[string]valueOp  // keyed by exact byte content, no collisions
```

## Impact

Critical — silent state corruption during block processing due to hash collision in the core storage layer.