### PR TITLE
Guard transaction replay height overflow

### DIFF
--- a/fsm/transaction.go
+++ b/fsm/transaction.go
@@ -243,7 +243,7 @@ func (s *StateMachine) CheckReplay(tx *lib.Transaction, txHash string) lib.Error
 		}
 	}
 	// this gives the protocol a theoretically safe tx indexer prune height
-	maxHeight, minHeight := s.Height()+BlockAcceptanceRange, uint64(0)
+	maxHeight, minHeight := maxAcceptedTxHeight(s.Height()), uint64(0)
 	// if height is after the BlockAcceptanceRange blocks
 	if s.Height() > BlockAcceptanceRange {
 		// update the minimum height
@@ -255,6 +255,13 @@ func (s *StateMachine) CheckReplay(tx *lib.Transaction, txHash string) lib.Error
 	}
 	// exit
 	return nil
+}
+
+func maxAcceptedTxHeight(height uint64) uint64 {
+	if height > math.MaxUint64-BlockAcceptanceRange {
+		return math.MaxUint64
+	}
+	return height + BlockAcceptanceRange
 }
 
 // CheckMessage() performs basic validations on the msg payload

--- a/fsm/transaction_test.go
+++ b/fsm/transaction_test.go
@@ -665,6 +665,16 @@ func TestCheckReplay(t *testing.T) {
 			},
 			height: 122,
 		},
+		{
+			name:   "maximum height overflow guard",
+			detail: "near max uint64 height should not wrap the maximum accepted tx height",
+			tx: &lib.Transaction{
+				CreatedHeight: math.MaxUint64 - 1,
+				NetworkId:     1,
+				ChainId:       1,
+			},
+			height: math.MaxUint64 - 1,
+		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {


### PR DESCRIPTION
## Summary

- Saturate the maximum accepted replay height when the current height is near max uint64.
- Prevent unsigned wraparound from rejecting otherwise valid transaction heights.
- Add a regression case for near-max replay height bounds.

## Why

CheckReplay calculated height + BlockAcceptanceRange directly. Near max uint64, that addition can wrap to a small value and make a same-height transaction fail the upper-bound check.

## Testing

- git diff --check
- Not run: Go toolchain is not installed in this environment.