### PR TITLE
fix(explorer): escape HTML before injecting raw JSON into the DOM

### DIFF
--- a/cmd/rpc/web/explorer/src/components/block/BlockDetailInfo.tsx
+++ b/cmd/rpc/web/explorer/src/components/block/BlockDetailInfo.tsx
@@ -4,7 +4,7 @@ import { Copy } from 'lucide-react'
 import toast from 'react-hot-toast'
 import blockDetailTexts from '../../data/blockDetail.json'
 import { GREEN_BADGE_CLASS } from '../ui/badgeStyles'
-import { formatCNPY } from '../../lib/utils'
+import { escapeHtml, formatCNPY } from '../../lib/utils'
 
 interface BlockDetailInfoProps {
     block: {
@@ -85,7 +85,7 @@ const BlockDetailInfo: React.FC<BlockDetailInfoProps> = ({ block, blockData }) =
                 <div className="border border-white/10 rounded-lg p-4">
                     <pre className="text-xs overflow-x-auto whitespace-pre-wrap">
                         <code className="text-gray-300">
-                            {JSON.stringify(blockData, null, 2)
+                            {escapeHtml(JSON.stringify(blockData, null, 2))
                                 .split('\n')
                                 .map((line, index) => (
                                     <div key={index} className="flex">

--- a/cmd/rpc/web/explorer/src/components/token-swaps/OrderDetailPage.tsx
+++ b/cmd/rpc/web/explorer/src/components/token-swaps/OrderDetailPage.tsx
@@ -5,7 +5,7 @@ import { Copy } from 'lucide-react'
 import { useOrder } from '../../hooks/useApi'
 import toast from 'react-hot-toast'
 
-import { formatDecimalWithSubscript, formatLocaleNumber, formatMicroCNPY } from '../../lib/utils'
+import { escapeHtml, formatDecimalWithSubscript, formatLocaleNumber, formatMicroCNPY } from '../../lib/utils'
 import { GREEN_BADGE_CLASS } from '../ui/badgeStyles'
 
 const SWAP_DECIMAL_PLACES = 6
@@ -186,7 +186,7 @@ const OrderDetailPage: React.FC = () => {
                                 <div className="rounded-lg border border-white/10 p-4">
                                     <pre className="overflow-x-auto whitespace-pre-wrap text-xs">
                                         <code className="text-gray-300">
-                                            {JSON.stringify(order, null, 2)
+                                            {escapeHtml(JSON.stringify(order, null, 2))
                                                 .split('\n')
                                                 .map((line, index) => (
                                                     <div key={index} className="flex">

--- a/cmd/rpc/web/explorer/src/components/transaction/TransactionDetailPage.tsx
+++ b/cmd/rpc/web/explorer/src/components/transaction/TransactionDetailPage.tsx
@@ -6,7 +6,7 @@ import { useTxByHash, useBlockByHeight, useLatestBlock } from '../../hooks/useAp
 import toast from 'react-hot-toast'
 import { format, formatDistanceToNow, parseISO, isValid } from 'date-fns'
 
-import { toCNPY, extractAmountMicro } from '../../lib/utils'
+import { escapeHtml, toCNPY, extractAmountMicro } from '../../lib/utils'
 import TransactionTypeBadge from './TransactionTypeBadge'
 
 // Helper function to format fee - shows in CNPY (converted from micro denomination)
@@ -703,7 +703,7 @@ const TransactionDetailPage: React.FC = () => {
                             <div className="border border-white/10 rounded-lg p-4">
                                 <pre className="text-xs overflow-x-auto whitespace-pre-wrap">
                                     <code className="text-gray-300">
-                                        {JSON.stringify(transaction, null, 2)
+                                        {escapeHtml(JSON.stringify(transaction, null, 2))
                                             .replace(/(".*?")\s*:/g, '<span class="text-blue-400">$1</span>:')
                                             .replace(/:\s*(".*?")/g, ': <span class="text-primary">$1</span>')
                                             .replace(/:\s*(\d+)/g, ': <span class="text-yellow-400">$1</span>')

--- a/cmd/rpc/web/explorer/src/lib/utils.ts
+++ b/cmd/rpc/web/explorer/src/lib/utils.ts
@@ -261,3 +261,13 @@ export function formatPaginationRange(start: number, end: number): string {
     if (start === end) return `${start}`
     return `${start} to ${end}`
 }
+
+// Escapes the HTML metacharacters that a browser would otherwise interpret as markup.
+// JSON.stringify leaves these characters as-is, so any string field it serializes has to
+// be escaped before the result is injected as HTML.
+export function escapeHtml(str: string): string {
+    return str
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+}


### PR DESCRIPTION
## Summary

The transaction, block and order **Raw** views serialize an object with
`JSON.stringify`, split the result into lines, and hand each line to
`dangerouslySetInnerHTML`. `JSON.stringify` does not escape `&`, `<` or `>`, so any
string field in the serialized object reaches the DOM as markup rather than as text.

Several of these fields are chain-supplied rather than controlled by the person viewing
the page. `transaction.memo` in particular is free-form and only length-limited
(200 bytes, `lib/tx.go`), with no content validation.

## Changes

- `src/lib/utils.ts` - added `escapeHtml`.
- `src/components/transaction/TransactionDetailPage.tsx`
- `src/components/block/BlockDetailInfo.tsx`
- `src/components/token-swaps/OrderDetailPage.tsx`

Each raw view now escapes the serialized JSON **before** the syntax-highlight step.
Ordering matters: escaping first leaves the highlighter's own `<span>` tags, which are
inserted afterwards, intact. Quotes are deliberately not escaped, because the highlight
patterns match on `"`.

## Verification

Running `{ height: 12, memo: '<b>markup</b> & "quoted"', ok: true }` through the
transaction view's highlight chain:

| | raw `<b>` reaches output | key / value / number / bool highlighting |
| --- | --- | --- |
| before | yes | yes |
| after | no | yes |

`tsc --noEmit` passes. `eslint` reports no new findings; the two `prefer-const` errors it
reports in `utils.ts` are pre-existing and untouched by this change.

## Notes

`CnpyColorIcon.tsx` also uses `dangerouslySetInnerHTML`, but its input is a locally
generated SVG string rather than API data, so it is left alone.
