### PR TITLE
Private Validator key `keygen` CLI command

### DIFF
--- a/cmd/cli/cli.go
+++ b/cmd/cli/cli.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"bufio"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -54,6 +55,28 @@ var versionCmd = &cobra.Command{
 	},
 }
 
+var newValidatorKeyCmd = &cobra.Command{
+	Use:   "new-validator-key",
+	Short: "Generate a new validator key (replaces current one if exists)",
+	// prevents the canopy root command to run and initialize directories
+	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+		return nil
+	},
+	Run: func(cmd *cobra.Command, args []string) {
+		privateValKeyPath := filepath.Join(DataDir, lib.ValKeyPath)
+		if _, err := os.Stat(privateValKeyPath); err == nil {
+			if !confirm("Are you sure you want to replace the existing validator key?") {
+				log.Fatal("Aborting key replacement")
+			}
+		} else if !errors.Is(err, os.ErrNotExist) {
+			log.Fatalf("validator_key.json stat: %s", err.Error())
+		}
+		if err := WriteValidatorKeyToFile(DataDir, lib.NewDefaultLogger()); err != nil {
+			log.Fatalf("writing validator key: %s", err.Error())
+		}
+	},
+}
+
 var (
 	client, config, l        = &rpc.Client{}, lib.Config{}, lib.LoggerI(nil)
 	DataDir, validatorKey    = "", crypto.PrivateKeyI(nil)
@@ -66,6 +89,7 @@ func init() {
 	rootCmd.AddCommand(queryCmd)
 	rootCmd.AddCommand(adminCmd)
 	rootCmd.AddCommand(autoCompleteCmd)
+	rootCmd.AddCommand(newValidatorKeyCmd)
 	autoCompleteCmd.AddCommand(generateCompleteCmd)
 	autoCompleteCmd.AddCommand(autoCompleteInstallCmd)
 	rootCmd.PersistentFlags().StringVar(&DataDir, "data-dir", lib.DefaultDataDirPath(), "custom data directory location")
@@ -179,38 +203,9 @@ func InitializeDataDirectory(dataDirPath string, log lib.LoggerI) (c lib.Config,
 	// make the private key file if missing
 	privateValKeyPath := filepath.Join(dataDirPath, lib.ValKeyPath)
 	if _, err := os.Stat(privateValKeyPath); errors.Is(err, os.ErrNotExist) {
-		blsPrivateKey, _ := crypto.NewBLS12381PrivateKey()
-		log.Infof("Creating %s file", lib.ValKeyPath)
-		if err = crypto.PrivateKeyToFile(blsPrivateKey, privateValKeyPath); err != nil {
+		if err := WriteValidatorKeyToFile(dataDirPath, log); err != nil {
 			log.Fatal(err.Error())
 		}
-		pwd = getFirstPassword(log)
-		// allow flag config to skip initial nickname
-		if nick == "" {
-			// get nickname from the user
-			log.Infof("Enter nickname for your new private key:")
-			_, e := fmt.Scanln(&nick)
-			if e != nil {
-				log.Fatal(e.Error())
-			}
-		}
-		// load the keystore from file
-		k, e := crypto.NewKeystoreFromFile(dataDirPath)
-		if e != nil {
-			log.Fatal(e.Error())
-		}
-		// import the validator key
-		address, e := k.ImportRaw(blsPrivateKey.Bytes(), pwd, crypto.ImportRawOpts{
-			Nickname: nick,
-		})
-		if e != nil {
-			log.Fatal(e.Error())
-		}
-		// save keystore to the file
-		if e = k.SaveToFile(dataDirPath); e != nil {
-			log.Fatal(e.Error())
-		}
-		log.Infof("Imported validator key %s to keystore", address)
 	}
 	// make the proposals.json file if missing
 	if _, err := os.Stat(filepath.Join(dataDirPath, lib.ProposalsFilePath)); errors.Is(err, os.ErrNotExist) {
@@ -304,6 +299,51 @@ func WriteDefaultGenesisFile(validatorPrivateKey crypto.PrivateKeyI, genesisFile
 	if err := os.WriteFile(genesisFilePath, bz, 0777); err != nil {
 		panic(err)
 	}
+}
+
+func WriteValidatorKeyToFile(dataDirPath string, log lib.LoggerI) error {
+	privateValKeyPath := filepath.Join(dataDirPath, lib.ValKeyPath)
+	blsPrivateKey, _ := crypto.NewBLS12381PrivateKey()
+	log.Infof("Creating %s file", lib.ValKeyPath)
+	if err := crypto.PrivateKeyToFile(blsPrivateKey, privateValKeyPath); err != nil {
+		return err
+	}
+	pwd = getFirstPassword(log)
+	// allow flag config to skip initial nickname
+	if nick == "" {
+		// get nickname from the user
+		log.Infof("Enter nickname for your new private key:")
+		_, e := fmt.Scanln(&nick)
+		if e != nil {
+			return e
+		}
+	}
+	// load the keystore from file
+	k, e := crypto.NewKeystoreFromFile(dataDirPath)
+	if e != nil {
+		return e
+	}
+	// import the validator key
+	address, e := k.ImportRaw(blsPrivateKey.Bytes(), pwd, crypto.ImportRawOpts{
+		Nickname: nick,
+	})
+	if e != nil {
+		return e
+	}
+	// save keystore to the file
+	if e = k.SaveToFile(dataDirPath); e != nil {
+		return e
+	}
+	log.Infof("Imported validator key %s to keystore", address)
+	return nil
+}
+
+func confirm(prompt string) bool {
+	fmt.Printf("%s [y/N]: ", prompt)
+	reader := bufio.NewReader(os.Stdin)
+	resp, _ := reader.ReadString('\n')
+	resp = strings.ToLower(strings.TrimSpace(resp))
+	return resp == "y" || resp == "yes"
 }
 
 func writeToConsole(a any, err error) {

--- a/cmd/cli/cli.go
+++ b/cmd/cli/cli.go
@@ -55,9 +55,9 @@ var versionCmd = &cobra.Command{
 }
 
 var (
-	client, config, l          = &rpc.Client{}, lib.Config{}, lib.LoggerI(nil)
-	DataDir, validatorKey      = "", crypto.PrivateKeyI(nil)
-	rpcURLFlag, adminURLFlag   string
+	client, config, l        = &rpc.Client{}, lib.Config{}, lib.LoggerI(nil)
+	DataDir, validatorKey    = "", crypto.PrivateKeyI(nil)
+	rpcURLFlag, adminURLFlag string
 )
 
 func init() {
@@ -144,7 +144,10 @@ func waitForKill() {
 
 func getFirstPassword(log lib.LoggerI) string {
 	// allow flag config to skip initial password
-	if pwd == "" {
+	if pwd != "" {
+		return pwd
+	}
+	for {
 		// get the password from the user
 		log.Infof("Enter password for your new private key:")
 		password, e := term.ReadPassword(int(os.Stdin.Fd()))
@@ -153,12 +156,10 @@ func getFirstPassword(log lib.LoggerI) string {
 		}
 		if password == nil {
 			log.Infof("Password cannot be empty")
-			return getFirstPassword(log)
+			continue
 		}
 		return string(password)
 	}
-
-	return pwd
 }
 
 // InitializeDataDirectory() populates the data directory with configuration and data files if missing


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the changes introduced in this pull request. -->
Adds a `canopy keygen` CLI command to write a new validator key into the `dataDirPath`

## Related Issues
<!-- List any issues this pull request closes. -->
Closes: N/A

## Changes Made
<!-- Highlight the key changes made in the code. For example:
- Added a new function to handle X
- Refactored Y for better performance
- Fixed bug Z
-->
- Add `canopy keygen` command
- Fix `stackoverflow` exception in password check

## Checklist
- [X] I have tested the changes locally and verified they work as intended.
- [ ] I have appropriately titled my branch `issue-#<issue-number>`.
- [ ] I have run re-built the web-wallet and/or block explorer (if applicable).
- [ ] I have run `npm run prettier` to format the web-wallet and/or block explorer (if applicable)
- [ ] I have updated documentation (if applicable).
- [ ] I have included tests for the changes (if applicable).

## Additional Notes
<!-- Add any additional context, screenshots, or information that reviewers might find helpful. -->
