### PR TITLE
Handle empty validator set in monitoring

### DIFF
--- a/cmd/rpc/web/wallet/src/core/dsCore.ts
+++ b/cmd/rpc/web/wallet/src/core/dsCore.ts
@@ -167,7 +167,27 @@ export async function fetchDsOnce<T=any>(chain: ChainLike, key: string, ctx?: Re
     const { url, init } = buildRequest(chain, leaf, ctx)
     if (!url) throw new Error(`Invalid DS url for key ${key}`)
     const res = await fetch(url, init)
-    if (!res.ok) throw new Error(`RPC ${res.status}`)
+    if (!res.ok) {
+        const ct = res.headers.get('content-type') || ''
+        let response: any
+        try {
+            response = ct.includes('application/json') ? await res.json() : await res.text()
+        } catch {
+            response = undefined
+        }
+
+        const message =
+            response && typeof response === 'object' && 'msg' in response
+                ? `RPC ${res.status}: ${response.msg}`
+                : `RPC ${res.status}`
+
+        throw Object.assign(new Error(message), {
+            status: res.status,
+            code: response && typeof response === 'object' ? response.code : undefined,
+            module: response && typeof response === 'object' ? response.module : undefined,
+            response,
+        })
+    }
     const parsed = await parseResponse(res, leaf)
     return parsed as T
 }

--- a/cmd/rpc/web/wallet/src/hooks/useNodes.ts
+++ b/cmd/rpc/web/wallet/src/hooks/useNodes.ts
@@ -31,6 +31,12 @@ export interface NodeData {
   validatorSet: any;
 }
 
+const isNoValidatorsError = (error: unknown): boolean =>
+  typeof error === "object" &&
+  error !== null &&
+  "code" in error &&
+  Number((error as { code?: unknown }).code) === 29;
+
 /**
  * Hook to fetch the current chain's committeeId from admin.config
  */
@@ -156,7 +162,12 @@ export const useNodeData = (nodeId: string) => {
           dsFetch("admin.consensusInfo"),
           dsFetch("admin.peerInfo"),
           dsFetch("admin.resourceUsage"),
-          dsFetch("validatorSet", { height: 0, committeeId: committeeId! }),
+          dsFetch("validatorSet", { height: 0, committeeId: committeeId! }).catch((error) => {
+            if (isNoValidatorsError(error)) {
+              return { validatorSet: [] };
+            }
+            throw error;
+          }),
         ]);
 
         return {


### PR DESCRIPTION
## Summary

- Preserve RPC error metadata in the wallet DS fetcher so callers can inspect server error codes.
- Treat validator-set error code 29 as an empty validator set in monitoring data loading.
- Keep other validator-set and monitoring fetch failures fatal.

## Why

Fixes #431. A chain with no staked committee validators returns the canonical no-validators response, but the monitoring page treated it as a fatal RPC 400 and hid the other data that loaded successfully.

## Testing

- npm run build
- git diff --check