### PR TITLE
Guard zero-token governance vote percentages

### DIFF
--- a/fsm/gov.go
+++ b/fsm/gov.go
@@ -495,17 +495,24 @@ func (s *StateMachine) PollsToResults(polls *ActivePolls) (result Poll, err lib.
 			}
 		}
 		// calculate stats for validators
-		r.Validators.ApprovePercentage = uint64(float64(r.Validators.ApproveTokens) / float64(r.Validators.TotalTokens) * 100)
-		r.Validators.RejectPercentage = uint64(float64(r.Validators.RejectTokens) / float64(r.Validators.TotalTokens) * 100)
-		r.Validators.VotedPercentage = uint64(float64(r.Validators.ApproveTokens+r.Validators.RejectTokens) / float64(r.Validators.TotalTokens) * 100)
+		r.Validators.ApprovePercentage = votePercentage(r.Validators.ApproveTokens, r.Validators.TotalTokens)
+		r.Validators.RejectPercentage = votePercentage(r.Validators.RejectTokens, r.Validators.TotalTokens)
+		r.Validators.VotedPercentage = votePercentage(r.Validators.ApproveTokens+r.Validators.RejectTokens, r.Validators.TotalTokens)
 		// calculate stats for accounts
-		r.Accounts.ApprovePercentage = uint64(float64(r.Accounts.ApproveTokens) / float64(r.Accounts.TotalTokens) * 100)
-		r.Accounts.RejectPercentage = uint64(float64(r.Accounts.RejectTokens) / float64(r.Accounts.TotalTokens) * 100)
-		r.Accounts.VotedPercentage = uint64(float64(r.Accounts.ApproveTokens+r.Accounts.RejectTokens) / float64(r.Accounts.TotalTokens) * 100)
+		r.Accounts.ApprovePercentage = votePercentage(r.Accounts.ApproveTokens, r.Accounts.TotalTokens)
+		r.Accounts.RejectPercentage = votePercentage(r.Accounts.RejectTokens, r.Accounts.TotalTokens)
+		r.Accounts.VotedPercentage = votePercentage(r.Accounts.ApproveTokens+r.Accounts.RejectTokens, r.Accounts.TotalTokens)
 		// set results
 		result[proposalHash] = r
 	}
 	return
+}
+
+func votePercentage(part, total uint64) uint64 {
+	if total == 0 {
+		return 0
+	}
+	return uint64(float64(part) / float64(total) * 100)
 }
 
 // UPGRADE CODE BELOW

--- a/fsm/gov_test.go
+++ b/fsm/gov_test.go
@@ -154,6 +154,44 @@ func TestUpdateParam(t *testing.T) {
 	}
 }
 
+func TestPollsToResultsZeroTotalTokens(t *testing.T) {
+	sm := newTestStateMachine(t)
+	validatorKey := newTestKeyGroup(t)
+	const stakeAmount = uint64(100)
+	const daoAmount = uint64(1)
+
+	require.NoError(t, sm.SetValidators([]*Validator{{
+		Address:      validatorKey.Address.Bytes(),
+		PublicKey:    validatorKey.PublicKey.Bytes(),
+		StakedAmount: stakeAmount,
+		Committees:   []uint64{sm.Config.ChainId},
+	}}, &Supply{}))
+	require.NoError(t, sm.SetPool(&Pool{Id: lib.DAOPoolID, Amount: daoAmount}))
+	require.NoError(t, sm.SetSupply(&Supply{Total: stakeAmount + daoAmount, Staked: stakeAmount}))
+
+	const proposalHash = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+	polls := &ActivePolls{
+		Polls: map[string]map[string]bool{
+			proposalHash: {
+				validatorKey.Address.String(): true,
+			},
+		},
+		PollMeta: map[string]*StartPoll{
+			proposalHash: {StartPoll: proposalHash, Url: "https://example.com", EndHeight: 10},
+		},
+	}
+
+	results, err := sm.PollsToResults(polls)
+
+	require.NoError(t, err)
+	require.Equal(t, uint64(0), results[proposalHash].Accounts.TotalTokens)
+	require.Equal(t, uint64(0), results[proposalHash].Accounts.ApprovePercentage)
+	require.Equal(t, uint64(0), results[proposalHash].Accounts.RejectPercentage)
+	require.Equal(t, uint64(0), results[proposalHash].Accounts.VotedPercentage)
+	require.Equal(t, uint64(100), results[proposalHash].Validators.ApprovePercentage)
+	require.Equal(t, uint64(100), results[proposalHash].Validators.VotedPercentage)
+}
+
 func TestConformStateToParamUpdate(t *testing.T) {
 	const amount = uint64(100)
 	// preset param sets to test the adjustment after the update


### PR DESCRIPTION
## Summary

- Add a shared vote percentage helper that returns zero when total voting power is zero.
- Use the helper for account and validator poll result percentages.
- Add coverage for poll results when all account voting power is staked or in the DAO pool.

## Why

Governance poll result rendering can encounter a voting group with zero total tokens. The previous direct division by total tokens could produce invalid percentage values for that group.

## Testing

- git diff --check
- Not run: Go toolchain is not installed in this environment.