### PR TITLE
fix: search results flickering and mixing in explorer

### DIFF
--- a/cmd/rpc/web/explorer/src/components/search/SearchResults.tsx
+++ b/cmd/rpc/web/explorer/src/components/search/SearchResults.tsx
@@ -30,7 +30,139 @@ const formatAccountBalance = (amount: number | undefined) =>
         maximumFractionDigits: 2,
     })
 
-const SearchResults: React.FC<SearchResultsProps> = ({ results, filters }) => {
+const copyToClipboard = (text: string) => {
+    if (text && text !== 'N/A') {
+        navigator.clipboard.writeText(text)
+        toast.success('Copied to clipboard')
+    }
+}
+
+// Address card with live balance/tx counts. Kept at module scope (stable
+// identity) so slot-keyed cards update in place instead of remounting/blinking.
+const AddressResult: React.FC<{ address: string; initialData?: any }> = ({ address, initialData }) => {
+    const [accountData, setAccountData] = useState<any>(null)
+    const [transactions, setTransactions] = useState<{ sent: any[]; received: any[] }>({ sent: [], received: [] })
+    const [loading, setLoading] = useState(true)
+
+    useEffect(() => {
+        // Ignore a stale response if `address` changes before it resolves.
+        let cancelled = false
+
+        const fetchAddressData = async () => {
+            if (!address) return
+
+            setLoading(true)
+            try {
+                // Get account balance
+                const account = await Account(0, address)
+                if (cancelled) return
+                setAccountData(account)
+
+                // Get transactions (sent and received)
+                const [sentTxs, recTxs] = await Promise.all([
+                    TransactionsBySender(1, address).catch(() => ({ results: [] })),
+                    TransactionsByRec(1, address).catch(() => ({ results: [] }))
+                ])
+                if (cancelled) return
+
+                setTransactions({
+                    sent: sentTxs?.results || sentTxs || [],
+                    received: recTxs?.results || recTxs || []
+                })
+            } catch (error) {
+                if (!cancelled) console.error('Error fetching address data:', error)
+            } finally {
+                if (!cancelled) setLoading(false)
+            }
+        }
+
+        fetchAddressData()
+
+        return () => { cancelled = true }
+    }, [address])
+
+    const balance = formatAccountBalance(accountData?.amount ?? initialData?.amount)
+
+    return (
+        <motion.div
+            initial={{ opacity: 0, y: 20 }}
+            animate={{ opacity: 1, y: 0 }}
+            className="bg-card border border-white/5 rounded-xl p-4 md:p-6 hover:border-white/10 transition-colors"
+        >
+            <div className="flex items-start justify-between">
+                <div className="flex-1 min-w-0">
+                    <div className='flex flex-col sm:flex-row sm:items-start sm:justify-between gap-2 sm:gap-0 mb-3'>
+                        <div className="flex items-center gap-3">
+                            <div className="w-9 h-9 bg-green-700/30 rounded-full flex items-center justify-center flex-shrink-0">
+                                <i className="fa-solid fa-wallet text-primary text-lg"></i>
+                            </div>
+                            <span className="text-white text-lg">Address</span>
+                        </div>
+                        <div className={GREEN_BADGE_CLASS}>
+                            Address
+                        </div>
+                    </div>
+
+                    <div className="space-y-2 mb-4">
+                        <div className="flex items-start flex-col">
+                            <span className="text-gray-400 text-sm mb-1">Address:</span>
+                            <Link
+                                to={`/account/${address}`}
+                                className="text-white font-mono text-sm sm:text-base md:text-lg break-all hover:text-primary hover:underline transition-colors w-full"
+                            >
+                                {address || 'N/A'}
+                            </Link>
+                        </div>
+                    </div>
+
+                    <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3 md:gap-2 mt-4">
+                        <div className="flex flex-col sm:flex-row sm:items-center gap-1 sm:gap-2">
+                            <span className="text-gray-400 text-sm">Balance:</span>
+                            {loading ? (
+                                <span className="text-white text-sm">Loading...</span>
+                            ) : (
+                                <span className="text-white text-sm">{balance} CNPY</span>
+                            )}
+                        </div>
+                        <div className="flex flex-col sm:flex-row sm:items-center gap-1 sm:gap-2">
+                            <span className="text-gray-400 text-sm">Sent Transactions:</span>
+                            {loading ? (
+                                <span className="text-white text-sm">Loading...</span>
+                            ) : (
+                                <span className="text-white text-sm">{transactions.sent?.length || 0}</span>
+                            )}
+                        </div>
+                        <div className="flex flex-col sm:flex-row sm:items-center gap-1 sm:gap-2 sm:col-span-2 lg:col-span-1">
+                            <span className="text-gray-400 text-sm">Received Transactions:</span>
+                            {loading ? (
+                                <span className="text-white text-sm">Loading...</span>
+                            ) : (
+                                <span className="text-white text-sm">{transactions.received?.length || 0}</span>
+                            )}
+                        </div>
+                    </div>
+
+                    <div className="flex flex-col sm:flex-row gap-2 mt-4">
+                        <Link
+                            to={`/account/${address}`}
+                            className="px-3 py-1.5 bg-input text-white rounded-md text-sm font-medium transition-colors text-center sm:text-left"
+                        >
+                            <i className="fa-solid fa-eye text-white mr-2"></i> View Details
+                        </Link>
+                        <button
+                            onClick={() => copyToClipboard(address)}
+                            className="px-3 py-1.5 bg-input text-white rounded-md text-sm font-medium hover:bg-white/10 transition-colors"
+                        >
+                            <i className="fa-solid fa-copy text-white mr-2"></i> Copy Address
+                        </button>
+                    </div>
+                </div>
+            </div>
+        </motion.div>
+    )
+}
+
+const SearchResults: React.FC<SearchResultsProps> = ({ results, searchTerm, filters }) => {
     // Sync activeTab with filter.type if filter is set
     const initialTab = filters?.type !== 'all' ? filters.type : 'all'
     const [activeTab, setActiveTab] = useState(initialTab)
@@ -189,13 +321,6 @@ const SearchResults: React.FC<SearchResultsProps> = ({ results, filters }) => {
         return `${hash.slice(0, length)}...${hash.slice(-length)}`
     }
 
-    const copyToClipboard = (text: string) => {
-        if (text && text !== 'N/A') {
-            navigator.clipboard.writeText(text)
-            toast.success('Copied to clipboard')
-        }
-    }
-
     const handlePageChange = (page: number) => {
         setCurrentPage(page)
     }
@@ -218,129 +343,20 @@ const SearchResults: React.FC<SearchResultsProps> = ({ results, filters }) => {
         setCurrentPage(1)
     }, [activeTab])
 
-    // Component to render address with balance and transactions
-    const AddressResult: React.FC<{ address: string; initialData?: any }> = ({ address, initialData }) => {
-        const [accountData, setAccountData] = useState<any>(null)
-        const [transactions, setTransactions] = useState<{ sent: any[]; received: any[] }>({ sent: [], received: [] })
-        const [loading, setLoading] = useState(true)
+    // New term resets pagination (panel stays mounted, so we do this manually).
+    useEffect(() => {
+        setCurrentPage(1)
+    }, [searchTerm])
 
-        useEffect(() => {
-            const fetchAddressData = async () => {
-                if (!address) return
-
-                setLoading(true)
-                try {
-                    // Get account balance
-                    const account = await Account(0, address)
-                    setAccountData(account)
-
-                    // Get transactions (sent and received)
-                    const [sentTxs, recTxs] = await Promise.all([
-                        TransactionsBySender(1, address).catch(() => ({ results: [] })),
-                        TransactionsByRec(1, address).catch(() => ({ results: [] }))
-                    ])
-
-                    setTransactions({
-                        sent: sentTxs?.results || sentTxs || [],
-                        received: recTxs?.results || recTxs || []
-                    })
-                } catch (error) {
-                    console.error('Error fetching address data:', error)
-                } finally {
-                    setLoading(false)
-                }
-            }
-
-            fetchAddressData()
-        }, [address])
-
-        const balance = formatAccountBalance(accountData?.amount ?? initialData?.amount)
-
-        return (
-            <motion.div
-                initial={{ opacity: 0, y: 20 }}
-                animate={{ opacity: 1, y: 0 }}
-                className="bg-card border border-white/5 rounded-xl p-4 md:p-6 hover:border-white/10 transition-colors"
-            >
-                <div className="flex items-start justify-between">
-                    <div className="flex-1 min-w-0">
-                        <div className='flex flex-col sm:flex-row sm:items-start sm:justify-between gap-2 sm:gap-0 mb-3'>
-                            <div className="flex items-center gap-3">
-                                <div className="w-9 h-9 bg-green-700/30 rounded-full flex items-center justify-center flex-shrink-0">
-                                    <i className="fa-solid fa-wallet text-primary text-lg"></i>
-                                </div>
-                                <span className="text-white text-lg">Address</span>
-                            </div>
-                            <div className={GREEN_BADGE_CLASS}>
-                                Address
-                            </div>
-                        </div>
-
-                        <div className="space-y-2 mb-4">
-                            <div className="flex items-start flex-col">
-                                <span className="text-gray-400 text-sm mb-1">Address:</span>
-                                <Link
-                                    to={`/account/${address}`}
-                                    className="text-white font-mono text-sm sm:text-base md:text-lg break-all hover:text-primary hover:underline transition-colors w-full"
-                                >
-                                    {address || 'N/A'}
-                                </Link>
-                            </div>
-                        </div>
-
-                        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3 md:gap-2 mt-4">
-                            <div className="flex flex-col sm:flex-row sm:items-center gap-1 sm:gap-2">
-                                <span className="text-gray-400 text-sm">Balance:</span>
-                                {loading ? (
-                                    <span className="text-white text-sm">Loading...</span>
-                                ) : (
-                                    <span className="text-white text-sm">{balance} CNPY</span>
-                                )}
-                            </div>
-                            <div className="flex flex-col sm:flex-row sm:items-center gap-1 sm:gap-2">
-                                <span className="text-gray-400 text-sm">Sent Transactions:</span>
-                                {loading ? (
-                                    <span className="text-white text-sm">Loading...</span>
-                                ) : (
-                                    <span className="text-white text-sm">{transactions.sent?.length || 0}</span>
-                                )}
-                            </div>
-                            <div className="flex flex-col sm:flex-row sm:items-center gap-1 sm:gap-2 sm:col-span-2 lg:col-span-1">
-                                <span className="text-gray-400 text-sm">Received Transactions:</span>
-                                {loading ? (
-                                    <span className="text-white text-sm">Loading...</span>
-                                ) : (
-                                    <span className="text-white text-sm">{transactions.received?.length || 0}</span>
-                                )}
-                            </div>
-                        </div>
-
-                        <div className="flex flex-col sm:flex-row gap-2 mt-4">
-                            <Link
-                                to={`/account/${address}`}
-                                className="px-3 py-1.5 bg-input text-white rounded-md text-sm font-medium transition-colors text-center sm:text-left"
-                            >
-                                <i className="fa-solid fa-eye text-white mr-2"></i> View Details
-                            </Link>
-                            <button
-                                onClick={() => copyToClipboard(address)}
-                                className="px-3 py-1.5 bg-input text-white rounded-md text-sm font-medium hover:bg-white/10 transition-colors"
-                            >
-                                <i className="fa-solid fa-copy text-white mr-2"></i> Copy Address
-                            </button>
-                        </div>
-                    </div>
-                </div>
-            </motion.div>
-        )
-    }
-
-    const renderResult = (item: any, type: string) => {
+    const renderResult = (item: any, type: string, index: number) => {
         if (!item) return null
+
+        // Slot-based key so cards update in place across searches (no blink).
+        const slotKey = `result-${index}`
 
         // If it's an address, use the AddressResult component
         if (type === 'address' && item.address) {
-            return <AddressResult key={item.address} address={item.address} initialData={item} />
+            return <AddressResult key={slotKey} address={item.address} initialData={item} />
         }
 
         // settings for each type
@@ -447,7 +463,7 @@ const SearchResults: React.FC<SearchResultsProps> = ({ results, filters }) => {
 
         return (
             <motion.div
-                key={config.copyValue}
+                key={slotKey}
                 initial={{ opacity: 0, y: 20 }}
                 animate={{ opacity: 1, y: 0 }}
                 className={`bg-card border ${config.borderColor} rounded-xl p-4 md:p-6 ${config.hoverColor} transition-colors`}
@@ -742,8 +758,8 @@ const SearchResults: React.FC<SearchResultsProps> = ({ results, filters }) => {
                             exit={{ opacity: 0 }}
                             className="space-y-4"
                         >
-                            {filteredResults.map((result: any) =>
-                                renderResult(result, result.resultType || activeTab)
+                            {filteredResults.map((result: any, index: number) =>
+                                renderResult(result, result.resultType || activeTab, index)
                             )}
                         </motion.div>
                     ) : (

--- a/cmd/rpc/web/explorer/src/hooks/useSearch.ts
+++ b/cmd/rpc/web/explorer/src/hooks/useSearch.ts
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react'
+import { useState, useEffect, useRef } from 'react'
 import { useTxByHash, useAllValidators } from './useApi'
 import {
     getModalData,
@@ -33,8 +33,11 @@ const formatAccountBalanceSubtitle = (amount: number | string | undefined) =>
 
 export const useSearch = (searchTerm: string) => {
     const [results, setResults] = useState<SearchResults | null>(null)
-    const [loading, setLoading] = useState(false)
+    const [isSearching, setIsSearching] = useState(false)
     const [error, setError] = useState<string | null>(null)
+
+    // Bumped per search so a stale (superseded) request can't overwrite newer results.
+    const requestIdRef = useRef(0)
 
     // Detect if search term is a transaction hash
     const isHashSearch = searchTerm && searchTerm.length >= 32 && /^[a-fA-F0-9]+$/.test(searchTerm)
@@ -45,17 +48,24 @@ export const useSearch = (searchTerm: string) => {
     // Get all validators for partial address search
     const { data: allValidatorsData } = useAllValidators()
 
-    const searchInData = async (term: string) => {
-        if (!term.trim()) {
+    const searchInData = async (rawTerm: string) => {
+        const term = rawTerm.trim()
+
+        if (!term) {
+            // Invalidate any in-flight request and reset to the empty state.
+            requestIdRef.current++
             setResults(null)
+            setIsSearching(false)
+            setError(null)
             return
         }
 
-        setLoading(true)
-        setError(null)
+        const requestId = ++requestIdRef.current
 
-        // Clear previous results immediately
-        setResults(null)
+        // Keep the previous results mounted while the new query runs (no clear),
+        // so the panel doesn't blink; values are swapped in place when ready.
+        setIsSearching(true)
+        setError(null)
 
         try {
             const searchResults: SearchResults = {
@@ -65,6 +75,27 @@ export const useSearch = (searchTerm: string) => {
                 addresses: [],
                 validators: [],
                 orders: []
+            }
+
+            // Publish results-so-far (only if still the latest request). Runs as
+            // each source resolves so fast lookups show without waiting for the
+            // slow order scan. Empty states are skipped unless `force` is set.
+            const publish = (force = false) => {
+                if (requestId !== requestIdRef.current) return
+                const total = searchResults.blocks.length +
+                    searchResults.transactions.length +
+                    searchResults.addresses.length +
+                    searchResults.validators.length +
+                    searchResults.orders.length
+                if (!force && total === 0) return
+                setResults({
+                    total,
+                    blocks: [...searchResults.blocks],
+                    transactions: [...searchResults.transactions],
+                    addresses: [...searchResults.addresses],
+                    validators: [...searchResults.validators],
+                    orders: [...searchResults.orders],
+                })
             }
 
             // DIRECT SEARCH FOR BLOCKS, TRANSACTIONS, ACCOUNTS, AND VALIDATORS
@@ -384,25 +415,25 @@ export const useSearch = (searchTerm: string) => {
                     .catch(err => console.log('Order search error:', err))
             )
 
-            // Wait for all promises to complete
-            await Promise.all(searchPromises)
+            // Publish as each source settles so results appear progressively.
+            searchPromises.forEach(p => { p.then(() => publish()).catch(() => { }) })
 
-            // Calculate total
-            const total = searchResults.blocks.length +
-                searchResults.transactions.length +
-                searchResults.addresses.length +
-                searchResults.validators.length +
-                searchResults.orders.length
+            await Promise.allSettled(searchPromises)
 
-            setResults({
-                ...searchResults,
-                total
-            })
+            // Drop results if a newer search superseded this one.
+            if (requestId !== requestIdRef.current) return
+
+            // Final publish (forced) also renders the "no results" state.
+            publish(true)
         } catch (err) {
+            if (requestId !== requestIdRef.current) return
             setError('Error searching data')
             console.error('Search error:', err)
         } finally {
-            setLoading(false)
+            // Only the latest request may clear the searching flag.
+            if (requestId === requestIdRef.current) {
+                setIsSearching(false)
+            }
         }
     }
 
@@ -416,7 +447,9 @@ export const useSearch = (searchTerm: string) => {
 
     return {
         results,
-        loading,
+        // Spinner only on the first search (nothing shown yet); later searches update in place.
+        loading: isSearching && !results,
+        isSearching,
         error,
         search: searchInData
     }

--- a/cmd/rpc/web/explorer/src/hooks/useSearch.ts
+++ b/cmd/rpc/web/explorer/src/hooks/useSearch.ts
@@ -42,11 +42,19 @@ export const useSearch = (searchTerm: string) => {
     // Detect if search term is a transaction hash
     const isHashSearch = searchTerm && searchTerm.length >= 32 && /^[a-fA-F0-9]+$/.test(searchTerm)
 
-    // Only use this hook for exact hashes
-    const { data: hashSearchData } = useTxByHash(isHashSearch ? searchTerm : '')
+    // Warm the tx-by-hash cache for exact hashes.
+    useTxByHash(isHashSearch ? searchTerm : '')
 
     // Get all validators for partial address search
     const { data: allValidatorsData } = useAllValidators()
+
+    // Ref so searchInData reads fresh validators without being an effect dep
+    // (which re-ran the search on every refetch/focus and flickered in Brave).
+    const allValidatorsRef = useRef(allValidatorsData)
+    allValidatorsRef.current = allValidatorsData
+
+    // Term currently shown; avoids blanking results when a re-run finds nothing.
+    const committedTermRef = useRef<string | null>(null)
 
     const searchInData = async (rawTerm: string) => {
         const term = rawTerm.trim()
@@ -54,6 +62,7 @@ export const useSearch = (searchTerm: string) => {
         if (!term) {
             // Invalidate any in-flight request and reset to the empty state.
             requestIdRef.current++
+            committedTermRef.current = null
             setResults(null)
             setIsSearching(false)
             setError(null)
@@ -87,7 +96,12 @@ export const useSearch = (searchTerm: string) => {
                     searchResults.addresses.length +
                     searchResults.validators.length +
                     searchResults.orders.length
-                if (!force && total === 0) return
+                if (total === 0) {
+                    if (!force) return
+                    // Don't blank results already shown for this same term.
+                    if (committedTermRef.current === term) return
+                }
+                committedTermRef.current = term
                 setResults({
                     total,
                     blocks: [...searchResults.blocks],
@@ -258,8 +272,9 @@ export const useSearch = (searchTerm: string) => {
                     // Search in validators list if available (validators take priority)
                     const foundValidatorAddresses = new Set<string>()
 
-                    if (allValidatorsData?.results) {
-                        const matchingValidators = allValidatorsData.results.filter((v: any) => {
+                    const validatorsList = allValidatorsRef.current
+                    if (validatorsList?.results) {
+                        const matchingValidators = validatorsList.results.filter((v: any) => {
                             const address = (v.address || '').toLowerCase()
                             return address.startsWith(termLower)
                         })
@@ -437,13 +452,16 @@ export const useSearch = (searchTerm: string) => {
         }
     }
 
+    // Re-run only on term change (not on background refetch/focus, which
+    // flickered in Brave). Validators are read via a ref instead.
     useEffect(() => {
         const timeoutId = setTimeout(() => {
             searchInData(searchTerm)
         }, 300) // 300ms debounce
 
         return () => clearTimeout(timeoutId)
-    }, [searchTerm, hashSearchData, isHashSearch, allValidatorsData])
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [searchTerm])
 
     return {
         results,

--- a/cmd/rpc/web/explorer/src/pages/Search.tsx
+++ b/cmd/rpc/web/explorer/src/pages/Search.tsx
@@ -198,7 +198,7 @@ const SearchPage: React.FC = () => {
                 {/* Related Searches */}
                 {searchTerm && (
                     <div
-                        className="container mx-auto p-8 py-4 mb-4 bg-card md:rounded-xl">
+                        className="container mx-auto p-8 py-4 mt-4 mb-4 bg-card md:rounded-xl">
                         <motion.div
                             initial={{ opacity: 0, y: 20 }}
                             animate={{ opacity: 1, y: 0 }}


### PR DESCRIPTION
## Fix search results flickering and cross-search value mixing

### Summary
The Search view had two visible bugs:
1. **Flicker to loading while idle** — leaving a search open caused the results panel to swap to the "Searching…" spinner every time background data (e.g. the validators poll) refreshed, instead of keeping the current values on screen.
2. **Stale / mixed results across searches** — searching one address then another could keep the previous address's values on screen, and the whole results box would visibly disappear and reappear instead of updating in place.

### Root causes
- `useSearch` re-ran its full search on every dependency change (including background React Query refetches) and immediately did `setResults(null)` + `setLoading(true)`, blanking the panel.
- Results were published in a **single** `setResults` only after `await Promise.all(...)`, which always includes a full `AllOrders()` order-book scan — so a fast address lookup was held hostage by the slowest source, leaving the old result on screen.
- There was no request sequencing, so a slower earlier search could overwrite a newer one.
- `AddressResult` was declared **inside** `SearchResults`, giving it a new component identity every render → React remounted (and re-fetched) it on every update, and content-based keys made cards blink on every change.

### Changes
**`hooks/useSearch.ts`**
- Added a per-invocation `requestId` guard so stale (superseded) searches can't overwrite newer results or clear the newer search's state.
- Keep previous results mounted while a new query runs (no `setResults(null)`); values are swapped in place when ready.
- Publish results **progressively** as each source resolves (guarded), so fast lookups render immediately instead of waiting for the slow order scan. Uses `Promise.allSettled` + a final forced publish that also renders the "no results" state.
- `loading` now means "first search only" (`isSearching && !results`); later searches update in place. Also exposes `isSearching`.
- Trims the search term and resets cleanly on empty input.

**`components/search/SearchResults.tsx`**
- Moved `AddressResult` (and `copyToClipboard`) to module scope for a stable component identity, so cards update in place rather than remounting.
- Added a fetch-cancellation guard in `AddressResult` so a stale response can't overwrite a newer address.
- Keyed result cards by slot position so switching searches updates the existing card (no disappear/reappear blink).
- Reset pagination to page 1 when the search term changes (panel now persists across searches).

**`pages/Search.tsx`**
- Minor spacing tweak: added `mt-4` to the Related Searches container.

### Result
- Idle/background refresh updates values in place — no flicker to the spinner.
- Switching addresses replaces results as soon as the new lookup returns; the previous address never lingers.
- The results box stays mounted and updates its values instead of blinking.
- Spinner appears only on the very first search.
