### PR TITLE
Allow zero requested amount on edit order

### DIFF
--- a/fsm/message_helpers.go
+++ b/fsm/message_helpers.go
@@ -661,7 +661,7 @@ func (x *MessageEditOrder) Check() lib.ErrorI {
 	if len(x.Data) > 100 {
 		return ErrInvalidOpcode()
 	}
-	if x.AmountForSale == 0 || x.RequestedAmount == 0 {
+	if x.AmountForSale == 0 {
 		return ErrInvalidAmount()
 	}
 	return checkExternalAddress(x.SellerReceiveAddress)

--- a/fsm/transaction_test.go
+++ b/fsm/transaction_test.go
@@ -704,6 +704,17 @@ func TestCheckMessage(t *testing.T) {
 	// convert the message to 'any' for transaction wrapping
 	msgSendAny, e := lib.NewAny(sendMsg)
 	require.NoError(t, e)
+	// predefine an edit-order message that leaves requested amount at zero
+	editOrderMsg := &MessageEditOrder{
+		OrderId:              newTestOrderId(t, 0),
+		ChainId:              lib.CanopyChainId,
+		AmountForSale:        1,
+		RequestedAmount:      0,
+		SellerReceiveAddress: newTestAddressBytes(t),
+	}
+	// convert the message to 'any' for transaction wrapping
+	msgEditOrderAny, e := lib.NewAny(editOrderMsg)
+	require.NoError(t, e)
 	tests := []struct {
 		name     string
 		detail   string
@@ -745,6 +756,12 @@ func TestCheckMessage(t *testing.T) {
 			detail:   "a valid message passes",
 			msg:      msgSendAny,
 			expected: sendMsg,
+		},
+		{
+			name:     "valid edit order keeps requested amount zero",
+			detail:   "an edit order may keep the requested amount at zero",
+			msg:      msgEditOrderAny,
+			expected: editOrderMsg,
 		},
 	}
 	for _, test := range tests {


### PR DESCRIPTION
## Summary

- Allow edit-order messages to keep requestedAmount at zero during stateless validation.
- Add CheckMessage coverage for an edit-order message that keeps requestedAmount zero.

## Why

HandleMessageEditOrder already supports existing edit-order flows where requestedAmount remains zero, but MessageEditOrder.Check rejected those messages before they could reach the handler.

## Testing

- git diff --check
- Not run: Go toolchain is not installed in this environment.