### PR TITLE
Guard empty RPC client admin flag

### DIFF
--- a/cmd/rpc/client.go
+++ b/cmd/rpc/client.go
@@ -1112,7 +1112,7 @@ func (c *Client) heightIdAndPointsRequest(routeName string, height, id uint64, p
 
 func (c *Client) url(routeName, param string, admin ...bool) string {
 	// if an admin call
-	if admin != nil && admin[0] {
+	if len(admin) > 0 && admin[0] {
 		return c.adminRpcUrl + routePaths[routeName].Path + param
 	}
 	// if non admin call

--- a/cmd/rpc/client_test.go
+++ b/cmd/rpc/client_test.go
@@ -1,0 +1,24 @@
+package rpc
+
+import "testing"
+
+func TestClientURLEmptyAdminFlag(t *testing.T) {
+	client := NewClient("http://query", "http://admin")
+	emptyAdmin := []bool{}
+
+	got := client.url(LogsRouteName, "", emptyAdmin...)
+	want := "http://query" + routePaths[LogsRouteName].Path
+	if got != want {
+		t.Fatalf("url with empty admin flag = %q, want %q", got, want)
+	}
+}
+
+func TestClientURLAdminFlag(t *testing.T) {
+	client := NewClient("http://query", "http://admin")
+
+	got := client.url(LogsRouteName, "", true)
+	want := "http://admin" + routePaths[LogsRouteName].Path
+	if got != want {
+		t.Fatalf("url with admin flag = %q, want %q", got, want)
+	}
+}


### PR DESCRIPTION
## Summary

- Check the variadic admin flag length before reading admin[0].
- Add client URL coverage for an empty forwarded admin flag and for an explicit admin call.

## Why

Callers can forward an empty []bool through the variadic admin flag. The previous nil-only check could panic on admin[0] in that case, even though it should behave like a normal query URL.

## Testing

- git diff --check
- Not run: Go toolchain is not installed in this environment.