### PR TITLE
fix(fsm/indexer): handle proto3 zero-value Pool.Id / Account.Address

### DIFF
--- a/fsm/indexer.go
+++ b/fsm/indexer.go
@@ -2,6 +2,7 @@ package fsm
 
 import (
 	"bytes"
+	"errors"
 
 	"github.com/canopy-network/canopy/lib"
 	"github.com/canopy-network/canopy/lib/codec"
@@ -314,20 +315,27 @@ func entriesByKey(entries [][]byte, keyExtractor func([]byte) (string, error)) (
 	return out, entryMap, nil
 }
 
-func accountEntryKey(entry []byte) (string, error) {
-	field, err := codec.GetRawProtoField(entry, 1) // Account.address
+// entryKeyOrZero extracts field #1 as a map key. In proto3, absent scalar
+// fields represent the zero value on the wire (Pool{Id:0}, Account{Address:nil}),
+// so codec.ErrFieldNotFound is a legal zero-value signal, not a parse error.
+// Real proto-parse errors (invalid tags, buffer overruns) still surface.
+func entryKeyOrZero(entry []byte) (string, error) {
+	field, err := codec.GetRawProtoField(entry, 1)
 	if err != nil {
+		if errors.Is(err, codec.ErrFieldNotFound) {
+			return "", nil
+		}
 		return "", err
 	}
 	return string(field), nil
 }
 
+func accountEntryKey(entry []byte) (string, error) {
+	return entryKeyOrZero(entry) // Account.address
+}
+
 func poolEntryKey(entry []byte) (string, error) {
-	field, err := codec.GetRawProtoField(entry, 1) // Pool.id
-	if err != nil {
-		return "", err
-	}
-	return string(field), nil
+	return entryKeyOrZero(entry) // Pool.id
 }
 
 func changedBlobKeys(current, previous map[string][]byte) (map[string]struct{}, map[string]struct{}) {

--- a/fsm/indexer_test.go
+++ b/fsm/indexer_test.go
@@ -150,3 +150,33 @@ func requireEntriesAsSet(t *testing.T, got [][]byte, expected ...[]byte) {
 	}
 	require.Equal(t, expSet, gotSet)
 }
+
+// TestDeltaIndexerBlobs_ZeroValuePoolAndAccount is a regression for the
+// proto3-zero-value bug that permanently 400s /v1/query/indexer-blobs when
+// chain state contains a Pool{Id:0} or Account{Address:nil}. Because proto3
+// omits zero-valued scalar fields from the wire, marshalling Pool{Id:0,Amount:5000}
+// produces bytes with only field #2 (Amount). Pre-fix, poolEntryKey called
+// codec.GetRawProtoField(entry, 1) and returned "field number 1 not found",
+// which bubbled up as lib.ErrUnmarshal and HTTP 400 on every affected height.
+// Post-fix, the missing field is treated as an empty (zero-value) key.
+func TestDeltaIndexerBlobs_ZeroValuePoolAndAccount(t *testing.T) {
+	zeroPool := mustMarshalProto(t, &Pool{Id: 0, Amount: 5000})
+	normalPool := mustMarshalProto(t, &Pool{Id: 32768, Amount: 25_000_000_000_000})
+	zeroAcc := mustMarshalProto(t, &Account{Address: nil, Amount: 1})
+	normalAcc := mustMarshalProto(t, &Account{Address: bytes.Repeat([]byte{7}, 20), Amount: 42})
+
+	curr := &IndexerBlob{
+		Block:    mustMarshalProto(t, &lib.BlockResult{}),
+		Accounts: [][]byte{zeroAcc, normalAcc},
+		Pools:    [][]byte{zeroPool, normalPool},
+	}
+	prev := &IndexerBlob{
+		Block:    mustMarshalProto(t, &lib.BlockResult{}),
+		Accounts: [][]byte{zeroAcc, normalAcc},
+		Pools:    [][]byte{zeroPool, normalPool},
+	}
+
+	delta, err := DeltaIndexerBlobs(&IndexerBlobs{Current: curr, Previous: prev})
+	require.NoError(t, err, "zero-value Pool.Id / Account.Address must not error")
+	require.NotNil(t, delta)
+}

--- a/lib/codec/codec.go
+++ b/lib/codec/codec.go
@@ -2,11 +2,19 @@ package codec
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"google.golang.org/protobuf/encoding/protowire"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/anypb"
 )
+
+// ErrFieldNotFound is returned by GetRawProtoField when the requested field
+// number is absent from the wire bytes. In proto3, absent scalar fields
+// represent the zero value, so callers that expect zero-valued fields
+// (e.g. Pool{Id:0}, Account{Address:nil}) should detect this via errors.Is
+// and treat the field as empty rather than as a parse error.
+var ErrFieldNotFound = errors.New("field number not found")
 
 // BinaryCodec is an interface model that defines the requirements for binary encoding and decoding
 // A binary encoder converts data into a compact, non-human-readable binary format, which is highly
@@ -107,7 +115,7 @@ func GetRawProtoField(protoBytes []byte, fieldNumber int) ([]byte, error) {
 			offset += skipLen
 		}
 	}
-	return nil, fmt.Errorf("field number %d not found", fieldNumber)
+	return nil, fmt.Errorf("%w: %d", ErrFieldNotFound, fieldNumber)
 }
 
 // NullifyProtoField removes a field from protobytes without unmarshalling


### PR DESCRIPTION
Pool{Id:0} in state permanently 400s /v1/query/indexer-blobs.

Proto3 omits zero-valued scalars from the wire, so a Pool with Id=0
marshals without field #1. poolEntryKey called GetRawProtoField(entry, 1)
and returned the parse error, which bubbled up as HTTP 400 on every
subsequent height because the entry persists in state.

Fix: treat codec.ErrFieldNotFound as the proto3 zero value in
entryKeyOrZero. Real parse errors still surface.