### PR TITLE
fix: resolve data race and leaked dialing counter in DialForOutboundPeers

### DIFF
--- a/p2p/p2p.go
+++ b/p2p/p2p.go
@@ -9,6 +9,7 @@ import (
 	"slices"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/canopy-network/canopy/lib"
@@ -184,7 +185,7 @@ func (p *P2P) ListenForInboundPeers(listenAddress *lib.PeerAddress) {
 // DialForOutboundPeers() uses the config and peer book to try to max out the outbound peer connections
 func (p *P2P) DialForOutboundPeers() {
 	// create a tracking variable to ensure not 'over dialing'
-	dialing := 0
+	var dialing atomic.Int64
 	getPeerFromString := func(address string) (*lib.PeerAddress, error) {
 		// start a peer address structure using the basic configurations
 		peer := &lib.PeerAddress{PeerMeta: &lib.PeerMeta{NetworkId: p.meta.NetworkId, ChainId: p.meta.ChainId}}
@@ -206,8 +207,9 @@ func (p *P2P) DialForOutboundPeers() {
 		}
 		// dial in a non-blocking fashion
 		go func() {
-			// increment dialing
-			dialing++
+			// increment dialing and decrement when done
+			dialing.Add(1)
+			defer dialing.Add(-1)
 			// dial the peer with exponential backoff
 			p.DialWithBackoff(peerAddress, true)
 		}()
@@ -219,7 +221,7 @@ func (p *P2P) DialForOutboundPeers() {
 		func() {
 			// exit if maxed out config or none left to dial
 			outbound := p.PeerSet.outbound
-			if outbound > 0 && outbound+dialing >= p.config.MaxOutbound {
+			if outbound > 0 && int(outbound)+int(dialing.Load()) >= p.config.MaxOutbound {
 				return
 			}
 			// try to get a peer to dial
@@ -243,8 +245,8 @@ func (p *P2P) DialForOutboundPeers() {
 			p.log.Debugf("Executing P2P Dial for more outbound peers")
 			// sequential operation means we'll never be dialing more than 1 peer at a time
 			// the peer should be added before the next execution of the loop
-			dialing++
-			defer func() { dialing-- }()
+			dialing.Add(1)
+			defer func() { dialing.Add(-1) }()
 			if err := p.Dial(peer, false, false); err != nil {
 				p.book.AddFailedDialAttempt(peer)
 				p.log.Debug(err.Error())


### PR DESCRIPTION
## Summary
Fixes the data race and permanent counter inflation reported in #491.

## Changes in `p2p/p2p.go`

- Replaced plain `int` `dialing` variable with `sync/atomic.Int64` to eliminate the data race between the initial `DialPeers` goroutines and the main loop
- Added `defer dialing.Add(-1)` in the initial goroutines so the counter correctly decrements when each `DialWithBackoff` call completes
- Updated all read/write sites to use `.Add()` and `.Load()`

## Before
```go
dialing := 0
go func() {
    dialing++ // unsynchronized, never decremented
    p.DialWithBackoff(peerAddress, true)
}()
```

## After
```go
var dialing atomic.Int64
go func() {
    dialing.Add(1)
    defer dialing.Add(-1) // correctly decrements on completion
    p.DialWithBackoff(peerAddress, true)
}()
```

Closes #491