### PR TITLE
Use requestedAmount JSON tag for order messages

### DIFF
--- a/fsm/message.pb.go
+++ b/fsm/message.pb.go
@@ -827,7 +827,7 @@ type MessageCreateOrder struct {
 	// amount_for_sale: the amount of uCNPY listed for sale, transferred to escrow
 	AmountForSale uint64 `protobuf:"varint,3,opt,name=AmountForSale,proto3" json:"amountForSale"` // @gotags: json:"amountForSale"
 	// requested_amount: the amount of the 'counter asset' the buyer must send in order to complete a swap
-	RequestedAmount uint64 `protobuf:"varint,4,opt,name=RequestedAmount,proto3" json:"requestAmount"` // @gotags: json:"requestAmount"
+	RequestedAmount uint64 `protobuf:"varint,4,opt,name=RequestedAmount,proto3" json:"requestedAmount"` // @gotags: json:"requestedAmount"
 	// sellers_receive_address: the address of the seller where the 'counter asset' will be received
 	SellerReceiveAddress []byte `protobuf:"bytes,5,opt,name=SellerReceiveAddress,proto3" json:"sellerReceiveAddress"` // @gotags: json:"sellerReceiveAddress"
 	// sellers_send_address: the Canopy address the seller is selling and signing from
@@ -1077,7 +1077,7 @@ type MessageDexLimitOrder struct {
 	// amount_for_sale: the amount of asset listed for sale, transferred to escrow
 	AmountForSale uint64 `protobuf:"varint,2,opt,name=amount_for_sale,json=amountForSale,proto3" json:"amountForSale"` // @gotags: json:"amountForSale"
 	// requested_amount: the minimum amount of the 'counter asset' the seller is willing to receive
-	RequestedAmount uint64 `protobuf:"varint,3,opt,name=requested_amount,json=requestedAmount,proto3" json:"requestAmount"` // @gotags: json:"requestAmount"
+	RequestedAmount uint64 `protobuf:"varint,3,opt,name=requested_amount,json=requestedAmount,proto3" json:"requestedAmount"` // @gotags: json:"requestedAmount"
 	// sellers_send_address: the address the seller is selling and signing from
 	Address []byte `protobuf:"bytes,4,opt,name=address,proto3" json:"sellersSendAddress"` // @gotags: json:"sellersSendAddress"
 	// OrderId: auto-populated by the state machine to assign the unique bytes to the order

--- a/lib/.proto/message.proto
+++ b/lib/.proto/message.proto
@@ -185,7 +185,7 @@ message MessageCreateOrder {
   // amount_for_sale: the amount of uCNPY listed for sale, transferred to escrow
   uint64 AmountForSale = 3; // @gotags: json:"amountForSale"
   // requested_amount: the amount of the 'counter asset' the buyer must send in order to complete a swap
-  uint64 RequestedAmount = 4; // @gotags: json:"requestAmount"
+  uint64 RequestedAmount = 4; // @gotags: json:"requestedAmount"
   // sellers_receive_address: the address of the seller where the 'counter asset' will be received
   bytes SellerReceiveAddress = 5; // @gotags: json:"sellerReceiveAddress"
   // sellers_send_address: the Canopy address the seller is selling and signing from
@@ -231,7 +231,7 @@ message MessageDexLimitOrder {
   // amount_for_sale: the amount of asset listed for sale, transferred to escrow
   uint64 amount_for_sale = 2; // @gotags: json:"amountForSale"
   // requested_amount: the minimum amount of the 'counter asset' the seller is willing to receive
-  uint64 requested_amount = 3; // @gotags: json:"requestAmount"
+  uint64 requested_amount = 3; // @gotags: json:"requestedAmount"
   // sellers_send_address: the address the seller is selling and signing from
   bytes address = 4; // @gotags: json:"sellersSendAddress"
   // OrderId: auto-populated by the state machine to assign the unique bytes to the order


### PR DESCRIPTION
## Summary

- Correct the MessageCreateOrder RequestedAmount JSON gotag from requestAmount to requestedAmount.
- Correct the MessageDexLimitOrder RequestedAmount JSON gotag to the same requestedAmount spelling.
- Keep the checked-in generated Go tags aligned with the proto annotations.

## Why

The rest of the order message JSON surface uses requestedAmount. These two proto gotags used requestAmount, which made the generated struct tags inconsistent with the documented/API spelling.

Addresses part of #167.

## Testing

- git diff --check
- Verified no requestAmount JSON gotags remain in lib/.proto/message.proto or fsm/message.pb.go
- Not run: Go toolchain/proto generator is not installed in this environment.