### PR TITLE
fix(fsm): check closure error 'e' not outer 'err' in ConformStateToParamUpdate

### DIFF
--- a/fsm/gov.go
+++ b/fsm/gov.go
@@ -178,7 +178,7 @@ func (s *StateMachine) ConformStateToParamUpdate(previousParams *Params) lib.Err
 				return e
 			}
 			// set validator to unstaking if below minium
-			if _, e = s.SetValidatorUnstakingIfBelowMinimum(v, params.Validator); err != nil {
+			if _, e = s.SetValidatorUnstakingIfBelowMinimum(v, params.Validator); e != nil {
 				return e
 			}
 			return


### PR DESCRIPTION
Closes #493

## Problem
In `ConformStateToParamUpdate()` (`fsm/gov.go`), the error returned by `SetValidatorUnstakingIfBelowMinimum` was assigned to the closure's named return variable `e`, but the condition checked the outer function-scope variable `err` which is always `nil` inside the closure (it only gets assigned when `IterateAndExecute` returns).

This caused errors to be silently discarded, potentially leaving validators below the new minimum stake active in committees after a governance parameter update.

## Fix
One-line change: `err != nil` → `e != nil`

```go
// Before (buggy):
if _, e = s.SetValidatorUnstakingIfBelowMinimum(v, params.Validator); err != nil {

// After (correct):
if _, e = s.SetValidatorUnstakingIfBelowMinimum(v, params.Validator); e != nil {
```