### PR TITLE
fix(fsm): guard against empty PaymentPercents slice in HandleCertificateResults

### DIFF
--- a/fsm/automatic.go
+++ b/fsm/automatic.go
@@ -144,8 +144,11 @@ func (s *StateMachine) HandleCertificateResults(qc *lib.QuorumCertificate, commi
 	if qc.Results.RewardRecipients == nil {
 		return lib.ErrNilRewardRecipients()
 	}
-	// guard against an empty PaymentPercents slice causing a silent no-op reward distribution
-	if len(qc.Results.RewardRecipients.PaymentPercents) == 0 && qc.Results.RewardRecipients != nil {
+	// Guard: an empty PaymentPercents slice would pass the nil check above but be
+	// silently persisted by UpsertCommitteeData, skipped by DistributeCommitteeRewards,
+	// and distort later reward accounting (NumberOfSamples accumulates without recipients).
+	// RewardRecipients non-nil is already guaranteed above; no need to re-check here.
+	if len(qc.Results.RewardRecipients.PaymentPercents) == 0 {
 		return lib.ErrInvalidPercentAllocation()
 	}
 	// ensure the committee isn't retired

--- a/fsm/automatic.go
+++ b/fsm/automatic.go
@@ -144,6 +144,10 @@ func (s *StateMachine) HandleCertificateResults(qc *lib.QuorumCertificate, commi
 	if qc.Results.RewardRecipients == nil {
 		return lib.ErrNilRewardRecipients()
 	}
+	// guard against an empty PaymentPercents slice causing a silent no-op reward distribution
+	if len(qc.Results.RewardRecipients.PaymentPercents) == 0 && qc.Results.RewardRecipients != nil {
+		return lib.ErrInvalidPercentAllocation()
+	}
 	// ensure the committee isn't retired
 	retired, err := s.CommitteeIsRetired(qc.Header.ChainId)
 	if err != nil {


### PR DESCRIPTION
## Bug

In `fsm/automatic.go`, `HandleCertificateResults()` checks that `RewardRecipients` is non-nil but does not guard against `PaymentPercents` being an empty slice:

```go
if qc.Results.RewardRecipients == nil {
    return lib.ErrNilRewardRecipients()
}
// No check that PaymentPercents is non-empty ↓
for i, p := range results.RewardRecipients.PaymentPercents {
    results.RewardRecipients.PaymentPercents[i].Percent = ...
}
```

An empty `PaymentPercents` slice causes the reward-distribution loop to silently skip all payments — validators complete work but receive **no rewards**, and the block is accepted without error. A malicious or buggy proposer can craft a `CertificateResult` with a non-nil `RewardRecipients` but zero `PaymentPercents` to silently starve the committee of rewards for that block height.

## Fix

Return `ErrInvalidPercentAllocation` when `PaymentPercents` is empty after the existing nil guard, making the invariant explicit and ensuring the block is rejected rather than silently misprocessed.

## Impact

Critical — malicious proposer can craft blocks that pass validation but deliver zero rewards to the committee.