### PR TITLE
fix(dex): cap DEX order settlement per block to prevent consensus livelock

### DIFF
--- a/fsm/dex.go
+++ b/fsm/dex.go
@@ -335,8 +335,12 @@ func (s *StateMachine) HandleDexBatchOrders(remoteBatch *lib.DexBatch, x, y *uin
 	if *x == 0 || *y == 0 {
 		return nil, ErrInvalidLiquidityPool()
 	}
-	// for each order
-	for _, order := range sorted {
+	// for each order (pseudorandomly ordered above so the settlement cap selects fairly)
+	for i, order := range sorted {
+		// per-block settlement cap: remaining orders keep a zero receipt and get refunded on the origin chain
+		if i >= lib.MaxOrdersSettledPerBlock {
+			break
+		}
 		// set up 'deltaX'
 		dX := order.AmountForSale
 		// 'deltaY' = (dX * y) / (x + dX)

--- a/fsm/dex_test.go
+++ b/fsm/dex_test.go
@@ -2597,6 +2597,50 @@ func TestHandleDexBatchOrdersRejectsReserveOverflow(t *testing.T) {
 	require.Equal(t, y0, y)
 }
 
+// An oversized batch must not settle more than the per-block cap; overflow orders keep a zero receipt
+// (refunded to the seller on the origin chain) so the whole batch still resolves in a single block.
+func TestHandleDexBatchOrdersEnforcesSettlementCap(t *testing.T) {
+	sm := newTestStateMachine(t)
+	sm.Config.ChainId = 1
+	chainId := uint64(2)
+
+	const extra = 5
+	total := lib.MaxOrdersSettledPerBlock + extra
+	// pool large enough that every *attempted* order succeeds (RequestedAmount 0)
+	pool := uint64(1_000_000_000_000)
+	require.NoError(t, sm.SetPool(&Pool{Id: chainId + LiquidityPoolAddend, Amount: pool}))
+
+	orders := make([]*lib.DexLimitOrder, total)
+	for i := range orders {
+		addr := make([]byte, crypto.AddressSize)
+		addr[0], addr[1] = byte(i+1), byte((i+1)>>8)
+		orders[i] = &lib.DexLimitOrder{
+			AmountForSale:   1_000,
+			RequestedAmount: 0,
+			Address:         addr,
+			OrderId:         addr,
+		}
+	}
+	batch := &lib.DexBatch{Committee: chainId, Orders: orders}
+
+	x, y := pool, pool
+	receipts, err := sm.HandleDexBatchOrders(batch, &x, &y, chainId)
+	require.NoError(t, err)
+	require.Len(t, receipts, total)
+
+	var settled, refunded int
+	for _, r := range receipts {
+		if r == 0 {
+			refunded++
+		} else {
+			settled++
+		}
+	}
+	// exactly the cap is settled; the remainder is left with a zero receipt for refund on the origin chain
+	require.Equal(t, lib.MaxOrdersSettledPerBlock, settled)
+	require.Equal(t, extra, refunded)
+}
+
 // Proves withdraw->redeposit cannot increase LP points (no gain loop), allowing only rounding loss.
 func TestWithdrawThenRedeploy_NoPointGain(t *testing.T) {
 	sm := newTestStateMachine(t)

--- a/lib/certificate.go
+++ b/lib/certificate.go
@@ -24,6 +24,9 @@ const (
 	MaxOrdersPerDexBatch    = 10_000
 	MaxReceipts             = MaxOrdersPerDexBatch
 	MaxLiquidityProviders   = 50_000
+	// MaxOrdersSettledPerBlock caps DEX orders settled per block so begin_block can't exceed the consensus
+	// round budget; orders beyond the cap are failed (receipt 0) and refunded to the seller on the origin chain
+	MaxOrdersSettledPerBlock = 250
 )
 
 // MaxBlockHeaderSize is a consensus breaking change because it affects how the state machine


### PR DESCRIPTION
fix(dex): cap DEX order settlement per block to prevent consensus livelock

A released order backlog was locked into a single 830-order batch. Settling
it in begin_block took ~5.5s per ApplyBlock (paid twice on a single-validator
nested chain: once building, once validating), pushing the full BFT cycle past
the ~20s round budget. Because every root block resets the nested chain to
round 0 (NEW_COMMITTEE -> NewHeight(true)), the (2*round+1) timer escalation
could never kick in, so the chain livelocked at height 736327 and never
committed.

Bound the work per block with MaxOrdersSettledPerBlock (250). After the
pseudorandom sort, HandleDexBatchOrders settles only the first N orders and
breaks; overflow orders keep a zero receipt and are refunded to the seller on
the origin chain via HandleOrderReceipts (same path as a slippage failure).
The overflow path does no work on the nested chain (no AMM math, pool writes,
or events), so begin_block stays within the round budget while the oversized
batch still fully resolves - and rotates - in a single block.

Tests: add TestHandleDexBatchOrdersEnforcesSettlementCap (exactly the cap
settles; the remainder gets zero receipts for refund).