### PR TITLE
Guard stake RPC operator public key

### DIFF
--- a/cmd/rpc/admin.go
+++ b/cmd/rpc/admin.go
@@ -177,8 +177,8 @@ func (s *Server) TransactionStake(w http.ResponseWriter, r *http.Request, _ http
 		if err != nil {
 			return nil, err
 		}
-		// Convert the public key from string to a crypto.PublicKey
-		pk, err := crypto.NewPublicKeyFromString(ptr.PubKey)
+		// Convert and validate the public key from string to a crypto.PublicKey
+		pk, err := stakePublicKeyFromRequest(ptr)
 		if err != nil {
 			return nil, err
 		}
@@ -584,8 +584,8 @@ func (s *Server) txHandler(w http.ResponseWriter, r *http.Request, callback func
 		write(w, err, http.StatusBadRequest)
 		return
 	}
-	// Set the public key in transaction request for reference.
-	ptr.PubKey = privateKey.PublicKey().String()
+	// Set the public key in transaction request for reference when one was not supplied.
+	setRequestPublicKey(ptr, privateKey)
 
 	// Call the provided callback function with the private key and transaction request.
 	p, err := callback(privateKey, ptr)
@@ -608,6 +608,23 @@ func (s *Server) txHandler(w http.ResponseWriter, r *http.Request, callback func
 			s.logger.Error(err.Error())
 			return
 		}
+	}
+}
+
+func stakePublicKeyFromRequest(ptr *txRequest) (crypto.PublicKeyI, error) {
+	pk, err := crypto.NewPublicKeyFromString(ptr.PubKey)
+	if err != nil {
+		return nil, err
+	}
+	if !bytes.Equal(pk.Address().Bytes(), ptr.Address) {
+		return nil, fmt.Errorf("stake public key address must match validator address")
+	}
+	return pk, nil
+}
+
+func setRequestPublicKey(ptr *txRequest, privateKey crypto.PrivateKeyI) {
+	if ptr.PubKey == "" {
+		ptr.PubKey = privateKey.PublicKey().String()
 	}
 }
 

--- a/cmd/rpc/admin_test.go
+++ b/cmd/rpc/admin_test.go
@@ -1,0 +1,63 @@
+package rpc
+
+import (
+	"testing"
+
+	"github.com/canopy-network/canopy/lib/crypto"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSetRequestPublicKeyPreservesExplicitPubKey(t *testing.T) {
+	operatorKey, err := crypto.NewBLS12381PrivateKey()
+	require.NoError(t, err)
+	signerKey, err := crypto.NewBLS12381PrivateKey()
+	require.NoError(t, err)
+
+	ptr := &txRequest{PubKey: operatorKey.PublicKey().String()}
+
+	setRequestPublicKey(ptr, signerKey)
+
+	require.Equal(t, operatorKey.PublicKey().String(), ptr.PubKey)
+}
+
+func TestSetRequestPublicKeyFallsBackToSignerPubKey(t *testing.T) {
+	signerKey, err := crypto.NewBLS12381PrivateKey()
+	require.NoError(t, err)
+
+	ptr := new(txRequest)
+
+	setRequestPublicKey(ptr, signerKey)
+
+	require.Equal(t, signerKey.PublicKey().String(), ptr.PubKey)
+}
+
+func TestStakePublicKeyFromRequestRequiresValidatorAddress(t *testing.T) {
+	operatorKey, err := crypto.NewBLS12381PrivateKey()
+	require.NoError(t, err)
+	signerKey, err := crypto.NewBLS12381PrivateKey()
+	require.NoError(t, err)
+
+	ptr := &txRequest{
+		PubKey:         signerKey.PublicKey().String(),
+		addressRequest: addressRequest{Address: operatorKey.PublicKey().Address().Bytes()},
+	}
+
+	_, err = stakePublicKeyFromRequest(ptr)
+
+	require.ErrorContains(t, err, "stake public key address must match validator address")
+}
+
+func TestStakePublicKeyFromRequestAcceptsValidatorPubKey(t *testing.T) {
+	operatorKey, err := crypto.NewBLS12381PrivateKey()
+	require.NoError(t, err)
+
+	ptr := &txRequest{
+		PubKey:         operatorKey.PublicKey().String(),
+		addressRequest: addressRequest{Address: operatorKey.PublicKey().Address().Bytes()},
+	}
+
+	got, err := stakePublicKeyFromRequest(ptr)
+
+	require.NoError(t, err)
+	require.True(t, operatorKey.PublicKey().Equals(got))
+}


### PR DESCRIPTION
## Summary

- Preserve an explicitly supplied stake pubKey instead of always replacing it with the signer key.
- Reject stake RPC requests when the supplied public key does not resolve to the requested validator address.
- Add focused RPC admin tests for pubKey preservation and validator-address validation.

## Why

Fixes #203. Signing a stake request with the output key should not silently construct a custodial validator registration for the output key.

## Testing

- git diff --check
- Not run: Go toolchain is not installed in this environment.