### PR TITLE
Normalize negative pagination params

### DIFF
--- a/lib/util.go
+++ b/lib/util.go
@@ -181,8 +181,8 @@ func (p *Page) LoadArray(slice any, results Pageable, callback func(item any) Er
 func (p *PageParams) skipToIndex() int {
 	// set the defaults
 	defaultPerPage, maxPerPage := 10, 5000
-	// if the perPage isn't set
-	if p.PerPage == 0 {
+	// if the perPage isn't set or is invalid
+	if p.PerPage <= 0 {
 		// use the default
 		p.PerPage = defaultPerPage
 	}
@@ -192,7 +192,7 @@ func (p *PageParams) skipToIndex() int {
 		p.PerPage = maxPerPage
 	}
 	// start page count at 1 not 0
-	if p.PageNumber == 0 {
+	if p.PageNumber <= 0 {
 		// set to page 1
 		p.PageNumber = 1
 	}

--- a/lib/util_test.go
+++ b/lib/util_test.go
@@ -11,6 +11,10 @@ import (
 
 // NOTE: pages are covered in the FSM module
 
+type testPageItems []int
+
+func (t *testPageItems) New() Pageable { return new(testPageItems) }
+
 func TestMarshalUnmarshal(t *testing.T) {
 	// create a proto structure to test with
 	expected := &Signature{
@@ -26,6 +30,23 @@ func TestMarshalUnmarshal(t *testing.T) {
 	require.NoError(t, Unmarshal(gotBytes, got))
 	// compare got vs expected
 	require.EqualExportedValues(t, expected, got)
+}
+
+func TestPageLoadArrayNormalizesNegativeParams(t *testing.T) {
+	results := make(testPageItems, 0)
+	page := NewPage(PageParams{PageNumber: -2, PerPage: -5}, "test-items")
+
+	err := page.LoadArray([]int{1, 2, 3}, &results, func(item any) ErrorI {
+		results = append(results, item.(int))
+		return nil
+	})
+
+	require.NoError(t, err)
+	require.Equal(t, 1, page.PageNumber)
+	require.Equal(t, 10, page.PerPage)
+	require.Equal(t, 3, page.Count)
+	require.Equal(t, 1, page.TotalPages)
+	require.Equal(t, testPageItems{1, 2, 3}, results)
 }
 
 func TestJSONMarshalUnmarshal(t *testing.T) {


### PR DESCRIPTION
## Summary

- Treat negative pageNumber values like missing values and default them to page 1.
- Treat negative perPage values like missing values and default them to 10.
- Add focused LoadArray coverage for negative pagination input.

## Why

PageParams are accepted from JSON/RPC as signed integers. Negative values previously bypassed the zero-value defaults and could produce invalid skip indexes and pagination metadata.

## Testing

- git diff --check
- Not run: Go toolchain is not installed in this environment.