### PR TITLE
fix(workflows): include proto/ in typescript plugin release tarball

### DIFF
--- a/.github/workflows/release-plugin-typescript.yml
+++ b/.github/workflows/release-plugin-typescript.yml
@@ -42,10 +42,21 @@ jobs:
         working-directory: plugin/typescript
         run: |
           mkdir -p release
-          # Create tarball with dist/, node_modules, package.json (for "type": "module")
+          # Create tarball with dist/, node_modules, package.json (for "type": "module"),
+          # AND proto/ — the raw .proto schema files are loaded at runtime by
+          # protobufjs.loadSync() from the compiled dist/contract/*.js. Without
+          # proto/ in the tarball, plugins that build with the canonical tutorial
+          # pattern crash on startup with ENOENT (see canopy-network/canopy#<TODO>).
+          # If a chain author has no proto/ directory, fall back to the legacy
+          # tarball shape so their build doesn't break.
+          #
           # Note: pluginctl.sh is NOT included - it's copied separately by Dockerfile
           # and we don't want old releases to overwrite newer pluginctl.sh versions
-          tar -czf release/typescript-plugin.tar.gz dist/ node_modules/ package.json
+          if [ -d proto ]; then
+            tar -czf release/typescript-plugin.tar.gz dist/ node_modules/ package.json proto/
+          else
+            tar -czf release/typescript-plugin.tar.gz dist/ node_modules/ package.json
+          fi
 
       - name: Create GitHub release
         uses: softprops/action-gh-release@v2


### PR DESCRIPTION
## Summary

`release-plugin-typescript.yml` packages only `dist/ node_modules/ package.json` — omitting `proto/`. The compiled `dist/contract/*.js` (per the canonical TUTORIAL.md pattern) uses `protobufjs.loadSync('proto/<file>.proto')` at runtime, so the plugin process crashes on first import with:

```
node:fs:561
Error: ENOENT: no such file or directory, open '/app/plugin/typescript/proto/<file>.proto'
    at Object.openSync (node:fs:561:18)
    at Object.readFileSync (node:fs:445:35)
    at fetch (/app/plugin/typescript/node_modules/protobufjs/src/root.js:195:34)
    at Root.loadSync (/app/plugin/typescript/node_modules/protobufjs/src/root.js:275:17)
    at file:///app/plugin/typescript/dist/contract/<file>.js:10:31
```

This causes `pluginctl.sh start` to report the generic `Error: TypeScript plugin failed to start`, and the chain pod enters CrashLoopBackOff.

## Repro (real)

- Chain: `proofarcadet-98795` on dev cluster (forked from `Valcio13/ProofArcade`, template = TypeScript Plugin)
- Tarball: `plugin-typescript-v2026.178.1782578829` from the fork's GitHub releases
- Pod logs (captured by running node manually inside the container after patching the entrypoint to sleep):
  ```
  Error: ENOENT: no such file or directory, open '/app/plugin/typescript/proto/game2048.proto'
  ```

## Blast radius

Every TypeScript-plugin chain that follows the documented `protobufjs.loadSync` pattern hits this. The fix needs to ship in canopy main; once it does, fork rebases + a fresh release tag pick it up automatically.

## Fix

Pack `proto/` into the tarball, guarded by `[ -d proto ]` so plugins that pre-compile descriptors (no raw `.proto` files at runtime) keep the legacy tarball shape and don't break.

```diff
-          tar -czf release/typescript-plugin.tar.gz dist/ node_modules/ package.json
+          if [ -d proto ]; then
+            tar -czf release/typescript-plugin.tar.gz dist/ node_modules/ package.json proto/
+          else
+            tar -czf release/typescript-plugin.tar.gz dist/ node_modules/ package.json
+          fi
```

## Test plan

- [ ] Merge → re-cut any TypeScript plugin release tag → `tar -tzf typescript-plugin.tar.gz | grep '\.proto$'` shows `proto/*.proto` included
- [ ] Affected chains (`proofarcadet-98795` + future TS-plugin graduations) boot cleanly without ENOENT

## Followup (separate PR, optional)

A more durable fix is to teach the canonical TUTORIAL.md pattern to embed proto descriptors at build time (using protobufjs CLI's `pbts`/`pbjs` JSON descriptor output) so the runtime doesn't need raw .proto files at all. That said, this PR is the minimal fix for the immediate breakage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
