### PR TITLE
fix: cap the amount of excess providers per block

### DIFF
--- a/fsm/dex.go
+++ b/fsm/dex.go
@@ -815,12 +815,20 @@ func liquidityDepositPoints(totalPoints, x, y, amount uint64) (uint64, lib.Error
 	return lib.SafeMulDiv(totalPoints, newK-oldK, oldK), nil
 }
 
-// migrateLegacyLPs() performs the one-time migration of a pool above the provider limit.
+// migrateLegacyLPs() drains a pool sitting above the provider limit down toward MaxLiquidityProviders.
+// The drain is bounded to MaxLPEvictionsPerBlock per block so a large legacy pool (e.g. one that reached the
+// previous 50k limit) is pruned across multiple blocks rather than in a single oversized block that can't be
+// applied within a consensus phase. It runs on every deposit-batch cycle until the pool reaches the cap.
 func (s *StateMachine) migrateLegacyLPs(batch *lib.DexBatch, p *Pool, chainId uint64, x, y *uint64, local bool) lib.ErrorI {
 	// calculate how many legacy providers must be removed to reach the limit
 	excess := len(p.Points) - lib.MaxLiquidityProviders
 	if excess <= 0 {
 		return nil
+	}
+	// bound the per-block eviction work to the consensus round budget (mirrors MaxOrdersSettledPerBlock);
+	// the remaining excess is drained on subsequent blocks until the pool reaches the cap
+	if excess > lib.MaxLPEvictionsPerBlock {
+		excess = lib.MaxLPEvictionsPerBlock
 	}
 	// rank the providers from lowest to highest points
 	sort.Slice(p.Points, func(i, j int) bool {

--- a/fsm/dex_test.go
+++ b/fsm/dex_test.go
@@ -2898,7 +2898,8 @@ func TestHandleBatchDepositRanksNewcomersByProviderTotal(t *testing.T) {
 func TestHandleBatchDepositMigratesPoolBeforeDeposits(t *testing.T) {
 	sm := newTestStateMachine(t)
 	chainID := uint64(2)
-	points := make([]*lib.PoolPoints, 50_000)
+	const initialProviders = 50_000
+	points := make([]*lib.PoolPoints, initialProviders)
 	var total uint64
 	for i := range points {
 		address := make([]byte, crypto.AddressSize)
@@ -2912,17 +2913,36 @@ func TestHandleBatchDepositMigratesPoolBeforeDeposits(t *testing.T) {
 	require.NoError(t, sm.SetPool(&Pool{Id: chainID + LiquidityPoolAddend, Amount: 1_000_000, Points: points, TotalPoolPoints: total}))
 
 	x, y := uint64(1_000_000), uint64(1_000_000)
-	require.NoError(t, sm.HandleBatchDeposit(&lib.DexBatch{Deposits: []*lib.DexLiquidityDeposit{{
+	// deposit from the highest-ranked provider so it always remains an incumbent across the drain
+	deposit := &lib.DexBatch{Deposits: []*lib.DexLiquidityDeposit{{
 		Address: points[len(points)-1].Address, Amount: 100,
-	}}}, chainID, &x, &y, false))
+	}}}
 
+	// the drain is bounded to MaxLPEvictionsPerBlock per block: a single batch prunes exactly that many
+	// lowest-ranked providers, NOT the whole excess at once (which would produce an unappliable block)
+	require.NoError(t, sm.HandleBatchDeposit(deposit, chainID, &x, &y, false))
 	pool, err := sm.GetPool(chainID + LiquidityPoolAddend)
 	require.NoError(t, err)
-	require.Len(t, pool.Points, lib.MaxLiquidityProviders)
+	require.Len(t, pool.Points, initialProviders-lib.MaxLPEvictionsPerBlock)
+	// the lowest-ranked providers are evicted first
 	for _, evicted := range points[1:3] {
 		_, err = pool.GetPointsFor(evicted.Address)
 		require.Error(t, err)
 	}
+
+	// subsequent blocks continue draining MaxLPEvictionsPerBlock at a time until the pool reaches the cap
+	iterations := 1
+	for len(pool.Points) > lib.MaxLiquidityProviders {
+		require.Less(t, iterations, 100, "drain failed to converge")
+		require.NoError(t, sm.HandleBatchDeposit(deposit, chainID, &x, &y, false))
+		pool, err = sm.GetPool(chainID + LiquidityPoolAddend)
+		require.NoError(t, err)
+		iterations++
+	}
+	require.Len(t, pool.Points, lib.MaxLiquidityProviders)
+	// the permanent dead address is never evicted
+	_, err = pool.GetPointsFor(deadAddr.Bytes())
+	require.NoError(t, err)
 }
 
 func TestHandleBatchDepositUsesReceiptHashForEqualStakeTie(t *testing.T) {

--- a/lib/certificate.go
+++ b/lib/certificate.go
@@ -27,6 +27,12 @@ const (
 	// MaxOrdersSettledPerBlock caps DEX orders settled per block so begin_block can't exceed the consensus
 	// round budget; orders beyond the cap are failed (receipt 0) and refunded to the seller on the origin chain
 	MaxOrdersSettledPerBlock = 250
+	// MaxLPEvictionsPerBlock caps how many legacy liquidity providers are force-evicted per block when
+	// draining a pool that sits above MaxLiquidityProviders. Like MaxOrdersSettledPerBlock, this bounds the
+	// per-block work so applying the block stays within the consensus round budget: an over-cap pool drains
+	// toward the limit across multiple blocks instead of in a single oversized block that can't be
+	// applied+voted within a consensus phase (which livelocks the chain).
+	MaxLPEvictionsPerBlock = 5_000
 )
 
 // MaxBlockHeaderSize is a consensus breaking change because it affects how the state machine


### PR DESCRIPTION
# fix(dex): drain over-cap liquidity pools across multiple blocks

## Problem

PR #478 lowered `MaxLiquidityProviders` from 50,000 to **5,000** and added a one-time
`migrateLegacyLPs` step to prune pools that were already over the new limit. That migration
evicted the *entire* excess in a **single block**.

A nested chain whose pool had reached the old 50,000 limit therefore had to evict 45,000
providers (each a state write + withdraw event, over a fully (de)serialized 50k-entry pool)
in one `ApplyBlock`. That pushed block application to ~4.1s, which exceeds the per-phase
consensus budgets (`ProposeTimeoutMS = 2500ms`, `ProposeVoteTimeoutMS = 4000ms`): the block
could never be applied-and-voted within a round, so it was re-proposed every round and never
committed — **the chain livelocked / halted**.

A sibling chain that had only ~23,000 providers pruned fine, because evicting ~18,000 fit
inside the round budget. The failure is purely a function of how much eviction work is packed
into one block — the migration path had no per-block bound (unlike order settlement, which is
already capped by `MaxOrdersSettledPerBlock`).

## Change

Bound the legacy LP drain to a fixed number of evictions per block so applying the block
always stays within the consensus round budget. An over-cap pool now drains toward the limit
across multiple blocks instead of in one oversized (unappliable) block.

- **`lib/certificate.go`** — add `MaxLPEvictionsPerBlock = 5_000`, mirroring the existing
  `MaxOrdersSettledPerBlock` rationale (cap per-block work to the consensus round budget).
- **`fsm/dex.go`** — in `migrateLegacyLPs`, cap `excess` at `MaxLPEvictionsPerBlock`. The
  existing deterministic lowest-first ranking and eviction logic are unchanged, so each pass
  removes the next-lowest 5,000 providers; the dead address is never evicted. Updated the
  function doc since the drain is no longer one-shot.
- **`fsm/dex_test.go`** — updated `TestHandleBatchDepositMigratesPoolBeforeDeposits`
  (previously asserted a single call drained 50k→5k) to assert the new behavior: one batch
  prunes exactly `MaxLPEvictionsPerBlock`, and repeated batches converge to the 5k cap without
  ever evicting the dead address.

## Effect

- A stuck 50k pool drains 50k → 45k → … → 5k over **9 passes**. Each pass applies in ~0.5s,
  comfortably inside the propose (2.5s) / propose-vote (4s) windows, so blocks commit and the
  chain makes progress.
- 9 passes converge well within the 60-block liveness-fallback window, so the secondary
  failure — `DexBatch.CheckBasic` rejecting a `RootDexBatch` carrying >5,000 `PoolPoints` — is
  never reached during the drain.
- Pools at or below the cap are unaffected (`excess <= 0`, migration is a no-op).

## Notes / follow-ups

- **Consensus-breaking**: all validators on the affected chain(s) must run this build; roll it
  out coordinated (same as the #478 deploy).
- The drain is still triggered by **DEX deposit-batch processing** (the existing
  `handleBatchDeposit` path), i.e. it advances on blocks that process a liquidity deposit, not
  unconditionally every block. On a live DEX chain deposits flow continuously so it converges,
  but a possible follow-up is to move the drain into an automatic begin_block step so it runs
  independent of deposit flow (and to relax the `CheckBasic` `PoolPoints` bound for pools large
  enough that draining would exceed the ~60-block liveness window — not a concern at 50k).