### PR TITLE
fix(bft): make GetLeadingVote deterministic on equal voting power

### DIFF
--- a/bft/vote.go
+++ b/bft/vote.go
@@ -38,10 +38,15 @@ func (b *BFT) GetMajorityVote() (m *Message, sig *lib.AggregateSignature, err li
 }
 
 // GetLeadingVote() returns the unique Vote Message that has the most power behind it and the number and percent voted that voted for it
+// Tiebreak: when two payloads have equal power, the one with the lexicographically smallest sign-bytes hash wins,
+// ensuring all honest nodes make the same deterministic choice.
 func (b *BFT) GetLeadingVote() (m *Message, maxVotePercent uint64, maxVotes uint64) {
-	for _, voteSet := range b.Votes[b.View.Round][phaseToString(b.View.Phase-1)] {
-		if voteSet.TotalVotedPower >= maxVotes {
+	var maxPayloadHash string
+	for payloadHash, voteSet := range b.Votes[b.View.Round][phaseToString(b.View.Phase-1)] {
+		if voteSet.TotalVotedPower > maxVotes ||
+			(voteSet.TotalVotedPower == maxVotes && (m == nil || payloadHash < maxPayloadHash)) {
 			m, maxVotes, maxVotePercent = voteSet.Vote, voteSet.TotalVotedPower, lib.Uint64PercentageDiv(voteSet.TotalVotedPower, b.ValidatorSet.TotalPower)
+			maxPayloadHash = payloadHash
 		}
 	}
 	return


### PR DESCRIPTION
## Bug

  `bft/vote.go`'s `GetLeadingVote()` selects the vote set with the most voting power using `>=` while iterating over a Go map:

  ```go
  for _, voteSet := range b.Votes[b.View.Round][...] {
      if voteSet.TotalVotedPower >= maxVotes {
          m, maxVotes = voteSet.Vote, voteSet.TotalVotedPower
      }
  }

  Go map iteration order is randomized. When two payload hashes have equal voting power, GetLeadingVote() can return different “leading” votes for the
  same local vote set.

  This function is currently used for consensus status reporting, not for QC construction or consensus advancement, but deterministic behavior is
  still preferable for consistent debugging, RPC output, and tests.

  ## Fix

  Iterate with the payload hash key and use a deterministic tie-break. Higher voting power still wins; when voting power is equal, the
  lexicographically smallest payload hash wins:

  if voteSet.TotalVotedPower > maxVotes ||
      (voteSet.TotalVotedPower == maxVotes && (m == nil || payloadHash < maxPayloadHash)) {

  This removes map-iteration randomness from GetLeadingVote() for identical local vote sets.

  ## Impact

  Low — this stabilizes leading-vote reporting in equal-power ties. It does not appear to affect consensus safety or liveness because consensus
  operation uses GetMajorityVote(), not GetLeadingVote().