### PR TITLE
fix(wallet): escape HTML in node log lines before highlighting

### DIFF
--- a/cmd/rpc/web/wallet/src/components/monitoring/NodeLogs.tsx
+++ b/cmd/rpc/web/wallet/src/components/monitoring/NodeLogs.tsx
@@ -9,6 +9,15 @@ interface NodeLogsProps {
     onExportLogs: () => void;
 }
 
+// Escapes the HTML metacharacters a browser would otherwise interpret as markup.
+// Log lines carry remote-supplied text, so they are escaped before the highlight
+// patterns insert their own span tags.
+const escapeHtml = (str: string): string =>
+    str
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;');
+
 export default function NodeLogs({
                                      logs,
                                      isPaused,
@@ -71,7 +80,7 @@ export default function NodeLogs({
             [/(Producing proposal as leader)/g, '<span style="color: #f59e0b; font-weight: 500">$1</span>']
         ];
 
-        let html = line;
+        let html = escapeHtml(line);
         for (const [pattern, replacement] of patterns) {
             html = html.replace(pattern, replacement as string);
         }


### PR DESCRIPTION
## Summary

`NodeLogs` applies a list of highlight patterns to each log line and passes the result to
`dangerouslySetInnerHTML`. The line is not escaped first, so `&`, `<` and `>` in a log
line reach the DOM as markup rather than as text.

Log lines carry remote-supplied text, including peer addresses and strings embedded in
error messages, so the content is not fully under the node operator's control.

## Changes

- `cmd/rpc/web/wallet/src/components/monitoring/NodeLogs.tsx` - escape the line before
  the highlight patterns run.

The highlight patterns match fixed phrases (`Committed block`, `Validating mempool`, and
so on) that contain no HTML metacharacters, so escaping first does not affect them.
Escaping has to come first so that the `<span>` tags the patterns insert are not
themselves escaped.

## Notes

Same defect class as #496, which covers the explorer's raw JSON views. Kept separate
because it is a different package and shares no code with that change.

`tsc --noEmit` passes on the wallet package.
