### PR TITLE
perf(rpc): eliminate the full account scan from indexer-blobs via single-block replay

### DIFF
--- a/cmd/rpc/query.go
+++ b/cmd/rpc/query.go
@@ -2,6 +2,7 @@ package rpc
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"net/http"
 	"os"
@@ -596,7 +597,7 @@ func (s *Server) IndexerBlobs(w http.ResponseWriter, r *http.Request, _ httprout
 	if ok := unmarshal(w, r, req); !ok {
 		return
 	}
-	_, bz, err := s.IndexerBlobsCached(req.Height)
+	_, bz, err := s.IndexerBlobsCached(r.Context(), req.Height)
 	if err != nil {
 		status := http.StatusBadRequest
 		if err.Code() == lib.CodeMarshal {
@@ -614,7 +615,7 @@ func (s *Server) IndexerBlobs(w http.ResponseWriter, r *http.Request, _ httprout
 }
 
 // IndexerBlobsCached() is a helper function for the indexer blobs implementation
-func (s *Server) IndexerBlobsCached(height uint64) (*fsm.IndexerBlobs, []byte, lib.ErrorI) {
+func (s *Server) IndexerBlobsCached(ctx context.Context, height uint64) (*fsm.IndexerBlobs, []byte, lib.ErrorI) {
 	currentHeight := s.controller.FSM.Height()
 	if height == 0 || height > currentHeight {
 		height = currentHeight
@@ -634,7 +635,7 @@ func (s *Server) IndexerBlobsCached(height uint64) (*fsm.IndexerBlobs, []byte, l
 	// after the fact both in logs and in canopy_indexer_blob_cold_read_time.
 	coldStart := time.Now()
 	defer s.controller.Metrics.RecordIndexerBlobCacheMiss(coldStart)
-	current, err := s.controller.FSM.IndexerBlob(height)
+	current, err := s.controller.FSM.IndexerBlob(ctx, height)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -648,7 +649,7 @@ func (s *Server) IndexerBlobsCached(height uint64) (*fsm.IndexerBlobs, []byte, l
 			previous = cachedPrev
 		} else {
 			s.controller.Metrics.RecordIndexerBlobPreviousReuseMiss()
-			prev, prevErr := s.controller.FSM.IndexerBlob(height - 1)
+			prev, prevErr := s.controller.FSM.IndexerBlob(ctx, height-1)
 			if prevErr != nil {
 				return nil, nil, prevErr
 			}
@@ -656,7 +657,10 @@ func (s *Server) IndexerBlobsCached(height uint64) (*fsm.IndexerBlobs, []byte, l
 		}
 	}
 
-	if elapsed := time.Since(coldStart); elapsed > time.Duration(s.config.TimeoutS)*time.Second {
+	if ctxErr := ctx.Err(); ctxErr != nil {
+		s.controller.Metrics.RecordIndexerBlobCancelled()
+		s.logger.Debugf("indexer-blobs cold read for height %d cancelled after %s: %s", height, time.Since(coldStart), ctxErr)
+	} else if elapsed := time.Since(coldStart); elapsed > time.Duration(s.config.TimeoutS)*time.Second {
 		s.logger.Warnf("indexer-blobs cold read for height %d took %s, exceeding the %ds RPC write deadline -- "+
 			"caller's write will fail with i/o timeout even though this read eventually succeeded", height, elapsed, s.config.TimeoutS)
 	} else {

--- a/cmd/rpc/query.go
+++ b/cmd/rpc/query.go
@@ -671,11 +671,15 @@ func (s *Server) IndexerBlobsCached(ctx context.Context, height uint64) (*fsm.In
 		Current:  current,
 		Previous: previous,
 	}
+	deltaComputeStart := time.Now()
 	blobDelta, err := fsm.DeltaIndexerBlobs(blobs)
+	s.controller.Metrics.ObserveIndexerBlobStep("delta_compute", deltaComputeStart)
 	if err != nil {
 		return nil, nil, err
 	}
+	deltaMarshalStart := time.Now()
 	deltaBytes, err := lib.Marshal(blobDelta)
+	s.controller.Metrics.ObserveIndexerBlobStep("delta_marshal", deltaMarshalStart)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/cmd/rpc/query.go
+++ b/cmd/rpc/query.go
@@ -626,16 +626,16 @@ func (s *Server) IndexerBlobsCached(ctx context.Context, height uint64) (*fsm.In
 		return entry.deltaBlobs, entry.deltaBytes, nil
 	}
 
-	// Cache miss: current/previous blobs must be built from the store, which
-	// for a height far behind the tip means a cold historical read. This is
-	// unbounded and not covered by the RPC write-deadline (the deadline keeps
-	// ticking while this call blocks, so a slow read here surfaces later as a
-	// "write tcp ...: i/o timeout" on the eventual w.Write, not here) -- log
-	// and record how long it actually took so a cold-path stall is visible
-	// after the fact both in logs and in canopy_indexer_blob_cold_read_time.
+	// Cache miss: a cold historical read, unbounded and not covered by the RPC
+	// write-deadline (a slow read surfaces later as an i/o timeout on the eventual
+	// w.Write) -- log and record how long it took so a stall is visible after the fact
 	coldStart := time.Now()
 	defer s.controller.Metrics.RecordIndexerBlobCacheMiss(coldStart)
-	current, err := s.controller.FSM.IndexerBlob(ctx, height)
+	// at height 2 there is no previous blob to diff against and DeltaIndexerBlobs keeps
+	// Current's full account set; preserve that byte-for-byte by falling back to the
+	// full scan for that one height (once in a chain's life, the cost is irrelevant)
+	useAccountDelta := height > 2
+	current, err := s.controller.FSM.IndexerBlob(ctx, height, useAccountDelta)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -646,10 +646,17 @@ func (s *Server) IndexerBlobsCached(ctx context.Context, height uint64) (*fsm.In
 	if height > 2 {
 		if cachedPrev, ok := s.indexerBlobCache.getCurrent(height - 1); ok {
 			s.controller.Metrics.RecordIndexerBlobPreviousReuseHit()
+			// the height-2 cached snapshot carries the full account set (see above);
+			// diffing it against current's nil Accounts would burn a throwaway full-scan
+			// diff. Hand DeltaIndexerBlobs a shallow copy with Accounts nil'd instead —
+			// the cached blob is shared with every other reader and must never be mutated
+			if useAccountDelta {
+				cachedPrev = fsm.IndexerBlobWithoutAccounts(cachedPrev)
+			}
 			previous = cachedPrev
 		} else {
 			s.controller.Metrics.RecordIndexerBlobPreviousReuseMiss()
-			prev, prevErr := s.controller.FSM.IndexerBlob(ctx, height-1)
+			prev, prevErr := s.controller.FSM.IndexerBlob(ctx, height-1, useAccountDelta)
 			if prevErr != nil {
 				return nil, nil, prevErr
 			}
@@ -660,11 +667,32 @@ func (s *Server) IndexerBlobsCached(ctx context.Context, height uint64) (*fsm.In
 	if ctxErr := ctx.Err(); ctxErr != nil {
 		s.controller.Metrics.RecordIndexerBlobCancelled()
 		s.logger.Debugf("indexer-blobs cold read for height %d cancelled after %s: %s", height, time.Since(coldStart), ctxErr)
+		// without this a cancelled request would go on to do the account-delta work
+		// and cache a response nobody is waiting for
+		return nil, nil, lib.ErrCancelled(ctxErr)
 	} else if elapsed := time.Since(coldStart); elapsed > time.Duration(s.config.TimeoutS)*time.Second {
 		s.logger.Warnf("indexer-blobs cold read for height %d took %s, exceeding the %ds RPC write deadline -- "+
 			"caller's write will fail with i/o timeout even though this read eventually succeeded", height, elapsed, s.config.TimeoutS)
 	} else {
 		s.logger.Debugf("indexer-blobs cold read for height %d took %s", height, elapsed)
+	}
+
+	// both blobs above were built with skipAccounts=true, so DeltaIndexerBlobs will compute
+	// an empty account delta. Source the real one by replaying the single block that
+	// produced this height. height is already clamped to the tip above, which
+	// GetAccountDelta depends on -- it errors rather than clamps
+	var accountDelta *fsm.AccountDelta
+	if useAccountDelta {
+		accountDeltaStart := time.Now()
+		var deltaErr lib.ErrorI
+		accountDelta, deltaErr = s.controller.GetAccountDelta(ctx, height)
+		s.controller.Metrics.ObserveIndexerBlobStep("account_delta_get", accountDeltaStart)
+		if deltaErr != nil {
+			// this fails the entire indexer response, not just accounts; log node-side
+			// so it's diagnosable without the indexer client's HTTP 400 body
+			s.logger.Warnf("account-delta replay failed for height %d: %s", height, deltaErr.Error())
+			return nil, nil, deltaErr
+		}
 	}
 
 	blobs := &fsm.IndexerBlobs{
@@ -676,6 +704,13 @@ func (s *Server) IndexerBlobsCached(ctx context.Context, height uint64) (*fsm.In
 	s.controller.Metrics.ObserveIndexerBlobStep("delta_compute", deltaComputeStart)
 	if err != nil {
 		return nil, nil, err
+	}
+	// override the (empty) account delta DeltaIndexerBlobs computed from the skipped
+	// account scans with the fast path's classified result
+	if useAccountDelta && blobDelta != nil {
+		if err = s.overrideAccountDelta(blobDelta, height, accountDelta); err != nil {
+			return nil, nil, err
+		}
 	}
 	deltaMarshalStart := time.Now()
 	deltaBytes, err := lib.Marshal(blobDelta)
@@ -692,6 +727,32 @@ func (s *Server) IndexerBlobsCached(ctx context.Context, height uint64) (*fsm.In
 	s.controller.Metrics.UpdateIndexerBlobCacheSize(s.indexerBlobCache.Len())
 
 	return blobDelta, deltaBytes, nil
+}
+
+// overrideAccountDelta() replaces the empty account sides DeltaIndexerBlobs produced from
+// the skipped account scans with the collector-sourced fast-path result, assembled by
+// fsm.AssembleAccountDeltaSides.
+func (s *Server) overrideAccountDelta(blobDelta *fsm.IndexerBlobs, height uint64, delta *fsm.AccountDelta) lib.ErrorI {
+	if blobDelta.Current == nil && blobDelta.Previous == nil {
+		return nil
+	}
+	// the forced set is derived from the CURRENT block's events for both sides,
+	// matching DeltaIndexerBlobs; with no current blob there is nothing to force
+	var currentBlockBz []byte
+	if blobDelta.Current != nil {
+		currentBlockBz = blobDelta.Current.Block
+	}
+	currentSide, previousSide, err := s.controller.FSM.AssembleAccountDeltaSides(delta, currentBlockBz, height)
+	if err != nil {
+		return err
+	}
+	if blobDelta.Current != nil {
+		blobDelta.Current.Accounts = currentSide
+	}
+	if blobDelta.Previous != nil {
+		blobDelta.Previous.Accounts = previousSide
+	}
+	return nil
 }
 
 // orderParams is a helper function to abstract common workflows around a callback requiring a state machine and order request

--- a/cmd/rpc/query.go
+++ b/cmd/rpc/query.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"slices"
 	"strconv"
+	"time"
 
 	"github.com/canopy-network/canopy/fsm"
 	"github.com/canopy-network/canopy/lib"
@@ -620,9 +621,19 @@ func (s *Server) IndexerBlobsCached(height uint64) (*fsm.IndexerBlobs, []byte, l
 	}
 
 	if entry, ok := s.indexerBlobCache.get(height); ok && entry != nil && entry.deltaBlobs != nil && entry.deltaBytes != nil {
+		s.controller.Metrics.RecordIndexerBlobCacheHit()
 		return entry.deltaBlobs, entry.deltaBytes, nil
 	}
 
+	// Cache miss: current/previous blobs must be built from the store, which
+	// for a height far behind the tip means a cold historical read. This is
+	// unbounded and not covered by the RPC write-deadline (the deadline keeps
+	// ticking while this call blocks, so a slow read here surfaces later as a
+	// "write tcp ...: i/o timeout" on the eventual w.Write, not here) -- log
+	// and record how long it actually took so a cold-path stall is visible
+	// after the fact both in logs and in canopy_indexer_blob_cold_read_time.
+	coldStart := time.Now()
+	defer s.controller.Metrics.RecordIndexerBlobCacheMiss(coldStart)
 	current, err := s.controller.FSM.IndexerBlob(height)
 	if err != nil {
 		return nil, nil, err
@@ -643,6 +654,13 @@ func (s *Server) IndexerBlobsCached(height uint64) (*fsm.IndexerBlobs, []byte, l
 		}
 	}
 
+	if elapsed := time.Since(coldStart); elapsed > time.Duration(s.config.TimeoutS)*time.Second {
+		s.logger.Warnf("indexer-blobs cold read for height %d took %s, exceeding the %ds RPC write deadline -- "+
+			"caller's write will fail with i/o timeout even though this read eventually succeeded", height, elapsed, s.config.TimeoutS)
+	} else {
+		s.logger.Debugf("indexer-blobs cold read for height %d took %s", height, elapsed)
+	}
+
 	blobs := &fsm.IndexerBlobs{
 		Current:  current,
 		Previous: previous,
@@ -661,6 +679,7 @@ func (s *Server) IndexerBlobsCached(height uint64) (*fsm.IndexerBlobs, []byte, l
 		deltaBlobs: blobDelta,
 		deltaBytes: deltaBytes,
 	})
+	s.controller.Metrics.UpdateIndexerBlobCacheSize(s.indexerBlobCache.Len())
 
 	return blobDelta, deltaBytes, nil
 }

--- a/cmd/rpc/query.go
+++ b/cmd/rpc/query.go
@@ -644,8 +644,10 @@ func (s *Server) IndexerBlobsCached(height uint64) (*fsm.IndexerBlobs, []byte, l
 	// Therefore "previous" exists only when (height-1) >= 2, i.e. height >= 3.
 	if height > 2 {
 		if cachedPrev, ok := s.indexerBlobCache.getCurrent(height - 1); ok {
+			s.controller.Metrics.RecordIndexerBlobPreviousReuseHit()
 			previous = cachedPrev
 		} else {
+			s.controller.Metrics.RecordIndexerBlobPreviousReuseMiss()
 			prev, prevErr := s.controller.FSM.IndexerBlob(height - 1)
 			if prevErr != nil {
 				return nil, nil, prevErr

--- a/cmd/rpc/query_test.go
+++ b/cmd/rpc/query_test.go
@@ -2,6 +2,7 @@ package rpc
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -38,7 +39,7 @@ func TestIndexerBlobs_IgnoresLegacyDeltaField(t *testing.T) {
 func TestIndexerBlobsCached_CachesDeltaResponsesOnly(t *testing.T) {
 	server := newTestIndexerBlobServer(t)
 
-	got, bz, err := server.IndexerBlobsCached(3)
+	got, bz, err := server.IndexerBlobsCached(context.Background(), 3)
 	require.NoError(t, err)
 	require.NotNil(t, got)
 	require.NotEmpty(t, bz)
@@ -55,7 +56,7 @@ func TestIndexerBlobsCached_CachesDeltaResponsesOnly(t *testing.T) {
 	require.Same(t, got, entry.deltaBlobs)
 	require.Equal(t, bz, entry.deltaBytes)
 
-	gotAgain, bzAgain, err := server.IndexerBlobsCached(3)
+	gotAgain, bzAgain, err := server.IndexerBlobsCached(context.Background(), 3)
 	require.NoError(t, err)
 	require.Same(t, entry.deltaBlobs, gotAgain)
 	require.Equal(t, entry.deltaBytes, bzAgain)
@@ -64,7 +65,7 @@ func TestIndexerBlobsCached_CachesDeltaResponsesOnly(t *testing.T) {
 func TestIndexerBlobsCached_RetainsOnlyLatestFullSnapshot(t *testing.T) {
 	server := newTestIndexerBlobServerWithHeights(t, 4)
 
-	got3, _, err := server.IndexerBlobsCached(3)
+	got3, _, err := server.IndexerBlobsCached(context.Background(), 3)
 	require.NoError(t, err)
 	require.NotNil(t, got3)
 
@@ -73,7 +74,7 @@ func TestIndexerBlobsCached_RetainsOnlyLatestFullSnapshot(t *testing.T) {
 	require.NotNil(t, entry3)
 	require.NotNil(t, entry3.current)
 
-	got4, _, err := server.IndexerBlobsCached(4)
+	got4, _, err := server.IndexerBlobsCached(context.Background(), 4)
 	require.NoError(t, err)
 	require.NotNil(t, got4)
 	require.NotNil(t, got4.Previous)
@@ -305,4 +306,20 @@ func setUnexportedField(t *testing.T, target any, name string, value any) {
 	field := reflect.ValueOf(target).Elem().FieldByName(name)
 	require.True(t, field.IsValid(), name)
 	reflect.NewAt(field.Type(), unsafe.Pointer(field.UnsafeAddr())).Elem().Set(reflect.ValueOf(value))
+}
+
+func TestIndexerBlobsCached_CancelledContextReturnsErrCancelled(t *testing.T) {
+	server := newTestIndexerBlobServer(t)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	got, bz, err := server.IndexerBlobsCached(ctx, 3)
+	require.NotNil(t, err)
+	require.Equal(t, lib.CodeCancelled, err.Code())
+	require.Nil(t, got)
+	require.Nil(t, bz)
+
+	_, ok := server.indexerBlobCache.get(3)
+	require.False(t, ok, "a cancelled scan must not populate the cache")
 }

--- a/cmd/rpc/query_test.go
+++ b/cmd/rpc/query_test.go
@@ -32,7 +32,7 @@ func TestIndexerBlobs_IgnoresLegacyDeltaField(t *testing.T) {
 	got := new(fsm.IndexerBlobs)
 	require.NoError(t, proto.Unmarshal(rec.Body.Bytes(), got))
 	require.NotNil(t, got.Current)
-	require.Len(t, got.Current.Accounts, 1)
+	require.Len(t, withoutFunderAccount(t, got.Current.Accounts), 1)
 	require.NotNil(t, got.Previous)
 }
 
@@ -43,7 +43,7 @@ func TestIndexerBlobsCached_CachesDeltaResponsesOnly(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, got)
 	require.NotEmpty(t, bz)
-	require.Len(t, got.Current.Accounts, 1)
+	require.Len(t, withoutFunderAccount(t, got.Current.Accounts), 1)
 	require.NotNil(t, got.Previous)
 
 	entry, ok := server.indexerBlobCache.get(3)
@@ -52,7 +52,10 @@ func TestIndexerBlobsCached_CachesDeltaResponsesOnly(t *testing.T) {
 	require.NotNil(t, entry.current)
 	require.NotNil(t, entry.deltaBlobs)
 	require.NotEmpty(t, entry.deltaBytes)
-	require.Len(t, entry.current.Accounts, 2)
+	// the cached full snapshot no longer carries accounts at all: IndexerBlob is now called
+	// with skipAccounts=true, which is the whole point of the fast path -- the ~1.35M-account
+	// scan that used to fill this field is exactly what was eliminated
+	require.Empty(t, entry.current.Accounts)
 	require.Same(t, got, entry.deltaBlobs)
 	require.Equal(t, bz, entry.deltaBytes)
 
@@ -92,6 +95,193 @@ func TestIndexerBlobsCached_RetainsOnlyLatestFullSnapshot(t *testing.T) {
 	require.NotNil(t, entry4.current)
 	require.NotNil(t, entry4.deltaBlobs)
 	require.NotEmpty(t, entry4.deltaBytes)
+}
+
+// the account delta on the response must come from Controller.GetAccountDelta, not from
+// diffing two full account scans: added+changed land on Current as their FINAL values, and
+// changed+removed land on Previous as their PREVIOUS values.
+func TestIndexerBlobsCached_UsesAccountDeltaFastPath(t *testing.T) {
+	server := newTestIndexerBlobServerWithHeights(t, 4)
+	addrA := crypto.NewAddress(bytes.Repeat([]byte{0x11}, crypto.AddressSize))
+	addrB := crypto.NewAddress(bytes.Repeat([]byte{0x22}, crypto.AddressSize))
+
+	// state version 4 is produced by block 3, whose seeded delta is "A and B both changed"
+	got, _, err := server.IndexerBlobsCached(context.Background(), 4)
+	require.NoError(t, err)
+	require.NotNil(t, got.Current)
+	require.NotNil(t, got.Previous)
+
+	// current side: the post-block values
+	require.Equal(t, [][]byte{
+		mustMarshalAccount(t, addrA.Bytes(), 125),
+		mustMarshalAccount(t, addrB.Bytes(), 75),
+	}, withoutFunderAccount(t, got.Current.Accounts))
+	// previous side: the pre-block values for the same two accounts
+	require.Equal(t, [][]byte{
+		mustMarshalAccount(t, addrA.Bytes(), 100),
+		mustMarshalAccount(t, addrB.Bytes(), 50),
+	}, withoutFunderAccount(t, got.Previous.Accounts))
+
+	// proof this did not come from the old full-scan diff: neither underlying snapshot blob
+	// carries accounts anymore, so a diff of them could only have produced an empty result
+	entry, ok := server.indexerBlobCache.get(4)
+	require.True(t, ok)
+	require.Empty(t, entry.current.Accounts)
+}
+
+// an added account has no previous-side entry and a removed account has no current-side
+// entry, matching DeltaIndexerBlobs's existing convention
+func TestIndexerBlobsCached_AddedAccountsOmittedFromPreviousSide(t *testing.T) {
+	server := newTestIndexerBlobServer(t)
+	addrB := crypto.NewAddress(bytes.Repeat([]byte{0x22}, crypto.AddressSize))
+
+	// state version 3 is produced by block 2, whose seeded delta is "B added, nothing else"
+	got, _, err := server.IndexerBlobsCached(context.Background(), 3)
+	require.NoError(t, err)
+	require.NotNil(t, got.Current)
+	require.NotNil(t, got.Previous)
+
+	require.Equal(t, [][]byte{mustMarshalAccount(t, addrB.Bytes(), 50)}, withoutFunderAccount(t, got.Current.Accounts))
+	require.Empty(t, withoutFunderAccount(t, got.Previous.Accounts))
+}
+
+// NOTE: the account-side assembly helpers (accountSide, sortedAccountEntries, the
+// force-include read-back) live in fsm next to DeltaIndexerBlobs and are tested there
+// (fsm/indexer_test.go: TestAccountSide_DoesNotMutateOrAliasInputs,
+// TestAccountSide_SortsByAddressAscending, TestAccountDelta_MatchesOldFullScanAndDiff);
+// this package only orchestrates fsm.AssembleAccountDeltaSides onto the response blobs.
+
+// At height 2 there is no previous blob and DeltaIndexerBlobs keeps Current's full
+// account set. The fast path cannot reproduce that (a collector only reports what block 1
+// wrote), so that one height falls back to the full scan to stay byte-identical.
+func TestIndexerBlobsCached_HeightTwoKeepsFullAccountSet(t *testing.T) {
+	server := newTestIndexerBlobServer(t)
+	addrA := crypto.NewAddress(bytes.Repeat([]byte{0x11}, crypto.AddressSize))
+
+	got, _, err := server.IndexerBlobsCached(context.Background(), 2)
+	require.NoError(t, err)
+	require.NotNil(t, got.Current)
+	require.Nil(t, got.Previous)
+
+	// state@2 holds addrA (plus the funder, funded one version earlier for later blocks'
+	// real sends), and both are present in full despite no account delta existing
+	require.Equal(t, [][]byte{mustMarshalAccount(t, addrA.Bytes(), 100)}, withoutFunderAccount(t, got.Current.Accounts))
+
+	// and the cached snapshot for this height carries the full set too, unlike height >= 3
+	entry, ok := server.indexerBlobCache.get(2)
+	require.True(t, ok)
+	require.Len(t, withoutFunderAccount(t, entry.current.Accounts), 1)
+}
+
+// A reward or slash event often names an account the block never writes (compounding
+// rewards and slashes move stake only), so the collector never sees it — yet the full-scan
+// path force-included it on both sides. This fixture is built so the named accounts are
+// never written; a reward that actually credited an account would not catch the regression.
+func TestIndexerBlobsCached_ForceIncludesUnwrittenRewardSlashAccounts(t *testing.T) {
+	server, addrA, addrB, addrC := newTestIndexerBlobServerWithRewardSlashEvents(t)
+
+	got, _, err := server.IndexerBlobsCached(context.Background(), 4)
+	require.NoError(t, err)
+	require.NotNil(t, got.Current)
+	require.NotNil(t, got.Previous)
+	current := withoutFunderAccount(t, got.Current.Accounts)
+	previous := withoutFunderAccount(t, got.Previous.Accounts)
+
+	// A (compounding reward) and C (slash) were never written by block 3, so the collector
+	// never saw them -- only B actually changed. All three must still be present.
+	require.Equal(t, [][]byte{
+		mustMarshalAccount(t, addrA.Bytes(), 100),
+		mustMarshalAccount(t, addrB.Bytes(), 75),
+		mustMarshalAccount(t, addrC.Bytes(), 100),
+	}, current)
+	require.Equal(t, [][]byte{
+		mustMarshalAccount(t, addrA.Bytes(), 100),
+		mustMarshalAccount(t, addrB.Bytes(), 50),
+		mustMarshalAccount(t, addrC.Bytes(), 100),
+	}, previous)
+
+	// the force-include rule emits an unchanged account on both sides with IDENTICAL bytes
+	require.Equal(t, current[0], previous[0], "A: reward, unwritten")
+	require.Equal(t, current[2], previous[2], "C: slash, unwritten")
+	// ...while an account that genuinely changed keeps its own per-side value
+	require.NotEqual(t, current[1], previous[1], "B: genuinely changed")
+}
+
+// newTestIndexerBlobServerWithRewardSlashEvents builds a 4-height fixture where block 3 emits
+// a reward event for addrA and a slash event for addrC, but writes NEITHER account -- exactly
+// the compounding-reward / stake-slash shape. Only addrB's account changes (50 -> 75).
+func newTestIndexerBlobServerWithRewardSlashEvents(t *testing.T) (_ *Server, addrA, addrB, addrC crypto.AddressI) {
+	t.Helper()
+
+	log := lib.NewDefaultLogger()
+	db, err := store.NewStoreInMemory(log)
+	require.NoError(t, err)
+
+	sm := newTestRPCStateMachine(t, db, log)
+	addrA = crypto.NewAddress(bytes.Repeat([]byte{0x11}, crypto.AddressSize))
+	addrB = crypto.NewAddress(bytes.Repeat([]byte{0x22}, crypto.AddressSize))
+	addrC = crypto.NewAddress(bytes.Repeat([]byte{0x33}, crypto.AddressSize))
+	funder := rpcTestKeyGroup(t, 3)
+	now := uint64(time.Now().UnixMicro())
+
+	require.NoError(t, sm.SetParams(fsm.DefaultParams()))
+	_, err = db.Commit()
+	require.NoError(t, err)
+	setFSMHeight(t, sm, 2)
+
+	// block 1 and block 2 establish A, B and C in state (hand-set: GetAccountDelta only ever
+	// replays blockHeight > 1, so blocks 1-2's application is never replayed). Committee/
+	// validators land in block 1's commit (version 2): block 3 is the first real ApplyBlock,
+	// with sm.height=3, so its BeginBlock reads LoadCommittee(chainId, s.Height()-1=2) --
+	// one version earlier than block 3's own state, matching where this commits them.
+	require.NoError(t, sm.SetAccount(&fsm.Account{Address: addrA.Bytes(), Amount: 100}))
+	setUpRPCTestValidators(t, sm)
+	require.NoError(t, sm.AccountAdd(funder.Address, 10_000_000))
+	require.NoError(t, sm.UpdateParam("fee", fsm.ParamSendFee, &lib.UInt64Wrapper{Value: 0}))
+	require.NoError(t, db.IndexBlock(&lib.BlockResult{
+		BlockHeader: &lib.BlockHeader{Height: 1, Hash: crypto.Hash([]byte("rs-block-1")), Time: now},
+	}))
+	_, err = db.Commit()
+	require.NoError(t, err)
+
+	require.NoError(t, sm.SetAccount(&fsm.Account{Address: addrB.Bytes(), Amount: 50}))
+	require.NoError(t, sm.SetAccount(&fsm.Account{Address: addrC.Bytes(), Amount: 100}))
+	// block 3's BeginBlock loads "last certificate" via LoadCertificate(s.Height()-1=2), and
+	// HandleCertificateResults' non-signer calculation needs a real Signature too.
+	placeholderQC2 := &lib.QuorumCertificate{
+		Header:      &lib.View{Height: 2, ChainId: lib.CanopyChainId},
+		ProposerKey: rpcTestKeyGroup(t, 0).PublicKey.Bytes(),
+		Results:     &lib.CertificateResult{RewardRecipients: &lib.RewardRecipients{}},
+	}
+	signRPCTestQC(t, sm, placeholderQC2)
+	require.NoError(t, db.IndexQC(placeholderQC2))
+	require.NoError(t, db.IndexBlock(&lib.BlockResult{
+		BlockHeader: &lib.BlockHeader{Height: 2, Hash: crypto.Hash([]byte("rs-block-2")), Time: now + 1},
+	}))
+	_, err = db.Commit()
+	require.NoError(t, err)
+	setFSMHeight(t, sm, 3)
+	sm.Reset()
+
+	// block 3: a real ApplyBlock moves B's balance via a send from the funder; A and C are
+	// never written, matching the compounding-reward / stake-slash shape where the reward
+	// lands on STAKE, not the account. The reward/slash events are then appended by hand --
+	// force-include reads events from the INDEXED block, not from real reward execution, so
+	// this proves the read-back without needing real committee reward/slash machinery to fire.
+	applyAndCommitRPCTestBlock(t, sm, db, [][]byte{
+		rpcTestSendTx(t, sm, funder, addrB, 25),
+	}, []*lib.Event{
+		{EventType: string(lib.EventTypeReward), Address: addrA.Bytes()},
+		{EventType: string(lib.EventTypeSlash), Address: addrC.Bytes()},
+	})
+
+	ctrl := &controller.Controller{FSM: sm, Config: sm.Config}
+
+	return &Server{
+		controller:       ctrl,
+		indexerBlobCache: newIndexerBlobCache(8),
+		logger:           log,
+	}, addrA, addrB, addrC
 }
 
 func TestAccountQueryReturnsVestingBreakdown(t *testing.T) {
@@ -204,15 +394,34 @@ func newTestIndexerBlobServerWithHeights(t *testing.T, height uint64) *Server {
 	sm := newTestRPCStateMachine(t, db, log)
 	addrA := crypto.NewAddress(bytes.Repeat([]byte{0x11}, crypto.AddressSize))
 	addrB := crypto.NewAddress(bytes.Repeat([]byte{0x22}, crypto.AddressSize))
+	funder := rpcTestKeyGroup(t, 3)
 	now := uint64(time.Now().UnixMicro())
 
+	// committee/validators must be committed at version 1: BeginBlock's LoadCommittee(chainId,
+	// s.Height()-1) reads a HISTORICAL snapshot at that version, so with sm.height=2 (set
+	// below) when the first real block applies, the committee must already exist at version 1
+	// -- one commit earlier than block 1's own state.
 	require.NoError(t, sm.SetParams(fsm.DefaultParams()))
+	setUpRPCTestValidators(t, sm)
+	require.NoError(t, sm.AccountAdd(funder.Address, 10_000_000))
+	require.NoError(t, sm.UpdateParam("fee", fsm.ParamSendFee, &lib.UInt64Wrapper{Value: 0}))
 	_, err = db.Commit()
 	require.NoError(t, err)
 	setFSMHeight(t, sm, 2)
 
-	require.NoError(t, sm.SetParams(fsm.DefaultParams()))
+	// block 1: hand-set genesis-like state -- GetAccountDelta only ever replays blockHeight
+	// > 1 (useAccountDelta requires state version > 2), so block 1's application is never
+	// replayed and can stay a bare-header fixture.
 	require.NoError(t, sm.SetAccount(&fsm.Account{Address: addrA.Bytes(), Amount: 100}))
+	// block 2's BeginBlock loads "last certificate" via LoadCertificate(s.Height()-1=1), and
+	// HandleCertificateResults' non-signer calculation needs a real Signature too.
+	placeholderQC1 := &lib.QuorumCertificate{
+		Header:      &lib.View{Height: 1, ChainId: lib.CanopyChainId},
+		ProposerKey: rpcTestKeyGroup(t, 0).PublicKey.Bytes(),
+		Results:     &lib.CertificateResult{RewardRecipients: &lib.RewardRecipients{}},
+	}
+	signRPCTestQC(t, sm, placeholderQC1)
+	require.NoError(t, db.IndexQC(placeholderQC1))
 	require.NoError(t, db.IndexBlock(&lib.BlockResult{
 		BlockHeader: &lib.BlockHeader{
 			Height: 1,
@@ -222,55 +431,70 @@ func newTestIndexerBlobServerWithHeights(t *testing.T, height uint64) *Server {
 	}))
 	_, err = db.Commit()
 	require.NoError(t, err)
+	setFSMHeight(t, sm, 2)
+	sm.Reset()
 
-	require.NoError(t, sm.SetParams(fsm.DefaultParams()))
-	require.NoError(t, sm.SetAccount(&fsm.Account{Address: addrA.Bytes(), Amount: 100}))
-	require.NoError(t, sm.SetAccount(&fsm.Account{Address: addrB.Bytes(), Amount: 50}))
-	require.NoError(t, db.IndexBlock(&lib.BlockResult{
-		BlockHeader: &lib.BlockHeader{
-			Height: 2,
-			Hash:   crypto.Hash([]byte("block-2")),
-			Time:   now + 1,
-		},
-	}))
-	_, err = db.Commit()
-	require.NoError(t, err)
-	setFSMHeight(t, sm, 3)
+	// block 2 (state 2 -> 3): a real ApplyBlock creates B via a send from the funder. A is
+	// never touched, so a collector correctly omits it (equivalent to the old fixture's
+	// "rewritten with an identical value" case, without needing a no-op write to prove it).
+	applyAndCommitRPCTestBlock(t, sm, db, [][]byte{
+		rpcTestSendTx(t, sm, funder, addrB, 50),
+	}, nil)
 
 	if height >= 4 {
-		require.NoError(t, sm.SetParams(fsm.DefaultParams()))
-		require.NoError(t, sm.SetAccount(&fsm.Account{Address: addrA.Bytes(), Amount: 125}))
-		require.NoError(t, sm.SetAccount(&fsm.Account{Address: addrB.Bytes(), Amount: 75}))
-		require.NoError(t, db.IndexBlock(&lib.BlockResult{
-			BlockHeader: &lib.BlockHeader{
-				Height: 3,
-				Hash:   crypto.Hash([]byte("block-3")),
-				Time:   now + 2,
-			},
-		}))
-		_, err = db.Commit()
-		require.NoError(t, err)
-		setFSMHeight(t, sm, 4)
+		// block 3 (state 3 -> 4): both A and B change value
+		applyAndCommitRPCTestBlock(t, sm, db, [][]byte{
+			rpcTestSendTx(t, sm, funder, addrA, 25),
+			rpcTestSendTx(t, sm, funder, addrB, 25),
+		}, nil)
 	}
 
+	ctrl := &controller.Controller{FSM: sm, Config: sm.Config}
+
 	return &Server{
-		controller:       &controller.Controller{FSM: sm},
+		controller:       ctrl,
 		indexerBlobCache: newIndexerBlobCache(8),
 		logger:           log,
 	}
+}
+
+func mustMarshalAccount(t *testing.T, address []byte, amount uint64) []byte {
+	t.Helper()
+	bz, err := lib.Marshal(&fsm.Account{Address: address, Amount: amount})
+	require.NoError(t, err)
+	return bz
+}
+
+// withoutFunderAccount strips the funder key group's own account entry (its balance
+// legitimately changes on every real send in these fixtures) so assertions can compare
+// against just the test-relevant addresses.
+func withoutFunderAccount(t *testing.T, entries [][]byte) [][]byte {
+	t.Helper()
+	funder := rpcTestKeyGroup(t, 3).Address.Bytes()
+	out := make([][]byte, 0, len(entries))
+	for _, e := range entries {
+		acc := new(fsm.Account)
+		require.NoError(t, lib.Unmarshal(e, acc))
+		if bytes.Equal(acc.Address, funder) {
+			continue
+		}
+		out = append(out, e)
+	}
+	return out
 }
 
 func newTestRPCStateMachine(t *testing.T, db lib.StoreI, log lib.LoggerI) *fsm.StateMachine {
 	t.Helper()
 
 	sm := &fsm.StateMachine{
-		ProtocolVersion: 0,
+		ProtocolVersion: 1,
 		NetworkID:       1,
 		Config: lib.Config{
 			MainConfig:         lib.DefaultMainConfig(),
 			StateMachineConfig: lib.DefaultStateMachineConfig(),
 		},
 	}
+	sm.Config.P2PConfig.NetworkID = 1
 
 	setUnexportedField(t, sm, "store", db)
 	setUnexportedField(t, sm, "height", uint64(2))
@@ -295,9 +519,122 @@ func setFSMCache(t *testing.T, sm *fsm.StateMachine) {
 	require.True(t, field.IsValid())
 
 	cacheValue := reflect.New(field.Type().Elem())
-	accounts := cacheValue.Elem().FieldByName("accounts")
-	reflect.NewAt(accounts.Type(), unsafe.Pointer(accounts.UnsafeAddr())).Elem().Set(reflect.MakeMap(accounts.Type()))
+	// ApplyBlock touches both the account and the pool caches, so both maps must exist
+	for _, name := range []string{"accounts", "pools"} {
+		mapField := cacheValue.Elem().FieldByName(name)
+		require.True(t, mapField.IsValid(), name)
+		reflect.NewAt(mapField.Type(), unsafe.Pointer(mapField.UnsafeAddr())).Elem().Set(reflect.MakeMap(mapField.Type()))
+	}
 	reflect.NewAt(field.Type(), unsafe.Pointer(field.UnsafeAddr())).Elem().Set(cacheValue)
+}
+
+// rpcTestBLSKeys are the same deterministic BLS12381 keys used throughout the fsm/controller
+// test fixtures, so validator/committee/QC-signing behavior mirrors already-proven fixtures.
+var rpcTestBLSKeys = []string{
+	"01553a101301cd7019b78ffa1186842dd93923e563b8ae22e2ab33ae889b23ee",
+	"1b6b244fbdf614acb5f0d00a2b56ffcbe2aa23dabd66365dffcd3f06491ae50a",
+	"2ee868f74134032eacba191ca529115c64aa849ac121b75ca79b37420a623036",
+	"3e3ab94c10159d63a12cb26aca4b0e76070a987d49dd10fc5f526031e05801da",
+}
+
+func rpcTestKeyGroup(t *testing.T, i int) *crypto.KeyGroup {
+	t.Helper()
+	key, err := crypto.StringToBLS12381PrivateKey(rpcTestBLSKeys[i])
+	require.NoError(t, err)
+	return crypto.NewKeyGroup(key)
+}
+
+// setUpRPCTestValidators configures a 4-validator committee (needed for ApplyBlock's
+// validator-root calculation and BeginBlock's committee lookups) with no stake movement of
+// its own -- fixtures that need real account-touching blocks build sends from a separately
+// funded key-group address, since addrA/addrB/addrC are plain byte patterns with no known
+// private key and can only ever be send RECIPIENTS.
+func setUpRPCTestValidators(t *testing.T, sm *fsm.StateMachine) {
+	t.Helper()
+	supply := &fsm.Supply{}
+	for i := 0; i < 4; i++ {
+		kg := rpcTestKeyGroup(t, i)
+		require.NoError(t, sm.SetValidators([]*fsm.Validator{{
+			Address:      kg.Address.Bytes(),
+			PublicKey:    kg.PublicKey.Bytes(),
+			StakedAmount: 100,
+			Committees:   []uint64{lib.CanopyChainId},
+			Output:       kg.Address.Bytes(),
+		}}, supply))
+		require.NoError(t, sm.SetCommitteeMember(kg.Address, lib.CanopyChainId, 100))
+	}
+	require.NoError(t, sm.SetSupply(supply))
+}
+
+// signRPCTestQC signs qc with 3 of the 4 committee validators set up by setUpRPCTestValidators
+func signRPCTestQC(t *testing.T, sm *fsm.StateMachine, qc *lib.QuorumCertificate) {
+	t.Helper()
+	committee, err := sm.GetCommitteeMembers(lib.CanopyChainId)
+	require.NoError(t, err)
+	mk := committee.MultiKey.Copy()
+	for i := 0; i < 3; i++ {
+		privateKey := rpcTestKeyGroup(t, i).PrivateKey
+		for j, pubKey := range mk.PublicKeys() {
+			if privateKey.PublicKey().Equals(pubKey) {
+				require.NoError(t, mk.AddSigner(privateKey.Sign(qc.SignBytes()), j))
+			}
+		}
+	}
+	aggSig, e := mk.AggregateSignatures()
+	require.NoError(t, e)
+	qc.Signature = &lib.AggregateSignature{Signature: aggSig, Bitmap: mk.Bitmap()}
+}
+
+// rpcTestSendTx builds a signed zero-fee send transaction from the funder key group, valid
+// at the state machine's current height
+func rpcTestSendTx(t *testing.T, sm *fsm.StateMachine, funder *crypto.KeyGroup, to crypto.AddressI, amount uint64) []byte {
+	t.Helper()
+	tx, err := fsm.NewSendTransaction(funder.PrivateKey, to, amount, uint64(sm.NetworkID), sm.Config.ChainId, 0, sm.Height(), "")
+	require.NoError(t, err)
+	bz, mErr := lib.Marshal(tx)
+	require.NoError(t, mErr)
+	return bz
+}
+
+// applyAndCommitRPCTestBlock applies a block at sm.Height() with the given transactions,
+// indexes the resulting BlockResult (with extraEvents appended, e.g. synthetic reward/slash
+// events a test wants force-included without triggering real reward execution) and a signed
+// certificate for that height, commits, and advances the state machine -- the same order
+// controller.CommitCertificate uses.
+func applyAndCommitRPCTestBlock(t *testing.T, sm *fsm.StateMachine, db lib.StoreI, txs [][]byte, extraEvents []*lib.Event) {
+	t.Helper()
+	height := sm.Height()
+	block := &lib.Block{
+		BlockHeader: &lib.BlockHeader{
+			Height:          height,
+			Time:            uint64(time.Now().UnixMicro()) + height*1_000_000,
+			ProposerAddress: rpcTestKeyGroup(t, 0).Address.Bytes(),
+		},
+		Transactions: txs,
+	}
+	header, result, err := sm.ApplyBlock(context.Background(), block, false, nil, false)
+	require.NoError(t, err)
+	for _, f := range result.Failed {
+		t.Logf("FAILED TX at height %d: %s", height, f.Error.Error())
+	}
+	require.Empty(t, result.Failed, "block at height %d had failed transactions", height)
+	qc := &lib.QuorumCertificate{
+		Header:      &lib.View{Height: height, ChainId: lib.CanopyChainId},
+		ProposerKey: rpcTestKeyGroup(t, 0).PublicKey.Bytes(),
+		Results:     &lib.CertificateResult{RewardRecipients: &lib.RewardRecipients{}}, // BeginBlock's HandleCertificateResults requires non-nil Results
+	}
+	signRPCTestQC(t, sm, qc)
+	require.NoError(t, db.IndexQC(qc))
+	require.NoError(t, db.IndexBlock(&lib.BlockResult{
+		BlockHeader:  header,
+		Transactions: result.Results,
+		Events:       append(result.Events, extraEvents...),
+	}))
+	_, e := db.Commit()
+	require.NoError(t, e)
+	setFSMHeight(t, sm, height+1)
+	sm.Reset()
+	require.Equal(t, sm.Height(), db.Version())
 }
 
 func setUnexportedField(t *testing.T, target any, name string, value any) {

--- a/cmd/rpc/types.go
+++ b/cmd/rpc/types.go
@@ -453,6 +453,13 @@ func newIndexerBlobCache(maxEntries int) *indexerBlobCache {
 	}
 }
 
+// Len returns the current number of entries in the cache.
+func (c *indexerBlobCache) Len() int {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return len(c.entries)
+}
+
 func (c *indexerBlobCache) get(height uint64) (*indexerBlobCacheEntry, bool) {
 	c.mu.RLock()
 	entry, ok := c.entries[height]

--- a/controller/account_delta.go
+++ b/controller/account_delta.go
@@ -1,0 +1,122 @@
+package controller
+
+import (
+	"context"
+
+	"github.com/canopy-network/canopy/fsm"
+	"github.com/canopy-network/canopy/lib"
+)
+
+// minAccountDeltaHeight is the lowest state version an account delta exists for.
+// A delta is the difference between state@height-1 and state@height, so height must
+// be at least 2 for both sides of the comparison to name a real committed state.
+const minAccountDeltaHeight = 2
+
+// GetAccountDelta returns the accounts added/changed/removed between state version
+// height-1 and state version height, as one fsm.AccountDelta.
+//
+// `height` is a state version (same convention as fsm.IndexerBlob): version H means
+// blocks 0..H-1 are applied, so the block replayed here is block H-1, against a
+// TimeMachine(H-1) snapshot — exactly the pre-state a live FSM had while applying it.
+// The replay is throwaway: writes are discarded, nothing is committed or cached.
+func (c *Controller) GetAccountDelta(ctx context.Context, height uint64) (delta *fsm.AccountDelta, err lib.ErrorI) {
+	// no committed block pairs with state version 0 or 1
+	if height < minAccountDeltaHeight {
+		return nil, lib.ErrWrongBlockHeight(height, minAccountDeltaHeight)
+	}
+	// the block whose application produced state version `height`
+	blockHeight := height - 1
+	// capture the live FSM once: commitToStore reassigns c.FSM, and re-reading it could
+	// invert the `!= liveFSM` Discard guards below across a concurrent commit
+	liveFSM := c.FSM
+	// never read the block or QC through the live store — commits swap its readers
+	// un-mutexed (store.Reset()). Read through a snapshot at version `height`, the
+	// earliest one containing both the block and its QC
+	readFSM, err := liveFSM.TimeMachine(height)
+	if err != nil {
+		return nil, err
+	}
+	// TimeMachine returns the receiver itself when it cannot build a historical view;
+	// discarding that would blow away the LIVE state machine's transaction
+	if readFSM != liveFSM {
+		defer readFSM.Discard()
+	}
+	// TimeMachine silently clamps a height above the tip, which would otherwise read a
+	// different height's block — and, when the receiver itself came back, fall through to
+	// the live store this snapshot exists to avoid
+	if readFSM.Height() != height {
+		return nil, lib.ErrWrongBlockHeight(readFSM.Height(), height)
+	}
+	// the snapshot store serves both the block fetch here and the QC fetch below
+	store, ok := readFSM.Store().(lib.StoreI)
+	if !ok {
+		return nil, fsm.ErrWrongStoreType()
+	}
+	blockResult, err := store.GetBlockByHeight(blockHeight)
+	if err != nil {
+		return nil, err
+	}
+	if blockResult == nil || blockResult.BlockHeader == nil {
+		return nil, lib.ErrNilBlockHeader()
+	}
+	if blockResult.BlockHeader.Height != blockHeight {
+		return nil, lib.ErrWrongBlockHeight(blockResult.BlockHeader.Height, blockHeight)
+	}
+	// GetBlockByHeight returns a *lib.BlockResult; ApplyBlock needs a *lib.Block
+	block, err := blockResult.ToBlock()
+	if err != nil {
+		return nil, err
+	}
+	// snapshot the pre-block state
+	replayFSM, err := liveFSM.TimeMachine(blockHeight)
+	if err != nil {
+		return nil, err
+	}
+	// TimeMachine returns the receiver itself when it cannot build a historical view;
+	// discarding that would blow away the LIVE state machine's transaction
+	if replayFSM != liveFSM {
+		defer replayFSM.Discard()
+	}
+	// TimeMachine silently clamps a height above the tip, which would otherwise replay
+	// the block against the wrong pre-state and return a plausible-looking wrong delta
+	if replayFSM.Height() != blockHeight {
+		return nil, lib.ErrWrongBlockHeight(replayFSM.Height(), blockHeight)
+	}
+	// restore the root DEX cache from the committed certificate, exactly as the commit path
+	// does. Without it, on a nested chain HandleDexBatch reads the fresh snapshot's nil
+	// cache and silently no-ops, dropping every account the DEX batch moved from the delta.
+	// The pre-normalization certificate this snapshot sees is fine: Results are bound by
+	// ResultsHash, so its RootDexBatch matches what the commit applied. BeginBlock skips
+	// certificate handling entirely at heights <= 1, so no QC is loaded there.
+	if blockHeight > 1 {
+		qc, qcErr := store.GetQCByHeight(blockHeight)
+		if qcErr != nil {
+			return nil, qcErr
+		}
+		// a missing key unmarshals into an empty, non-nil QC, so a nil Header means the
+		// certificate could not be loaded — whether a RootDexBatch existed is then
+		// unknowable and the delta may be silently incomplete. Fail loudly instead.
+		if qc == nil || qc.Header == nil {
+			return nil, lib.ErrEmptyQuorumCertificate()
+		}
+		// nil Results/RootDexBatch is normal (root chain, or no root batch in the
+		// certificate) — the live path leaves the cache nil there too
+		if qc.Results != nil && qc.Results.RootDexBatch != nil {
+			replayFSM.SetRootDexCache(qc.Results.RootDexBatch)
+		}
+	}
+	// the collector's baseline lookup must read the snapshot, not the live state
+	collector := fsm.NewAccountChangeCollector(replayFSM.Get)
+	// ReplayBlock applies with skipRoot=true: the result is never committed and its
+	// StateRoot never inspected; writes die with the Discard above
+	_, applyResult, err := replayFSM.ReplayBlock(ctx, block, collector)
+	if err != nil {
+		return nil, err
+	}
+	// a committed block never has failed transactions (consensus rejects them), so a
+	// failure here means the replay diverged and the delta is wrong — fail loudly
+	if len(applyResult.Failed) != 0 {
+		return nil, lib.ErrFailedTransactions()
+	}
+	return collector.Results(), nil
+}

--- a/controller/account_delta_replay_test.go
+++ b/controller/account_delta_replay_test.go
@@ -1,0 +1,519 @@
+package controller
+
+import (
+	"bytes"
+	"context"
+	"reflect"
+	"testing"
+	"time"
+	"unsafe"
+
+	"github.com/canopy-network/canopy/fsm"
+	"github.com/canopy-network/canopy/lib"
+	"github.com/canopy-network/canopy/lib/crypto"
+	"github.com/canopy-network/canopy/store"
+	"github.com/stretchr/testify/require"
+)
+
+/*
+This file covers controller.GetAccountDelta's REPLAY branch (the fall-through when the tip
+cache misses), which the cache-hit tests in account_delta_test.go deliberately never reach:
+the TimeMachine snapshot reads, the above-tip clamp guard, the block fetch + height check,
+the QC fetch (and its blockHeight>1 gating), the RootDexBatch restore, and a full happy-path
+replay against a REAL committed chain.
+
+The chain fixture mirrors fsm/indexer_test.go's newTestAccountDeltaChain (which controller
+tests cannot call -- test helpers don't cross packages), built here from exported fsm APIs
+plus the same reflection seam cmd/rpc/query_test.go uses to construct a StateMachine outside
+the fsm package.
+*/
+
+// testChainTimestamp is the fixed base block time the chain fixture uses (same date as the
+// fsm package's fixtures)
+var testChainTimestamp = uint64(time.Date(2024, 02, 01, 0, 0, 0, 0, time.UTC).UnixMicro())
+
+// testChainBLSKeys are the same deterministic BLS12381 private keys the fsm package's test
+// fixtures use (fsm/state_test.go newTestKeyGroup), so this fixture's validator set and
+// QC-signing behavior mirror the proven-good fsm chain fixture exactly
+var testChainBLSKeys = []string{
+	"01553a101301cd7019b78ffa1186842dd93923e563b8ae22e2ab33ae889b23ee",
+	"1b6b244fbdf614acb5f0d00a2b56ffcbe2aa23dabd66365dffcd3f06491ae50a",
+	"2ee868f74134032eacba191ca529115c64aa849ac121b75ca79b37420a623036",
+	"3e3ab94c10159d63a12cb26aca4b0e76070a987d49dd10fc5f526031e05801da",
+	"479839d3edbd0eefa60111db569ded6a1a642cc84781600f0594bd8d4a429319",
+	"51eb5eb6eca0b47c8383652a6043aadc66ddbcbe240474d152f4d9a7439eae42",
+	"637cb8e916bba4c1773ed34d89ebc4cb86e85c145aea5653a58de930590a2aa4",
+	"7235e5757e6f52e6ae4f9e20726d9c514281e58e839e33a7f667167c524ff658",
+}
+
+func testChainKeyGroup(t *testing.T, i int) *crypto.KeyGroup {
+	t.Helper()
+	key, err := crypto.StringToBLS12381PrivateKey(testChainBLSKeys[i])
+	require.NoError(t, err)
+	return crypto.NewKeyGroup(key)
+}
+
+func testChainAddress(t *testing.T, i int) crypto.AddressI {
+	t.Helper()
+	return testChainKeyGroup(t, i).Address
+}
+
+func testChainAddressBytes(t *testing.T, i int) []byte {
+	t.Helper()
+	return testChainAddress(t, i).Bytes()
+}
+
+// setUnexportedField / setFSMHeight / setFSMCacheMaps are the same reflection seam
+// cmd/rpc/query_test.go uses to build an fsm.StateMachine outside the fsm package
+func setUnexportedField(t *testing.T, target any, name string, value any) {
+	t.Helper()
+	field := reflect.ValueOf(target).Elem().FieldByName(name)
+	require.True(t, field.IsValid(), name)
+	reflect.NewAt(field.Type(), unsafe.Pointer(field.UnsafeAddr())).Elem().Set(reflect.ValueOf(value))
+}
+
+func setFSMHeight(t *testing.T, sm *fsm.StateMachine, height uint64) {
+	t.Helper()
+	setUnexportedField(t, sm, "height", height)
+}
+
+func setFSMCacheMaps(t *testing.T, sm *fsm.StateMachine) {
+	t.Helper()
+	field := reflect.ValueOf(sm).Elem().FieldByName("cache")
+	require.True(t, field.IsValid())
+	cacheValue := reflect.New(field.Type().Elem())
+	// ApplyBlock touches both the account and the pool caches, so both maps must exist
+	for _, name := range []string{"accounts", "pools"} {
+		mapField := cacheValue.Elem().FieldByName(name)
+		require.True(t, mapField.IsValid(), name)
+		reflect.NewAt(mapField.Type(), unsafe.Pointer(mapField.UnsafeAddr())).Elem().Set(reflect.MakeMap(mapField.Type()))
+	}
+	reflect.NewAt(field.Type(), unsafe.Pointer(field.UnsafeAddr())).Elem().Set(cacheValue)
+}
+
+// newReflectedFSM builds a StateMachine over db at the given height, mirroring the fsm
+// package's newTestStateMachine. The config's P2P NetworkID must agree with the hand-set
+// NetworkID: TimeMachine snapshots derive theirs from Config (newStateMachine), and a
+// mismatch would fail every replayed transaction's network-id check.
+func newReflectedFSM(t *testing.T, db lib.StoreI, log lib.LoggerI, height uint64) *fsm.StateMachine {
+	t.Helper()
+	sm := &fsm.StateMachine{
+		ProtocolVersion: 1,
+		NetworkID:       1,
+		Config: lib.Config{
+			MainConfig:         lib.DefaultMainConfig(),
+			StateMachineConfig: lib.DefaultStateMachineConfig(),
+		},
+	}
+	sm.Config.P2PConfig.NetworkID = 1
+	setUnexportedField(t, sm, "store", db)
+	setUnexportedField(t, sm, "height", height)
+	setUnexportedField(t, sm, "slashTracker", fsm.NewSlashTracker())
+	setUnexportedField(t, sm, "proposeVoteConfig", fsm.AcceptAllProposals)
+	setUnexportedField(t, sm, "events", new(lib.EventsTracker))
+	setUnexportedField(t, sm, "log", log)
+	setFSMCacheMaps(t, sm)
+	return sm
+}
+
+// newBareReplayController builds a Controller over an FSM whose in-memory store has
+// `versions` committed versions but no real chain -- just enough for GetAccountDelta's
+// snapshot reads to run. blockAtLastVersion, if non-nil, is indexed into the final
+// version's commit. NOTE on heights: the store package keeps a GLOBAL block cache keyed
+// only by height, so fixtures in this package must use heights no other fixture indexes
+// when they rely on a block being MISSING.
+func newBareReplayController(t *testing.T, versions uint64, blockAtLastVersion *lib.BlockResult) *Controller {
+	t.Helper()
+	log := lib.NewDefaultLogger()
+	db, err := store.NewStoreInMemory(log)
+	require.NoError(t, err)
+	sm := newReflectedFSM(t, db, log, 0)
+	for v := uint64(1); v <= versions; v++ {
+		if v == versions && blockAtLastVersion != nil {
+			require.NoError(t, db.IndexBlock(blockAtLastVersion))
+		}
+		_, e := db.Commit()
+		require.NoError(t, e)
+	}
+	setFSMHeight(t, sm, db.Version())
+	sm.Reset()
+	return &Controller{FSM: sm, log: log}
+}
+
+// signTestChainQC signs qc with 3 of the fixture's 4 committee validators (mirrors the fsm
+// fixtures' QC signing)
+func signTestChainQC(t *testing.T, sm *fsm.StateMachine, qc *lib.QuorumCertificate) {
+	t.Helper()
+	committee, err := sm.GetCommitteeMembers(lib.CanopyChainId)
+	require.NoError(t, err)
+	mk := committee.MultiKey.Copy()
+	for i := 0; i < 3; i++ {
+		privateKey := testChainKeyGroup(t, i).PrivateKey
+		for j, pubKey := range mk.PublicKeys() {
+			if privateKey.PublicKey().Equals(pubKey) {
+				require.NoError(t, mk.AddSigner(privateKey.Sign(qc.SignBytes()), j))
+			}
+		}
+	}
+	aggSig, e := mk.AggregateSignatures()
+	require.NoError(t, e)
+	qc.Signature = &lib.AggregateSignature{Signature: aggSig, Bitmap: mk.Bitmap()}
+}
+
+// testChainSendTx builds a signed zero-fee send transaction from test key group
+// `fromKeyGroup`, valid at the state machine's current height
+func testChainSendTx(t *testing.T, sm *fsm.StateMachine, fromKeyGroup int, to crypto.AddressI, amount uint64) []byte {
+	t.Helper()
+	kg := testChainKeyGroup(t, fromKeyGroup)
+	tx, err := fsm.NewSendTransaction(kg.PrivateKey, to, amount, uint64(sm.NetworkID), sm.Config.ChainId, 0, sm.Height(), "")
+	require.NoError(t, err)
+	bz, mErr := lib.Marshal(tx)
+	require.NoError(t, mErr)
+	return bz
+}
+
+// applyAndCommitTestChainBlock applies a block at sm.Height() with the given transactions,
+// indexes the resulting BlockResult and a signed certificate for that height, commits, and
+// advances the state machine -- the same order controller.CommitCertificate uses. qcMutate,
+// if non-nil, edits the certificate BEFORE signing (used to vary Results for the
+// RootDexBatch restore tests).
+func applyAndCommitTestChainBlock(t *testing.T, sm *fsm.StateMachine, db lib.StoreI, txs [][]byte, qcMutate func(*lib.QuorumCertificate)) {
+	t.Helper()
+	height := sm.Height()
+	block := &lib.Block{
+		BlockHeader: &lib.BlockHeader{
+			Height:          height,
+			Time:            testChainTimestamp + height*1_000_000,
+			ProposerAddress: testChainAddressBytes(t, 0),
+		},
+		Transactions: txs,
+	}
+	header, result, err := sm.ApplyBlock(context.Background(), block, false, nil, false)
+	require.NoError(t, err)
+	for _, f := range result.Failed {
+		t.Logf("FAILED TX at height %d: %s", height, f.Error.Error())
+	}
+	require.Empty(t, result.Failed, "block at height %d had failed transactions", height)
+	// ChainId is what keys the committee data the reward machinery pays out from; the
+	// recipient is validator #3 (non-compounding), so its reward lands on its OUTPUT
+	// account (key group 0) -- mirrors fsm's testAccountDeltaQC
+	qc := &lib.QuorumCertificate{
+		Header: &lib.View{Height: height, ChainId: lib.CanopyChainId},
+		Results: &lib.CertificateResult{RewardRecipients: &lib.RewardRecipients{
+			PaymentPercents: []*lib.PaymentPercents{{
+				Address: testChainAddressBytes(t, 3),
+				Percent: 100,
+				ChainId: lib.CanopyChainId,
+			}},
+		}},
+	}
+	if qcMutate != nil {
+		qcMutate(qc)
+	}
+	signTestChainQC(t, sm, qc)
+	require.NoError(t, db.IndexQC(qc))
+	require.NoError(t, db.IndexBlock(&lib.BlockResult{
+		BlockHeader:  header,
+		Transactions: result.Results,
+		Events:       result.Events,
+	}))
+	_, e := db.Commit()
+	require.NoError(t, e)
+	setFSMHeight(t, sm, height+1)
+	sm.Reset()
+	require.Equal(t, sm.Height(), db.Version())
+}
+
+// newAccountDeltaChainController builds a Controller over a REAL committed chain (blocks 3,
+// 4 and 5 applied via ApplyBlock + IndexQC + IndexBlock + Commit), mirroring fsm's
+// newTestAccountDeltaChain. Block 5 -- the one GetAccountDelta(6) replays -- exercises a
+// brand-new account (added), balance changes (changed), a net-unchanged self-send (dropped),
+// and an account zeroed out (removed). finalQCMutate, if non-nil, edits block 5's
+// certificate before it is signed and indexed.
+func newAccountDeltaChainController(t *testing.T, finalQCMutate func(*lib.QuorumCertificate)) *Controller {
+	t.Helper()
+	log := lib.NewDefaultLogger()
+	db, err := store.NewStoreInMemory(log)
+	require.NoError(t, err)
+	sm := newReflectedFSM(t, db, log, 2)
+	// -- base state at heights <= 2 (mirrors fsm's newTestStateMachine + newTestApplyBlockFixture) --
+	require.NoError(t, sm.SetParams(fsm.DefaultParams()))
+	_, e := db.Commit()
+	require.NoError(t, e)
+	require.NoError(t, sm.SetParams(fsm.DefaultParams()))
+	// preset the 'last block' so block 3's application can load its predecessor
+	require.NoError(t, db.IndexBlock(&lib.BlockResult{BlockHeader: &lib.BlockHeader{
+		Height: 2,
+		Hash:   crypto.Hash([]byte("block_hash")),
+		Time:   testChainTimestamp,
+	}}))
+	require.NoError(t, sm.UpdateParam("fee", fsm.ParamSendFee, &lib.UInt64Wrapper{Value: 1}))
+	require.NoError(t, sm.AccountAdd(testChainAddress(t, 0), 2))
+	supply := &fsm.Supply{}
+	for i := 0; i < 4; i++ {
+		require.NoError(t, sm.SetValidators([]*fsm.Validator{{
+			Address:      testChainAddressBytes(t, i),
+			PublicKey:    testChainKeyGroup(t, i).PublicKey.Bytes(),
+			StakedAmount: 100,
+			Committees:   []uint64{lib.CanopyChainId},
+			Output:       testChainAddressBytes(t, 0),
+		}}, supply))
+		require.NoError(t, sm.SetCommitteeMember(testChainAddress(t, i), lib.CanopyChainId, 100))
+	}
+	require.NoError(t, sm.SetSupply(supply))
+	qc2 := &lib.QuorumCertificate{
+		Header: &lib.View{Height: 2},
+		Results: &lib.CertificateResult{RewardRecipients: &lib.RewardRecipients{
+			PaymentPercents: []*lib.PaymentPercents{{Address: testChainAddressBytes(t, 0), Percent: 100}},
+		}},
+	}
+	signTestChainQC(t, sm, qc2)
+	require.NoError(t, db.IndexQC(qc2))
+	setFSMHeight(t, sm, 3)
+	_, e = db.Commit()
+	require.NoError(t, e)
+	// -- the chain itself (mirrors fsm's newTestAccountDeltaChain) --
+	// align the store version with sm.Height()
+	_, e = db.Commit()
+	require.NoError(t, e)
+	require.Equal(t, sm.Height(), db.Version())
+	// send fee of zero, so the net-unchanged self-send below really is net-unchanged
+	require.NoError(t, sm.UpdateParam("fee", fsm.ParamSendFee, &lib.UInt64Wrapper{Value: 0}))
+	// funder pays for everything downstream
+	require.NoError(t, sm.AccountAdd(testChainAddress(t, 0), 10_000_000))
+	// block 3: no transactions -- exists so block 4's BeginBlock has a real committed
+	// predecessor block and certificate to load
+	applyAndCommitTestChainBlock(t, sm, db, nil, nil)
+	// block 4: fund the accounts block 5 will change / zero / self-send
+	applyAndCommitTestChainBlock(t, sm, db, [][]byte{
+		testChainSendTx(t, sm, 0, testChainAddress(t, 4), 5_000), // net-unchanged self-sender
+		testChainSendTx(t, sm, 0, testChainAddress(t, 5), 3_000), // zeroed out in block 5
+		testChainSendTx(t, sm, 0, testChainAddress(t, 6), 2_000), // changed in block 5
+		testChainSendTx(t, sm, 0, testChainAddress(t, 3), 4_000), // reward-event recipient; untouched by block 5
+	}, nil)
+	// block 5: the measured block
+	brandNew := crypto.NewAddressFromBytes(bytes.Repeat([]byte{0xAB}, crypto.AddressSize))
+	applyAndCommitTestChainBlock(t, sm, db, [][]byte{
+		testChainSendTx(t, sm, 0, brandNew, 1_500),               // brandNew added; kg0 changed
+		testChainSendTx(t, sm, 6, testChainAddress(t, 7), 1_000), // kg6 changed; kg7 added (never funded)
+		testChainSendTx(t, sm, 4, testChainAddress(t, 4), 5_000), // kg4 self-send: touched, net-unchanged
+		testChainSendTx(t, sm, 5, testChainAddress(t, 6), 3_000), // kg5 sends its whole balance -> removed
+	}, finalQCMutate)
+	// sm.Height() is now 6; blocks 2..5 and their QCs are indexed, so GetAccountDelta(6)
+	// (replay of block 5) resolves entirely from the store
+	return &Controller{FSM: sm, Config: sm.Config, log: log}
+}
+
+// entryAddressSet collapses delta entries to their address set for order-independent compare
+func entryAddressSet(entries []*fsm.AccountChangeEntry) map[string]struct{} {
+	set := make(map[string]struct{}, len(entries))
+	for _, e := range entries {
+		set[string(e.Address)] = struct{}{}
+	}
+	return set
+}
+
+func addressSet(addresses ...[]byte) map[string]struct{} {
+	set := make(map[string]struct{}, len(addresses))
+	for _, a := range addresses {
+		set[string(a)] = struct{}{}
+	}
+	return set
+}
+
+// accountBytesAtVersion reads the raw stored account bytes at a state version through a
+// throwaway snapshot -- the independent ground truth the replay's delta is checked against
+func accountBytesAtVersion(t *testing.T, c *Controller, version uint64, address []byte) []byte {
+	t.Helper()
+	snap, err := c.FSM.TimeMachine(version)
+	require.NoError(t, err)
+	require.NotSame(t, c.FSM, snap)
+	defer snap.Discard()
+	bz, gErr := snap.Get(fsm.KeyForAccount(crypto.NewAddressFromBytes(address)))
+	require.NoError(t, gErr)
+	return bz
+}
+
+// requireDeltaMatchesCommittedState checks every entry's classification and values against
+// the committed state at versions height-1 and height -- nothing is hand-seeded, so a replay
+// that drifted from the real block application fails here
+func requireDeltaMatchesCommittedState(t *testing.T, c *Controller, delta *fsm.AccountDelta, height uint64) {
+	t.Helper()
+	for _, e := range delta.Added {
+		require.Nil(t, e.PrevValue, "an added account must have no previous value")
+		require.Empty(t, accountBytesAtVersion(t, c, height-1, e.Address), "an added account must not exist at the previous version")
+		require.Equal(t, accountBytesAtVersion(t, c, height, e.Address), e.FinalValue)
+	}
+	for _, e := range delta.Changed {
+		require.Equal(t, accountBytesAtVersion(t, c, height-1, e.Address), e.PrevValue)
+		require.Equal(t, accountBytesAtVersion(t, c, height, e.Address), e.FinalValue)
+		require.NotEqual(t, e.PrevValue, e.FinalValue, "a changed account must actually change")
+	}
+	for _, e := range delta.Removed {
+		require.Equal(t, accountBytesAtVersion(t, c, height-1, e.Address), e.PrevValue)
+		require.Nil(t, e.FinalValue, "a removed account must have no final value")
+		require.Empty(t, accountBytesAtVersion(t, c, height, e.Address), "a removed account must not exist at the current version")
+	}
+}
+
+// TestGetAccountDelta_ReplayHappyPath replays block 5 of a real committed chain through the
+// full production path and checks the classified delta against the committed state at
+// versions 5 and 6
+func TestGetAccountDelta_ReplayHappyPath(t *testing.T) {
+	c := newAccountDeltaChainController(t, nil)
+	delta, err := c.GetAccountDelta(context.Background(), 6)
+	require.NoError(t, err)
+	require.NotNil(t, delta)
+	brandNew := bytes.Repeat([]byte{0xAB}, crypto.AddressSize)
+	// exact address sets: kg4's net-unchanged self-send must NOT appear anywhere, and kg3
+	// (funded in block 4, untouched by block 5) must not leak in either. kg0 is changed by
+	// both its sends and the block's committee reward (validator #3 is non-compounding, so
+	// its reward lands on its output account, kg0).
+	require.Equal(t, addressSet(brandNew, testChainAddressBytes(t, 7)), entryAddressSet(delta.Added))
+	require.Equal(t, addressSet(testChainAddressBytes(t, 0), testChainAddressBytes(t, 6)), entryAddressSet(delta.Changed))
+	require.Equal(t, addressSet(testChainAddressBytes(t, 5)), entryAddressSet(delta.Removed))
+	requireDeltaMatchesCommittedState(t, c, delta, 6)
+}
+
+// TestGetAccountDelta_ReplayCommittedQCVariants exercises the RootDexBatch restore branch:
+// the committed certificate's Results feed SetRootDexCache before the replay, exactly as
+// the live commit path does. A full nested-chain fixture (where the restored batch changes
+// HandleDexBatch's behavior) is not constructible in-process without a root chain to sync
+// against, so this covers the QC-read/restore decision logic on a root chain: a certificate
+// CARRYING a RootDexBatch must be tolerated and restored without disturbing the delta (the
+// cache only alters nested-chain replay), and a certificate with nil Results is normal and
+// must not error.
+func TestGetAccountDelta_ReplayCommittedQCVariants(t *testing.T) {
+	expectDelta := func(t *testing.T, c *Controller) {
+		delta, err := c.GetAccountDelta(context.Background(), 6)
+		require.NoError(t, err)
+		require.NotNil(t, delta)
+		brandNew := bytes.Repeat([]byte{0xAB}, crypto.AddressSize)
+		require.Equal(t, addressSet(brandNew, testChainAddressBytes(t, 7)), entryAddressSet(delta.Added))
+		require.Equal(t, addressSet(testChainAddressBytes(t, 0), testChainAddressBytes(t, 6)), entryAddressSet(delta.Changed))
+		require.Equal(t, addressSet(testChainAddressBytes(t, 5)), entryAddressSet(delta.Removed))
+		requireDeltaMatchesCommittedState(t, c, delta, 6)
+	}
+	t.Run("certificate carrying a RootDexBatch is restored and tolerated", func(t *testing.T) {
+		c := newAccountDeltaChainController(t, func(qc *lib.QuorumCertificate) {
+			qc.Results.RootDexBatch = &lib.DexBatch{Committee: lib.CanopyChainId}
+		})
+		expectDelta(t, c)
+	})
+	t.Run("certificate with nil Results is normal", func(t *testing.T) {
+		c := newAccountDeltaChainController(t, func(qc *lib.QuorumCertificate) {
+			qc.Results = nil
+		})
+		expectDelta(t, c)
+	})
+}
+
+// TestGetAccountDelta_ReplayMissingBlock: a request for a height whose block was never
+// indexed must fail loudly. NOTE: the store returns a zero-value (non-nil) header for a
+// missing block -- lib.Unmarshal(nil) fills nothing -- so the miss surfaces through the
+// height-mismatch guard (got=0), not the nil-header guard, which is defense-in-depth for a
+// nil blockResult the store API cannot actually produce.
+func TestGetAccountDelta_ReplayMissingBlock(t *testing.T) {
+	// heights in the 40s: the store's global block cache is keyed only by height, so this
+	// fixture must use heights no other fixture in this package indexes (see
+	// newBareReplayController)
+	c := newBareReplayController(t, 42, nil)
+	delta, err := c.GetAccountDelta(context.Background(), 42)
+	require.Nil(t, delta)
+	require.NotNil(t, err)
+	require.Equal(t, lib.CodeWrongBlockHeight, err.Code())
+	// got=0 pins WHICH guard fired: the missing block's zero-value header, not the clamp
+	require.Contains(t, err.Error(), "got=0 | wanted=41")
+}
+
+// TestGetAccountDelta_ReplayAboveTipRejected: TimeMachine silently clamps a height above
+// the tip to the tip; the explicit height check must convert that clamp into an error
+// instead of replaying a different height's block
+func TestGetAccountDelta_ReplayAboveTipRejected(t *testing.T) {
+	c := newBareReplayController(t, 3, nil)
+	delta, err := c.GetAccountDelta(context.Background(), 9)
+	require.Nil(t, delta)
+	require.NotNil(t, err)
+	require.Equal(t, lib.CodeWrongBlockHeight, err.Code())
+	// got=3 (the clamped tip) pins the above-tip guard, not the missing-block guard
+	require.Contains(t, err.Error(), "got=3 | wanted=9")
+}
+
+// TestGetAccountDelta_ReplayMissingQC: a block whose certificate cannot be loaded must fail
+// loudly (a missing QC unmarshals into an empty, non-nil certificate with a nil Header) --
+// whether a RootDexBatch existed is unknowable, so the delta could be silently incomplete
+func TestGetAccountDelta_ReplayMissingQC(t *testing.T) {
+	// height 60: unique to this fixture (global block cache, see newBareReplayController)
+	c := newBareReplayController(t, 61, &lib.BlockResult{BlockHeader: &lib.BlockHeader{
+		Height: 60,
+		Hash:   crypto.Hash([]byte("qc-missing-block-60")),
+		Time:   testChainTimestamp,
+	}})
+	delta, err := c.GetAccountDelta(context.Background(), 61)
+	require.Nil(t, delta)
+	require.NotNil(t, err)
+	require.Equal(t, lib.CodeEmptyQuorumCertificate, err.Code())
+}
+
+// TestGetAccountDelta_HeightTwoBoundarySkipsQC: height 2 is the lowest servable height and
+// replays block 1, the only block whose certificate is legitimately absent (BeginBlock
+// skips certificate handling entirely at height <= 1). The QC fetch must be gated off for
+// blockHeight 1 -- this fixture indexes NO certificate anywhere, so a regression that reads
+// the QC unconditionally fails with ErrEmptyQuorumCertificate.
+func TestGetAccountDelta_HeightTwoBoundarySkipsQC(t *testing.T) {
+	log := lib.NewDefaultLogger()
+	db, err := store.NewStoreInMemory(log)
+	require.NoError(t, err)
+	sm := newReflectedFSM(t, db, log, 1)
+	// hand-written pre-block-1 state: params for tx/block machinery, a validator set for
+	// ApplyBlock's validator-root calculation
+	require.NoError(t, sm.SetParams(fsm.DefaultParams()))
+	supply := &fsm.Supply{}
+	for i := 0; i < 4; i++ {
+		require.NoError(t, sm.SetValidators([]*fsm.Validator{{
+			Address:      testChainAddressBytes(t, i),
+			PublicKey:    testChainKeyGroup(t, i).PublicKey.Bytes(),
+			StakedAmount: 100,
+			Committees:   []uint64{lib.CanopyChainId},
+			Output:       testChainAddressBytes(t, 0),
+		}}, supply))
+		require.NoError(t, sm.SetCommitteeMember(testChainAddress(t, i), lib.CanopyChainId, 100))
+	}
+	require.NoError(t, sm.SetSupply(supply))
+	// stub block 1 so ApplyBlock's last-block load (clamped to height 1) has a header
+	require.NoError(t, db.IndexBlock(&lib.BlockResult{BlockHeader: &lib.BlockHeader{
+		Height: 1,
+		Hash:   crypto.Hash([]byte("boundary-stub-1")),
+		Time:   testChainTimestamp,
+	}}))
+	_, e := db.Commit()
+	require.NoError(t, e)
+	sm.Reset()
+	// apply and commit a REAL (empty) block 1; deliberately index NO certificate
+	block1 := &lib.Block{BlockHeader: &lib.BlockHeader{
+		Height:          1,
+		Time:            testChainTimestamp + 1_000_000,
+		ProposerAddress: testChainAddressBytes(t, 0),
+	}}
+	header, result, aErr := sm.ApplyBlock(context.Background(), block1, false, nil, false)
+	require.NoError(t, aErr)
+	require.Empty(t, result.Failed)
+	require.NoError(t, db.IndexBlock(&lib.BlockResult{
+		BlockHeader:  header,
+		Transactions: result.Results,
+		Events:       result.Events,
+	}))
+	_, e = db.Commit()
+	require.NoError(t, e)
+	setFSMHeight(t, sm, 2)
+	sm.Reset()
+	c := &Controller{FSM: sm, log: log}
+	// must succeed -- in particular it must NOT be ErrEmptyQuorumCertificate
+	delta, dErr := c.GetAccountDelta(context.Background(), 2)
+	require.NoError(t, dErr)
+	require.NotNil(t, delta)
+	// an empty block 1 with no certificate to pay rewards from touches no accounts
+	require.Empty(t, delta.Added)
+	require.Empty(t, delta.Changed)
+	require.Empty(t, delta.Removed)
+}

--- a/controller/account_delta_test.go
+++ b/controller/account_delta_test.go
@@ -1,0 +1,25 @@
+package controller
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/canopy-network/canopy/lib"
+	"github.com/stretchr/testify/require"
+)
+
+// heights below 2 have no committed block to pair with and must be rejected before any
+// store or FSM access (matching fsm.IndexerBlob's own height<=1 guard)
+func TestGetAccountDelta_RejectsHeightsBelowTwo(t *testing.T) {
+	c := &Controller{}
+	require.Nil(t, c.FSM)
+	for _, height := range []uint64{0, 1} {
+		t.Run(fmt.Sprintf("height %d", height), func(t *testing.T) {
+			delta, err := c.GetAccountDelta(context.Background(), height)
+			require.NotNil(t, err)
+			require.Equal(t, lib.CodeWrongBlockHeight, err.Code())
+			require.Nil(t, delta)
+		})
+	}
+}

--- a/controller/block.go
+++ b/controller/block.go
@@ -504,12 +504,17 @@ func (c *Controller) commitToStore(storeI lib.StoreI, qc *lib.QuorumCertificate,
 	c.log.Infof("Committed block %s at H:%d 🔒", lib.BytesToTruncatedString(qc.BlockHash), height)
 	// set up the finite state machine for the next height
 	c.FSM, err = fsm.New(c.Config, storeI, c.Plugin, c.Metrics, c.log)
-	return err
+	if err != nil {
+		// exit with error
+		return err
+	}
+	return nil
 }
 
 // INTERNAL HELPERS BELOW
 
-// ApplyAndValidateBlock() plays the block against the state machine which returns a result that is compared against the candidate block header
+// ApplyAndValidateBlock() plays the block against the state machine which returns a result
+// that is compared against the candidate block header.
 func (c *Controller) ApplyAndValidateBlock(block *lib.Block, commit bool) (b *lib.BlockResult, err lib.ErrorI) {
 	// define convenience variables for the block header, hash, and height
 	candidate, candidateHash, candidateHeight := block.BlockHeader, lib.BytesToString(block.BlockHeader.Hash), block.BlockHeader.Height
@@ -521,7 +526,7 @@ func (c *Controller) ApplyAndValidateBlock(block *lib.Block, commit bool) (b *li
 	// log the start of 'apply block'
 	c.log.Debugf("Applying block %s for height %d", candidateHash[:20], candidateHeight)
 	// apply the block against the state machine
-	compare, results, err := c.FSM.ApplyBlock(context.Background(), block, false)
+	compare, results, err := c.FSM.ApplyBlock(context.Background(), block, false, nil, false)
 	if err != nil {
 		// exit with error
 		return

--- a/controller/controller.go
+++ b/controller/controller.go
@@ -42,9 +42,10 @@ type Controller struct {
 	RCManager   lib.RCManagerI                     // the data manager for the 'root chain'
 	Plugin      *lib.Plugin                        // extensible plugin for FSM
 	checkpoints map[uint64]map[uint64]lib.HexBytes // cached checkpoints loaded from file
-	isSyncing   *atomic.Bool                       // is the chain currently being downloaded from peers
-	log         lib.LoggerI                        // object for logging
-	*sync.Mutex                                    // mutex for thread safety
+
+	isSyncing   *atomic.Bool // is the chain currently being downloaded from peers
+	log         lib.LoggerI  // object for logging
+	*sync.Mutex              // mutex for thread safety
 }
 
 // New() creates a new instance of a Controller, this is the entry point when initializing an instance of a Canopy application

--- a/controller/tx.go
+++ b/controller/tx.go
@@ -306,7 +306,7 @@ func (m *Mempool) CheckMempool() (err lib.ErrorI) {
 	}
 	// apply the block to the mempool FSM to get the result and validate the transactions
 	applyBlockStartTime := time.Now()
-	block.BlockHeader, result, err = m.FSM.ApplyBlock(ctx, block, true)
+	block.BlockHeader, result, err = m.FSM.ApplyBlock(ctx, block, true, nil, false)
 	applyBlockDuration := time.Since(applyBlockStartTime)
 	if m.metrics != nil {
 		m.metrics.ProposalApplyBlockTime.Observe(applyBlockDuration.Seconds())

--- a/fsm/account_change.go
+++ b/fsm/account_change.go
@@ -1,0 +1,114 @@
+package fsm
+
+import (
+	"bytes"
+
+	"github.com/canopy-network/canopy/lib"
+)
+
+// accountKeyPrefix is AccountPrefix() computed once: the hooks in StateMachine.Set/Delete
+// run this prefix compare on every write of a live block application, and AccountPrefix()
+// allocates a fresh slice per call (lib.JoinLenPrefix). Safe to hoist because the source
+// accountPrefix byte slice is a package var that is never mutated.
+var accountKeyPrefix = AccountPrefix()
+
+// AccountChangeEntry is one account touched during a single ApplyBlock call.
+// PrevValue is nil if the account did not exist at height-1 (the pre-block baseline).
+// FinalValue is nil if the account was deleted by the end of the block.
+type AccountChangeEntry struct {
+	Address    []byte
+	PrevValue  []byte
+	FinalValue []byte
+}
+
+// AccountDelta is one block's classified account changes: added (didn't exist at
+// height-1), changed (existed with a different value), and removed (existed at height-1,
+// deleted by end of block). One unit so the three identically-typed slices can't be
+// transposed across a call boundary.
+type AccountDelta struct {
+	Added   []*AccountChangeEntry
+	Changed []*AccountChangeEntry
+	Removed []*AccountChangeEntry
+}
+
+// AccountChangeCollector accumulates every account write/delete during a single
+// ApplyBlock call, keyed by address, classifying each against the pre-block (height-1)
+// baseline. The baseline is captured on first touch only — before any of this block's own
+// writes can shadow it. Only ever runs during a throwaway replay (StateMachine.ReplayBlock),
+// never during a real commit, so a failure here fails one RPC request, not consensus.
+type AccountChangeCollector struct {
+	getPrevValue func(key []byte) ([]byte, lib.ErrorI)
+	entries      map[string]*AccountChangeEntry
+}
+
+// NewAccountChangeCollector takes a lookup callback (StateMachine.Get bound to the
+// FSM instance being hooked) used to fetch each touched account's pre-block value.
+func NewAccountChangeCollector(getPrevValue func(key []byte) ([]byte, lib.ErrorI)) *AccountChangeCollector {
+	return &AccountChangeCollector{
+		getPrevValue: getPrevValue,
+		entries:      make(map[string]*AccountChangeEntry),
+	}
+}
+
+// RecordSet records an account write. key includes AccountPrefix(); value is the
+// account's already-marshalled bytes (matches SetAccount's `bz` argument to Set).
+func (c *AccountChangeCollector) RecordSet(key, value []byte) lib.ErrorI {
+	entry, err := c.entryFor(key)
+	if err != nil {
+		return err
+	}
+	entry.FinalValue = append([]byte(nil), value...)
+	return nil
+}
+
+// RecordDelete records an account deletion. key includes AccountPrefix().
+func (c *AccountChangeCollector) RecordDelete(key []byte) lib.ErrorI {
+	entry, err := c.entryFor(key)
+	if err != nil {
+		return err
+	}
+	entry.FinalValue = nil
+	return nil
+}
+
+func (c *AccountChangeCollector) entryFor(key []byte) (*AccountChangeEntry, lib.ErrorI) {
+	addrKey := string(key)
+	if entry, ok := c.entries[addrKey]; ok {
+		return entry, nil
+	}
+	// key is accountKeyPrefix followed by a length-prefixed address segment
+	// (KeyForAccount uses lib.JoinLenPrefix(accountPrefix, addr.Bytes())), so skip
+	// the prefix plus the address segment's own 1-byte length prefix. Checked before the
+	// baseline read so a malformed key fails without a wasted store Get.
+	if len(key) < len(accountKeyPrefix)+1 {
+		return nil, ErrInvalidKey(key)
+	}
+	prevValue, err := c.getPrevValue(key)
+	if err != nil {
+		return nil, err
+	}
+	address := append([]byte(nil), key[len(accountKeyPrefix)+1:]...)
+	entry := &AccountChangeEntry{Address: address, PrevValue: prevValue}
+	c.entries[addrKey] = entry
+	return entry, nil
+}
+
+// Results classifies every touched account into added/changed/removed. An account
+// touched but net-unchanged (set then deleted, or set to its existing value) is
+// dropped from all three lists.
+func (c *AccountChangeCollector) Results() *AccountDelta {
+	delta := new(AccountDelta)
+	for _, e := range c.entries {
+		switch {
+		case e.PrevValue == nil && e.FinalValue == nil:
+			continue
+		case e.PrevValue == nil:
+			delta.Added = append(delta.Added, e)
+		case e.FinalValue == nil:
+			delta.Removed = append(delta.Removed, e)
+		case !bytes.Equal(e.PrevValue, e.FinalValue):
+			delta.Changed = append(delta.Changed, e)
+		}
+	}
+	return delta
+}

--- a/fsm/account_change_test.go
+++ b/fsm/account_change_test.go
@@ -1,0 +1,144 @@
+// fsm/account_change_test.go
+package fsm
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/canopy-network/canopy/lib"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAccountChangeCollector_NewAccountIsAdded(t *testing.T) {
+	getPrev := func(key []byte) ([]byte, lib.ErrorI) { return nil, nil } // didn't exist before
+	c := NewAccountChangeCollector(getPrev)
+	address := newTestAddress(t)
+	key := KeyForAccount(address)
+	require.NoError(t, c.RecordSet(key, []byte("v1")))
+	delta := c.Results()
+	require.NotNil(t, delta)
+	added, changed, removed := delta.Added, delta.Changed, delta.Removed
+	require.Len(t, added, 1)
+	require.Empty(t, changed)
+	require.Empty(t, removed)
+	require.Equal(t, address.Bytes(), added[0].Address)
+	require.Equal(t, []byte("v1"), added[0].FinalValue)
+	require.Nil(t, added[0].PrevValue)
+}
+
+func TestAccountChangeCollector_ExistingAccountIsChanged(t *testing.T) {
+	getPrev := func(key []byte) ([]byte, lib.ErrorI) { return []byte("old"), nil }
+	c := NewAccountChangeCollector(getPrev)
+	address := newTestAddress(t)
+	key := KeyForAccount(address)
+	require.NoError(t, c.RecordSet(key, []byte("new")))
+	delta := c.Results()
+	require.NotNil(t, delta)
+	added, changed, removed := delta.Added, delta.Changed, delta.Removed
+	require.Empty(t, added)
+	require.Len(t, changed, 1)
+	require.Empty(t, removed)
+	require.Equal(t, []byte("old"), changed[0].PrevValue)
+	require.Equal(t, []byte("new"), changed[0].FinalValue)
+}
+
+func TestAccountChangeCollector_SetSameValueIsNotChanged(t *testing.T) {
+	getPrev := func(key []byte) ([]byte, lib.ErrorI) { return []byte("same"), nil }
+	c := NewAccountChangeCollector(getPrev)
+	address := newTestAddress(t)
+	key := KeyForAccount(address)
+	require.NoError(t, c.RecordSet(key, []byte("same")))
+	delta := c.Results()
+	require.NotNil(t, delta)
+	added, changed, removed := delta.Added, delta.Changed, delta.Removed
+	require.Empty(t, added)
+	require.Empty(t, changed)
+	require.Empty(t, removed)
+}
+
+func TestAccountChangeCollector_DeleteExistingAccountIsRemoved(t *testing.T) {
+	getPrev := func(key []byte) ([]byte, lib.ErrorI) { return []byte("old"), nil }
+	c := NewAccountChangeCollector(getPrev)
+	address := newTestAddress(t)
+	key := KeyForAccount(address)
+	require.NoError(t, c.RecordDelete(key))
+	delta := c.Results()
+	require.NotNil(t, delta)
+	added, changed, removed := delta.Added, delta.Changed, delta.Removed
+	require.Empty(t, added)
+	require.Empty(t, changed)
+	require.Len(t, removed, 1)
+	require.Equal(t, []byte("old"), removed[0].PrevValue)
+	require.Nil(t, removed[0].FinalValue)
+}
+
+func TestAccountChangeCollector_SetThenDeleteSameBlockIsNetNoOp(t *testing.T) {
+	// account existed before this block (SetAccount's zero-balance path deletes an
+	// account that was created and zeroed out within the same block).
+	getPrev := func(key []byte) ([]byte, lib.ErrorI) { return nil, nil }
+	c := NewAccountChangeCollector(getPrev)
+	address := newTestAddress(t)
+	key := KeyForAccount(address)
+	require.NoError(t, c.RecordSet(key, []byte("v1")))
+	require.NoError(t, c.RecordDelete(key))
+	delta := c.Results()
+	require.NotNil(t, delta)
+	added, changed, removed := delta.Added, delta.Changed, delta.Removed
+	require.Empty(t, added)
+	require.Empty(t, changed)
+	require.Empty(t, removed)
+}
+
+func TestAccountChangeCollector_MultipleTouchesUseHeight1Baseline(t *testing.T) {
+	// two writes to the same account within a block must classify against the
+	// pre-block baseline, not the mid-block intermediate value.
+	getPrevCalls := 0
+	getPrev := func(key []byte) ([]byte, lib.ErrorI) {
+		getPrevCalls++
+		return []byte("baseline"), nil
+	}
+	c := NewAccountChangeCollector(getPrev)
+	address := newTestAddress(t)
+	key := KeyForAccount(address)
+	require.NoError(t, c.RecordSet(key, []byte("intermediate")))
+	require.NoError(t, c.RecordSet(key, []byte("final")))
+	require.Equal(t, 1, getPrevCalls, "baseline should only be fetched once, on first touch")
+	delta := c.Results()
+	require.NotNil(t, delta)
+	added, changed, removed := delta.Added, delta.Changed, delta.Removed
+	require.Empty(t, added)
+	require.Len(t, changed, 1)
+	require.Empty(t, removed)
+	require.Equal(t, []byte("baseline"), changed[0].PrevValue)
+	require.Equal(t, []byte("final"), changed[0].FinalValue)
+}
+
+// TestAccountChangeCollector_GetPrevErrorPropagates: the collector only ever runs during a
+// throwaway on-demand replay (never a real block commit, see StateMachine.ApplyBlock), so
+// an internal failure is a plain propagated error like any other Set/Delete failure.
+func TestAccountChangeCollector_GetPrevErrorPropagates(t *testing.T) {
+	getPrevErr := lib.ErrUnmarshal(errors.New("test"))
+	getPrev := func(key []byte) ([]byte, lib.ErrorI) { return nil, getPrevErr }
+	c := NewAccountChangeCollector(getPrev)
+	address := newTestAddress(t)
+	key := KeyForAccount(address)
+	err := c.RecordSet(key, []byte("v1"))
+	require.Error(t, err)
+	require.Equal(t, getPrevErr.Error(), err.Error())
+}
+
+// TestAccountChangeCollector_TooShortKeyErrorsWithoutPanic guards entryFor's slice bound:
+// a key that carries AccountPrefix() but is too short to also contain the address segment's
+// length-prefix byte must return an error, not panic.
+func TestAccountChangeCollector_TooShortKeyErrorsWithoutPanic(t *testing.T) {
+	getPrev := func(key []byte) ([]byte, lib.ErrorI) { return nil, nil }
+	c := NewAccountChangeCollector(getPrev)
+	// exactly AccountPrefix() with nothing appended -- too short to contain the address
+	// segment's own 1-byte length prefix, let alone an address.
+	key := append([]byte(nil), AccountPrefix()...)
+	var err lib.ErrorI
+	require.NotPanics(t, func() {
+		err = c.RecordSet(key, []byte("v1"))
+	})
+	require.Error(t, err)
+}

--- a/fsm/indexer.go
+++ b/fsm/indexer.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"slices"
 	"time"
 
 	"github.com/canopy-network/canopy/lib"
@@ -13,26 +14,33 @@ import (
 
 // INDEXER.GO IS ONLY USED FOR CANOPY INDEXING RPC - NOT A CRITICAL PIECE OF THE STATE MACHINE
 
-// IndexerBlob() retrieves the protobuf blobs for a blockchain indexer
+// IndexerBlobs() retrieves the protobuf blobs for a blockchain indexer.
+//
+// Deprecated: this does a full account prefix scan of both Current and Previous state.
+// Use the RPC IndexerBlobsCached fast path instead, which sources the account delta
+// from Controller.GetAccountDelta rather than scanning.
 func (s *StateMachine) IndexerBlobs(ctx context.Context, height uint64) (b *IndexerBlobs, err lib.ErrorI) {
 	b = &IndexerBlobs{}
 	// IndexerBlob(height) is only valid for height >= 2 (it pairs state@height with block height-1).
 	// Therefore "previous" exists only when (height-1) >= 2, i.e. height >= 3.
 	if height > 2 {
-		b.Previous, err = s.IndexerBlob(ctx, height-1)
+		b.Previous, err = s.IndexerBlob(ctx, height-1, false)
 		if err != nil {
 			return nil, err
 		}
 	}
-	b.Current, err = s.IndexerBlob(ctx, height)
+	b.Current, err = s.IndexerBlob(ctx, height, false)
 	if err != nil {
 		return nil, err
 	}
 	return
 }
 
-// IndexerBlob() retrieves the protobuf blobs for a blockchain indexer
-func (s *StateMachine) IndexerBlob(ctx context.Context, height uint64) (b *IndexerBlob, err lib.ErrorI) {
+// IndexerBlob() retrieves the protobuf blobs for a blockchain indexer.
+// skipAccounts, if true, leaves Accounts nil instead of doing the full accounts scan below -
+// used when the caller (IndexerBlobsCached) is going to source the account delta separately
+// via Controller.GetAccountDelta.
+func (s *StateMachine) IndexerBlob(ctx context.Context, height uint64, skipAccounts bool) (b *IndexerBlob, err lib.ErrorI) {
 	if height == 0 || height > s.height {
 		height = s.height
 	}
@@ -70,12 +78,15 @@ func (s *StateMachine) IndexerBlob(ctx context.Context, height uint64) (b *Index
 		return nil, lib.ErrWrongBlockHeight(block.BlockHeader.Height, blockHeight)
 	}
 	// use sm for consistent snapshot reads at the requested height
-	// retrieve the accounts
-	stepStart = time.Now()
-	accounts, err := sm.IterateAndAppend(ctx, AccountPrefix())
-	s.Metrics.ObserveIndexerBlobStep("accounts_iterate", stepStart)
-	if err != nil {
-		return nil, err
+	// retrieve the accounts, unless the caller is sourcing them separately (see skipAccounts doc)
+	var accounts [][]byte
+	if !skipAccounts {
+		stepStart = time.Now()
+		accounts, err = sm.IterateAndAppend(ctx, AccountPrefix())
+		s.Metrics.ObserveIndexerBlobStep("accounts_iterate", stepStart)
+		if err != nil {
+			return nil, err
+		}
 	}
 	// retrieve pools
 	stepStart = time.Now()
@@ -505,6 +516,153 @@ func forceIncludeKeys(
 			previousInclude[key] = struct{}{}
 		}
 	}
+}
+
+// RewardSlashAccountKeys() exposes the reward/slash force-include address set that
+// DeltaIndexerBlobs derives from the current block. Collector-sourced callers need it
+// because a reward or slash frequently moves stake rather than writing the named account,
+// so the account never appears in the collector's results — yet the full-scan path always
+// emitted it on both sides. Returned keys are raw address bytes as map-string keys.
+func RewardSlashAccountKeys(blockBz []byte) (map[string]struct{}, lib.ErrorI) {
+	return rewardSlashAccountKeys(blockBz)
+}
+
+// AccountEntriesAtVersion() reads the raw stored account bytes for the given addresses at a
+// state version, skipping any address with no account there. The returned slices are
+// copies: the snapshot is discarded before returning, so handing back store-owned
+// buffers would be a use-after-free hazard.
+func (s *StateMachine) AccountEntriesAtVersion(version uint64, addresses map[string]struct{}) (map[string][]byte, lib.ErrorI) {
+	out := make(map[string][]byte, len(addresses))
+	if len(addresses) == 0 {
+		return out, nil
+	}
+	sm, err := s.TimeMachine(version)
+	if err != nil {
+		return nil, err
+	}
+	// TimeMachine returns the receiver itself when it cannot build a historical view;
+	// discarding that would blow away the live state machine's transaction
+	if sm != s {
+		defer sm.Discard()
+	}
+	for address := range addresses {
+		bz, e := sm.Get(KeyForAccount(crypto.NewAddressFromBytes([]byte(address))))
+		if e != nil {
+			return nil, e
+		}
+		if len(bz) == 0 {
+			continue
+		}
+		out[address] = append([]byte(nil), bz...)
+	}
+	return out, nil
+}
+
+// AssembleAccountDeltaSides converts a collector-sourced AccountDelta into the two
+// wire-ready account sides an indexer-blob delta carries, reproducing the reward/slash
+// force-include (see RewardSlashAccountKeys) and the ascending-by-address ordering the
+// full-scan diff provided for free — the sides are cached and served to every caller, so
+// unsorted map order would make the same height return different bytes across nodes.
+// currentBlockBz is the current side's marshalled BlockResult; currentVersion is the
+// state version the current side represents (the previous side is currentVersion-1).
+func (s *StateMachine) AssembleAccountDeltaSides(delta *AccountDelta, currentBlockBz []byte, currentVersion uint64) (currentSide, previousSide [][]byte, err lib.ErrorI) {
+	if delta == nil {
+		delta = new(AccountDelta)
+	}
+	forced, err := RewardSlashAccountKeys(currentBlockBz)
+	if err != nil {
+		return nil, nil, err
+	}
+	// current side: added+changed as their FINAL values (state@currentVersion)
+	current := accountSide(delta.Added, delta.Changed, true)
+	if err = s.forceIncludeAccounts(current, forced, currentVersion); err != nil {
+		return nil, nil, err
+	}
+	// previous side: changed+removed as their PREVIOUS values (state@currentVersion-1)
+	previous := accountSide(delta.Changed, delta.Removed, false)
+	if err = s.forceIncludeAccounts(previous, forced, currentVersion-1); err != nil {
+		return nil, nil, err
+	}
+	return sortedAccountEntries(current), sortedAccountEntries(previous), nil
+}
+
+// forceIncludeAccounts() reads back any forced address missing from a side and adds it, at
+// the state version that side represents. Addresses with no account at that version are
+// skipped, matching forceIncludeKeys' rule.
+func (s *StateMachine) forceIncludeAccounts(side map[string][]byte, forced map[string]struct{}, version uint64) lib.ErrorI {
+	missing := make(map[string]struct{}, len(forced))
+	for address := range forced {
+		if _, ok := side[address]; !ok {
+			missing[address] = struct{}{}
+		}
+	}
+	// avoid the TimeMachine snapshot entirely on the common "nothing to force-include" path
+	if len(missing) == 0 {
+		return nil
+	}
+	entries, err := s.AccountEntriesAtVersion(version, missing)
+	if err != nil {
+		return err
+	}
+	for address, bz := range entries {
+		side[address] = bz
+	}
+	return nil
+}
+
+// accountSide() collects one delta side's accounts, keyed by address so a force-included
+// entry cannot duplicate an address the collector already reported. useFinal selects
+// FinalValue (current side) vs PrevValue (previous side). Values are copied, never
+// aliased: the result lands in the shared RPC blob cache, so referencing the caller's
+// backing arrays would let a mutation there corrupt the cache for all readers.
+func accountSide(a, b []*AccountChangeEntry, useFinal bool) map[string][]byte {
+	side := make(map[string][]byte, len(a)+len(b))
+	collect := func(entries []*AccountChangeEntry) {
+		for _, e := range entries {
+			if e == nil {
+				continue
+			}
+			value := e.FinalValue
+			if !useFinal {
+				value = e.PrevValue
+			}
+			if value == nil {
+				continue
+			}
+			side[string(e.Address)] = append([]byte(nil), value...)
+		}
+	}
+	collect(a)
+	collect(b)
+	return side
+}
+
+// sortedAccountEntries() flattens an address-keyed account set into the ascending-by-address
+// [][]byte wire shape IndexerBlob.Accounts uses. Addresses are fixed-width, so ordering by
+// raw address bytes matches the KeyForAccount storage order the old prefix scan produced.
+func sortedAccountEntries(side map[string][]byte) [][]byte {
+	addresses := make([]string, 0, len(side))
+	for address := range side {
+		addresses = append(addresses, address)
+	}
+	slices.Sort(addresses)
+	out := make([][]byte, 0, len(addresses))
+	for _, address := range addresses {
+		out = append(out, side[address])
+	}
+	return out
+}
+
+// IndexerBlobWithoutAccounts returns blob with its Accounts nil'd, via a structural copy
+// when needed -- the input may be a shared cached blob that must never be mutated (see
+// cloneIndexerBlob's sharing semantics). A blob already without accounts is returned as-is.
+func IndexerBlobWithoutAccounts(blob *IndexerBlob) *IndexerBlob {
+	if blob == nil || blob.Accounts == nil {
+		return blob
+	}
+	out := cloneIndexerBlob(blob)
+	out.Accounts = nil
+	return out
 }
 
 // rewardSlashAccountKeys() finds reward/slash event addresses in the current block.

--- a/fsm/indexer.go
+++ b/fsm/indexer.go
@@ -3,6 +3,7 @@ package fsm
 import (
 	"bytes"
 	"errors"
+	"time"
 
 	"github.com/canopy-network/canopy/lib"
 	"github.com/canopy-network/canopy/lib/codec"
@@ -43,7 +44,9 @@ func (s *StateMachine) IndexerBlob(height uint64) (b *IndexerBlob, err lib.Error
 		return nil, lib.ErrWrongBlockHeight(0, 1)
 	}
 	blockHeight := height - 1
+	stepStart := time.Now()
 	sm, err := s.TimeMachine(height)
+	s.Metrics.ObserveIndexerBlobStep("time_machine", stepStart)
 	if err != nil {
 		return nil, err
 	}
@@ -53,7 +56,9 @@ func (s *StateMachine) IndexerBlob(height uint64) (b *IndexerBlob, err lib.Error
 	// Use the snapshot store (not the live store) for all height-based indexer reads.
 	st := sm.store.(lib.StoreI)
 	// retrieve the block, transactions, and events
+	stepStart = time.Now()
 	block, err := st.GetBlockByHeight(blockHeight)
+	s.Metrics.ObserveIndexerBlobStep("block_fetch", stepStart)
 	if err != nil {
 		return nil, err
 	}
@@ -65,82 +70,114 @@ func (s *StateMachine) IndexerBlob(height uint64) (b *IndexerBlob, err lib.Error
 	}
 	// use sm for consistent snapshot reads at the requested height
 	// retrieve the accounts
+	stepStart = time.Now()
 	accounts, err := sm.IterateAndAppend(AccountPrefix())
+	s.Metrics.ObserveIndexerBlobStep("accounts_iterate", stepStart)
 	if err != nil {
 		return nil, err
 	}
 	// retrieve pools
+	stepStart = time.Now()
 	pools, err := sm.IterateAndAppend(PoolPrefix())
+	s.Metrics.ObserveIndexerBlobStep("pools_iterate", stepStart)
 	if err != nil {
 		return nil, err
 	}
 	// retrieve validators
+	stepStart = time.Now()
 	validators, err := sm.IterateAndAppend(ValidatorPrefix())
+	s.Metrics.ObserveIndexerBlobStep("validators_iterate", stepStart)
 	if err != nil {
 		return nil, err
 	}
 	// retrieve dex prices
+	stepStart = time.Now()
 	dexPrices, err := sm.GetDexPrices()
+	s.Metrics.ObserveIndexerBlobStep("dex_prices_get", stepStart)
 	if err != nil {
 		return nil, err
 	}
 	// retrieve nonSigners
+	stepStart = time.Now()
 	nonSigners, err := sm.IterateAndAppend(NonSignerPrefix())
+	s.Metrics.ObserveIndexerBlobStep("non_signers_iterate", stepStart)
 	if err != nil {
 		return nil, err
 	}
 	// retrieve doubleSigners
+	stepStart = time.Now()
 	doubleSigners, err := st.GetDoubleSignersAsOf(blockHeight)
+	s.Metrics.ObserveIndexerBlobStep("double_signers_get", stepStart)
 	if err != nil {
 		return nil, err
 	}
 	// retrieve per-block non-signers from the committed QC for this block
+	stepStart = time.Now()
 	blockNonSigners, err := sm.blockNonSignerAddresses(blockHeight)
+	s.Metrics.ObserveIndexerBlobStep("block_non_signers_get", stepStart)
 	if err != nil {
 		blockNonSigners = nil
 	}
 	// retrieve orders
+	stepStart = time.Now()
 	orderBooks, err := sm.GetOrderBooks()
+	s.Metrics.ObserveIndexerBlobStep("order_books_get", stepStart)
 	if err != nil {
 		return nil, err
 	}
 	// retrieve params
+	stepStart = time.Now()
 	params, err := sm.GetParams()
+	s.Metrics.ObserveIndexerBlobStep("params_get", stepStart)
 	if err != nil {
 		return nil, err
 	}
 	// retrieve dex batches
+	stepStart = time.Now()
 	dexBatches, err := sm.IterateAndAppend(lib.JoinLenPrefix(dexPrefix, lockedBatchSegment))
+	s.Metrics.ObserveIndexerBlobStep("dex_batches_iterate", stepStart)
 	if err != nil {
 		return nil, err
 	}
 	// retrieve next dex batches
+	stepStart = time.Now()
 	nextDexBatches, err := sm.IterateAndAppend(lib.JoinLenPrefix(dexPrefix, nextBatchSement))
+	s.Metrics.ObserveIndexerBlobStep("next_dex_batches_iterate", stepStart)
 	if err != nil {
 		return nil, err
 	}
 	// get the CommitteesData bytes under 'committees data prefix'
+	stepStart = time.Now()
 	committeesData, err := sm.Get(CommitteesDataPrefix())
+	s.Metrics.ObserveIndexerBlobStep("committees_data_get", stepStart)
 	if err != nil {
 		return nil, err
 	}
 	// get subsidized committees
+	stepStart = time.Now()
 	subsidizedCommittees, err := sm.GetSubsidizedCommittees()
+	s.Metrics.ObserveIndexerBlobStep("subsidized_committees_get", stepStart)
 	if err != nil {
 		return nil, err
 	}
 	// get retired committees
+	stepStart = time.Now()
 	retiredCommittees, err := sm.GetRetiredCommittees()
+	s.Metrics.ObserveIndexerBlobStep("retired_committees_get", stepStart)
 	if err != nil {
 		return nil, err
 	}
 	// get the supply tracker bytes from the state
+	stepStart = time.Now()
 	supply, err := sm.Get(SupplyPrefix())
+	s.Metrics.ObserveIndexerBlobStep("supply_get", stepStart)
 	if err != nil {
 		return nil, err
 	}
 	// marshal block to bytes
+	stepStart = time.Now()
 	blockBz, err := lib.Marshal(block)
+	s.Metrics.ObserveIndexerBlobStep("block_marshal", stepStart)
 	if err != nil {
 		return nil, err
 	}

--- a/fsm/indexer.go
+++ b/fsm/indexer.go
@@ -289,6 +289,9 @@ func DeltaIndexerBlobs(blobs *IndexerBlobs) (*IndexerBlobs, lib.ErrorI) {
 	previous := nilSafeBlob(out.Previous)
 
 	// accounts: changed+added in current, changed+removed in previous
+	// currentAccounts/previousAccounts come from a Pebble prefix scan over AccountPrefix(),
+	// so both are already ascending by address bytes - accountEntryKey extracts that same
+	// address as the raw key, so entry order matches key order and the merge walk is safe.
 	currentAccounts, currentAccountMap, err := accountEntries(out.Current.Accounts)
 	if err != nil {
 		return nil, err
@@ -297,7 +300,7 @@ func DeltaIndexerBlobs(blobs *IndexerBlobs) (*IndexerBlobs, lib.ErrorI) {
 	if err != nil {
 		return nil, err
 	}
-	currentAccountKeys, previousAccountKeys := changedBlobKeys(currentAccountMap, previousAccountMap)
+	currentAccountKeys, previousAccountKeys := mergeChangedBlobKeys(currentAccounts, previousAccounts)
 	forcedAccountKeys, err := rewardSlashAccountKeys(out.Current.Block)
 	if err != nil {
 		return nil, err
@@ -309,6 +312,10 @@ func DeltaIndexerBlobs(blobs *IndexerBlobs) (*IndexerBlobs, lib.ErrorI) {
 	}
 
 	// pools: changed+added in current, changed+removed in previous
+	// NOT converted to the sorted merge walk: poolEntryKey extracts Pool.Id's raw varint
+	// wire bytes, but the Pebble storage key (KeyForPool) encodes Id big-endian - the two
+	// orderings diverge at varint length boundaries (e.g. id 16383 vs 16384), so entry order
+	// here does not reliably match key order. Map-based diff stays correct regardless of order.
 	currentPools, currentPoolMap, err := poolEntries(out.Current.Pools)
 	if err != nil {
 		return nil, err
@@ -324,6 +331,8 @@ func DeltaIndexerBlobs(blobs *IndexerBlobs) (*IndexerBlobs, lib.ErrorI) {
 	}
 
 	// validators: changed+added in current, changed+removed in previous
+	// Same order guarantee as accounts: validatorEntries' key is the unmarshalled
+	// validator.Address, matching KeyForValidator's raw address bytes.
 	currentValidators, currentValidatorMap, currentOutputIndex, err := validatorEntries(out.Current.Validators)
 	if err != nil {
 		return nil, err
@@ -332,7 +341,7 @@ func DeltaIndexerBlobs(blobs *IndexerBlobs) (*IndexerBlobs, lib.ErrorI) {
 	if err != nil {
 		return nil, err
 	}
-	currentValidatorKeys, previousValidatorKeys := changedBlobKeys(currentValidatorMap, previousValidatorMap)
+	currentValidatorKeys, previousValidatorKeys := mergeChangedBlobKeys(currentValidators, previousValidators)
 	forcedValidatorKeys, err := validatorForceKeys(out.Current.Block, currentOutputIndex, previousOutputIndex)
 	if err != nil {
 		return nil, err
@@ -414,6 +423,41 @@ func accountEntryKey(entry []byte) (string, error) {
 
 func poolEntryKey(entry []byte) (string, error) {
 	return entryKeyOrZero(entry) // Pool.id
+}
+
+// mergeChangedBlobKeys() is changedBlobKeys' sorted-input equivalent: current and previous
+// must each be ascending by key (true for a Pebble prefix-scan result - see call sites).
+// A two-pointer merge walk finds the same added/changed/removed keys as the map-based
+// version without hashing every key into a map[string][]byte first.
+func mergeChangedBlobKeys(current, previous []blobEntry) (map[string]struct{}, map[string]struct{}) {
+	currentChanged := make(map[string]struct{})
+	previousChanged := make(map[string]struct{})
+	i, j := 0, 0
+	for i < len(current) && j < len(previous) {
+		c, p := current[i], previous[j]
+		switch {
+		case c.key < p.key:
+			currentChanged[c.key] = struct{}{}
+			i++
+		case c.key > p.key:
+			previousChanged[p.key] = struct{}{}
+			j++
+		default:
+			if !bytes.Equal(c.bz, p.bz) {
+				currentChanged[c.key] = struct{}{}
+				previousChanged[p.key] = struct{}{}
+			}
+			i++
+			j++
+		}
+	}
+	for ; i < len(current); i++ {
+		currentChanged[current[i].key] = struct{}{}
+	}
+	for ; j < len(previous); j++ {
+		previousChanged[previous[j].key] = struct{}{}
+	}
+	return currentChanged, previousChanged
 }
 
 func changedBlobKeys(current, previous map[string][]byte) (map[string]struct{}, map[string]struct{}) {

--- a/fsm/indexer.go
+++ b/fsm/indexer.go
@@ -2,6 +2,7 @@ package fsm
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"time"
 
@@ -13,17 +14,17 @@ import (
 // INDEXER.GO IS ONLY USED FOR CANOPY INDEXING RPC - NOT A CRITICAL PIECE OF THE STATE MACHINE
 
 // IndexerBlob() retrieves the protobuf blobs for a blockchain indexer
-func (s *StateMachine) IndexerBlobs(height uint64) (b *IndexerBlobs, err lib.ErrorI) {
+func (s *StateMachine) IndexerBlobs(ctx context.Context, height uint64) (b *IndexerBlobs, err lib.ErrorI) {
 	b = &IndexerBlobs{}
 	// IndexerBlob(height) is only valid for height >= 2 (it pairs state@height with block height-1).
 	// Therefore "previous" exists only when (height-1) >= 2, i.e. height >= 3.
 	if height > 2 {
-		b.Previous, err = s.IndexerBlob(height - 1)
+		b.Previous, err = s.IndexerBlob(ctx, height-1)
 		if err != nil {
 			return nil, err
 		}
 	}
-	b.Current, err = s.IndexerBlob(height)
+	b.Current, err = s.IndexerBlob(ctx, height)
 	if err != nil {
 		return nil, err
 	}
@@ -31,7 +32,7 @@ func (s *StateMachine) IndexerBlobs(height uint64) (b *IndexerBlobs, err lib.Err
 }
 
 // IndexerBlob() retrieves the protobuf blobs for a blockchain indexer
-func (s *StateMachine) IndexerBlob(height uint64) (b *IndexerBlob, err lib.ErrorI) {
+func (s *StateMachine) IndexerBlob(ctx context.Context, height uint64) (b *IndexerBlob, err lib.ErrorI) {
 	if height == 0 || height > s.height {
 		height = s.height
 	}
@@ -71,21 +72,21 @@ func (s *StateMachine) IndexerBlob(height uint64) (b *IndexerBlob, err lib.Error
 	// use sm for consistent snapshot reads at the requested height
 	// retrieve the accounts
 	stepStart = time.Now()
-	accounts, err := sm.IterateAndAppend(AccountPrefix())
+	accounts, err := sm.IterateAndAppend(ctx, AccountPrefix())
 	s.Metrics.ObserveIndexerBlobStep("accounts_iterate", stepStart)
 	if err != nil {
 		return nil, err
 	}
 	// retrieve pools
 	stepStart = time.Now()
-	pools, err := sm.IterateAndAppend(PoolPrefix())
+	pools, err := sm.IterateAndAppend(ctx, PoolPrefix())
 	s.Metrics.ObserveIndexerBlobStep("pools_iterate", stepStart)
 	if err != nil {
 		return nil, err
 	}
 	// retrieve validators
 	stepStart = time.Now()
-	validators, err := sm.IterateAndAppend(ValidatorPrefix())
+	validators, err := sm.IterateAndAppend(ctx, ValidatorPrefix())
 	s.Metrics.ObserveIndexerBlobStep("validators_iterate", stepStart)
 	if err != nil {
 		return nil, err
@@ -99,7 +100,7 @@ func (s *StateMachine) IndexerBlob(height uint64) (b *IndexerBlob, err lib.Error
 	}
 	// retrieve nonSigners
 	stepStart = time.Now()
-	nonSigners, err := sm.IterateAndAppend(NonSignerPrefix())
+	nonSigners, err := sm.IterateAndAppend(ctx, NonSignerPrefix())
 	s.Metrics.ObserveIndexerBlobStep("non_signers_iterate", stepStart)
 	if err != nil {
 		return nil, err
@@ -134,14 +135,14 @@ func (s *StateMachine) IndexerBlob(height uint64) (b *IndexerBlob, err lib.Error
 	}
 	// retrieve dex batches
 	stepStart = time.Now()
-	dexBatches, err := sm.IterateAndAppend(lib.JoinLenPrefix(dexPrefix, lockedBatchSegment))
+	dexBatches, err := sm.IterateAndAppend(ctx, lib.JoinLenPrefix(dexPrefix, lockedBatchSegment))
 	s.Metrics.ObserveIndexerBlobStep("dex_batches_iterate", stepStart)
 	if err != nil {
 		return nil, err
 	}
 	// retrieve next dex batches
 	stepStart = time.Now()
-	nextDexBatches, err := sm.IterateAndAppend(lib.JoinLenPrefix(dexPrefix, nextBatchSement))
+	nextDexBatches, err := sm.IterateAndAppend(ctx, lib.JoinLenPrefix(dexPrefix, nextBatchSement))
 	s.Metrics.ObserveIndexerBlobStep("next_dex_batches_iterate", stepStart)
 	if err != nil {
 		return nil, err

--- a/fsm/indexer_test.go
+++ b/fsm/indexer_test.go
@@ -144,6 +144,38 @@ func TestDeltaIndexerBlobs_KeepsBlockNonSigners(t *testing.T) {
 	require.Equal(t, previousNonSigners, delta.Previous.BlockNonSigners)
 }
 
+func TestMergeChangedBlobKeys_MatchesMapBasedDiff(t *testing.T) {
+	// sorted ascending by key, as accountEntries/validatorEntries produce from a Pebble scan
+	current := []blobEntry{
+		{key: "a", bz: []byte("a1")}, // changed
+		{key: "b", bz: []byte("b1")}, // unchanged
+		{key: "d", bz: []byte("d1")}, // added
+	}
+	previous := []blobEntry{
+		{key: "a", bz: []byte("a0")},
+		{key: "b", bz: []byte("b1")},
+		{key: "c", bz: []byte("c1")}, // removed
+	}
+
+	currentMap := map[string][]byte{"a": []byte("a1"), "b": []byte("b1"), "d": []byte("d1")}
+	previousMap := map[string][]byte{"a": []byte("a0"), "b": []byte("b1"), "c": []byte("c1")}
+
+	gotCurrentChanged, gotPreviousChanged := mergeChangedBlobKeys(current, previous)
+	wantCurrentChanged, wantPreviousChanged := changedBlobKeys(currentMap, previousMap)
+
+	require.Equal(t, wantCurrentChanged, gotCurrentChanged)
+	require.Equal(t, wantPreviousChanged, gotPreviousChanged)
+	require.Equal(t, map[string]struct{}{"a": {}, "d": {}}, gotCurrentChanged)
+	require.Equal(t, map[string]struct{}{"a": {}, "c": {}}, gotPreviousChanged)
+}
+
+func TestMergeChangedBlobKeys_EmptyPrevious(t *testing.T) {
+	current := []blobEntry{{key: "a", bz: []byte("a1")}, {key: "b", bz: []byte("b1")}}
+	gotCurrentChanged, gotPreviousChanged := mergeChangedBlobKeys(current, nil)
+	require.Equal(t, map[string]struct{}{"a": {}, "b": {}}, gotCurrentChanged)
+	require.Empty(t, gotPreviousChanged)
+}
+
 func mustMarshalProto(t *testing.T, message any) []byte {
 	t.Helper()
 	bz, err := lib.Marshal(message)

--- a/fsm/indexer_test.go
+++ b/fsm/indexer_test.go
@@ -2,9 +2,12 @@ package fsm
 
 import (
 	"bytes"
+	"context"
 	"testing"
+	"time"
 
 	"github.com/canopy-network/canopy/lib"
+	"github.com/canopy-network/canopy/lib/crypto"
 	"github.com/stretchr/testify/require"
 )
 
@@ -176,6 +179,498 @@ func TestMergeChangedBlobKeys_EmptyPrevious(t *testing.T) {
 	require.Empty(t, gotPreviousChanged)
 }
 
+// TestAccountDelta_MatchesOldFullScanAndDiff is the differential regression test for the
+// account-delta fast path: it runs the old path (full scan of both heights, diffed by
+// DeltaIndexerBlobs) and the new path (single-block replay with a collector, assembled by
+// AssembleAccountDeltaSides) against the same committed chain, requiring byte-for-byte,
+// order-for-order equality of both sides. Neither expectation is hand-seeded.
+//
+// Limitation: this chain runs on the root chain, so it does not exercise the nested-chain
+// root-DEX-batch restore (that lives in controller.GetAccountDelta and cannot be reached
+// from an fsm-package test) — the equivalence proven here covers root-chain blocks only.
+func TestAccountDelta_MatchesOldFullScanAndDiff(t *testing.T) {
+	sm, targetHeight := newTestAccountDeltaChain(t)
+	ctx := context.Background()
+
+	// OLD PATH: full account scan at both heights, diffed by DeltaIndexerBlobs
+	oldCurrent, err := sm.IndexerBlob(ctx, targetHeight, false)
+	require.NoError(t, err)
+	oldPrevious, err := sm.IndexerBlob(ctx, targetHeight-1, false)
+	require.NoError(t, err)
+	oldDelta, err := DeltaIndexerBlobs(&IndexerBlobs{Current: oldCurrent, Previous: oldPrevious})
+	require.NoError(t, err)
+
+	// NEW PATH: replay the single block whose application moved state from targetHeight-1 to
+	// targetHeight, capturing touched accounts. Mirrors controller.GetAccountDelta's replay
+	// branch (block read from the live store, pre-state from TimeMachine(blockHeight),
+	// collector baselined on the snapshot, skipRoot=true, never committed).
+	blockHeight := targetHeight - 1
+	blockResult, err := sm.store.(lib.StoreI).GetBlockByHeight(blockHeight)
+	require.NoError(t, err)
+	require.NotNil(t, blockResult)
+	block, err := blockResult.ToBlock()
+	require.NoError(t, err)
+	replaySM, err := sm.TimeMachine(blockHeight)
+	require.NoError(t, err)
+	require.NotSame(t, sm, replaySM, "TimeMachine must produce a real snapshot, not the live FSM")
+	defer replaySM.Discard()
+	require.Equal(t, blockHeight, replaySM.Height())
+	collector := NewAccountChangeCollector(replaySM.Get)
+	_, applyResult, err := replaySM.ReplayBlock(ctx, block, collector)
+	require.NoError(t, err)
+	require.Empty(t, applyResult.Failed)
+	delta := collector.Results()
+	require.NotNil(t, delta)
+
+	// sanity-check the fixture actually produced the scenarios it claims to, so a chain that
+	// silently stopped exercising them can't turn this into a vacuous empty-vs-empty compare
+	require.NotEmpty(t, delta.Added, "fixture must produce at least one brand-new account")
+	require.NotEmpty(t, delta.Changed, "fixture must produce at least one changed account")
+	require.NotEmpty(t, delta.Removed, "fixture must produce at least one removed (zeroed) account")
+
+	// ...and that the force-include path has real work to do: the block must emit a
+	// reward event naming an address the collector never saw written, so both assemblies
+	// have to read that account back rather than derive it from the replay
+	forced, err := RewardSlashAccountKeys(oldCurrent.Block)
+	require.NoError(t, err)
+	require.NotEmpty(t, forced, "fixture must emit a reward/slash event")
+	touched := make(map[string]struct{})
+	for _, entries := range [][]*AccountChangeEntry{delta.Added, delta.Changed, delta.Removed} {
+		for _, e := range entries {
+			touched[string(e.Address)] = struct{}{}
+		}
+	}
+	for address := range forced {
+		require.NotContains(t, touched, address,
+			"the forced address must be untouched by the block, or the read-back never runs")
+	}
+
+	// assemble both sides through the REAL production code cmd/rpc serves through
+	newCurrent, newPrevious, err := sm.AssembleAccountDeltaSides(delta, oldCurrent.Block, targetHeight)
+	require.NoError(t, err)
+
+	// exact ordered equality: both paths are ascending-by-address (the old side comes from an
+	// ascending Pebble prefix scan, the new one from sortedAccountEntries), so ElementsMatch
+	// would silently tolerate an ordering regression that changes the cached response bytes.
+	require.Equal(t, oldDelta.Current.Accounts, newCurrent)
+	require.Equal(t, oldDelta.Previous.Accounts, newPrevious)
+}
+
+// TestAccountDelta_EmptyBlockOnlyMovesRewardAccounts extends the differential test to an
+// EMPTY block: block 6 carries no transactions, so its only account movement comes from the
+// automatic reward machinery (QC5 pays validator #3, which is non-compounding, so the tokens
+// land on its OUTPUT account -- key group 0). The fast path must classify exactly that
+// movement and still match the old full-scan-and-diff byte for byte.
+func TestAccountDelta_EmptyBlockOnlyMovesRewardAccounts(t *testing.T) {
+	sm, _ := newTestAccountDeltaChain(t)
+	// block 6: empty
+	testApplyAndCommitBlock(t, sm, nil)
+	targetHeight := sm.height
+	ctx := context.Background()
+
+	// OLD PATH: full account scan at both heights, diffed by DeltaIndexerBlobs
+	oldCurrent, err := sm.IndexerBlob(ctx, targetHeight, false)
+	require.NoError(t, err)
+	oldPrevious, err := sm.IndexerBlob(ctx, targetHeight-1, false)
+	require.NoError(t, err)
+	oldDelta, err := DeltaIndexerBlobs(&IndexerBlobs{Current: oldCurrent, Previous: oldPrevious})
+	require.NoError(t, err)
+
+	// NEW PATH: replay the empty block with a collector (same recipe as the main test)
+	blockHeight := targetHeight - 1
+	blockResult, err := sm.store.(lib.StoreI).GetBlockByHeight(blockHeight)
+	require.NoError(t, err)
+	require.NotNil(t, blockResult)
+	block, err := blockResult.ToBlock()
+	require.NoError(t, err)
+	replaySM, err := sm.TimeMachine(blockHeight)
+	require.NoError(t, err)
+	defer replaySM.Discard()
+	collector := NewAccountChangeCollector(replaySM.Get)
+	_, applyResult, err := replaySM.ReplayBlock(ctx, block, collector)
+	require.NoError(t, err)
+	require.Empty(t, applyResult.Failed)
+	delta := collector.Results()
+	require.NotNil(t, delta)
+
+	// an empty block adds and removes nothing; the only movement is the reward payout to
+	// validator #3's output account (key group 0)
+	require.Empty(t, delta.Added)
+	require.Empty(t, delta.Removed)
+	require.NotEmpty(t, delta.Changed, "the reward payout must move at least one account")
+	for _, e := range delta.Changed {
+		require.Equal(t, newTestAddressBytes(t), e.Address,
+			"an empty block may only move the reward output account")
+	}
+
+	// assemble through the REAL production code and require byte-for-byte equality
+	newCurrent, newPrevious, err := sm.AssembleAccountDeltaSides(delta, oldCurrent.Block, targetHeight)
+	require.NoError(t, err)
+	require.Equal(t, oldDelta.Current.Accounts, newCurrent)
+	require.Equal(t, oldDelta.Previous.Accounts, newPrevious)
+}
+
+// AccountEntriesAtVersion must silently skip a forced address with no account at that
+// version -- matching forceIncludeKeys' rule that a forced key is only included on a side
+// where the account actually exists
+func TestAccountEntriesAtVersion_SkipsMissingAccounts(t *testing.T) {
+	sm, _ := newTestApplyBlockFixture(t)
+	st := sm.store.(lib.StoreI)
+	funded := newTestAddressBytes(t) // AccountAdd(newTestAddress(t), 2) in the fixture
+	missing := bytes.Repeat([]byte{0xEE}, crypto.AddressSize)
+	entries, err := sm.AccountEntriesAtVersion(st.Version(), map[string]struct{}{
+		string(funded):  {},
+		string(missing): {},
+	})
+	require.NoError(t, err)
+	require.Len(t, entries, 1)
+	require.NotContains(t, entries, string(missing), "an address with no account must be skipped, not emitted empty")
+	require.Equal(t, mustMarshalProto(t, &Account{Address: funded, Amount: 2}), entries[string(funded)])
+}
+
+// accountSide must never mutate or alias the slices it is handed: GetAccountDelta can return
+// the tip-cache entry's slices (see controller/account_delta_cache.go), and the assembled
+// result is stored in the RPC blob cache and served to every later caller
+func TestAccountSide_DoesNotMutateOrAliasInputs(t *testing.T) {
+	added := []*AccountChangeEntry{{Address: []byte("a"), FinalValue: []byte("af")}}
+	changed := []*AccountChangeEntry{{Address: []byte("b"), PrevValue: []byte("bp"), FinalValue: []byte("bf")}}
+	// spare capacity: an append-in-place would write through into the shared backing array
+	removed := make([]*AccountChangeEntry, 1, 4)
+	removed[0] = &AccountChangeEntry{Address: []byte("c"), PrevValue: []byte("cp")}
+
+	require.Equal(t, [][]byte{[]byte("af"), []byte("bf")}, sortedAccountEntries(accountSide(added, changed, true)))
+	require.Equal(t, [][]byte{[]byte("bp"), []byte("cp")}, sortedAccountEntries(accountSide(changed, removed, false)))
+
+	require.Len(t, added, 1)
+	require.Len(t, changed, 1)
+	require.Len(t, removed, 1)
+	require.Equal(t, []byte("af"), added[0].FinalValue)
+	require.Equal(t, []byte("bp"), changed[0].PrevValue)
+	require.Equal(t, []byte("bf"), changed[0].FinalValue)
+	require.Equal(t, []byte("cp"), removed[0].PrevValue)
+	require.Equal(t, 4, cap(removed), "the input slice's backing array must be untouched")
+
+	// the emitted bytes must be copies -- mutating them must not reach back into the entries
+	out := sortedAccountEntries(accountSide(added, nil, true))
+	require.Len(t, out, 1)
+	out[0][0] = 'X'
+	require.Equal(t, []byte("af"), added[0].FinalValue, "the result must not alias the entry's bytes")
+}
+
+// AccountChangeCollector.Results() ranges a Go map, so the entries arrive in random order;
+// the wire format must still be ascending by address, because the assembled bytes are cached
+// and served to every later caller and an unstable order would make the same height return
+// different bytes across calls and across nodes
+func TestAccountSide_SortsByAddressAscending(t *testing.T) {
+	entries := []*AccountChangeEntry{
+		{Address: []byte{0x03}, FinalValue: []byte("c")},
+		{Address: []byte{0x01}, FinalValue: []byte("a")},
+		{Address: []byte{0x02}, FinalValue: []byte("b")},
+	}
+	require.Equal(t,
+		[][]byte{[]byte("a"), []byte("b"), []byte("c")},
+		sortedAccountEntries(accountSide(entries, nil, true)),
+	)
+}
+
+// the input may be a shared cached blob, so stripping accounts must NEVER mutate it —
+// a copy is returned when there is something to strip, and the copy shares everything else
+func TestIndexerBlobWithoutAccounts(t *testing.T) {
+	require.Nil(t, IndexerBlobWithoutAccounts(nil))
+
+	// a blob already without accounts is returned as-is (no pointless copy)
+	noAccounts := &IndexerBlob{Pools: [][]byte{[]byte("p")}}
+	require.Same(t, noAccounts, IndexerBlobWithoutAccounts(noAccounts))
+
+	// a blob with accounts yields a copy with them stripped, original untouched
+	withAccounts := &IndexerBlob{
+		Accounts: [][]byte{[]byte("acc")},
+		Pools:    [][]byte{[]byte("p")},
+		Block:    []byte("blk"),
+	}
+	stripped := IndexerBlobWithoutAccounts(withAccounts)
+	require.NotSame(t, withAccounts, stripped)
+	require.Nil(t, stripped.Accounts)
+	require.Equal(t, [][]byte{[]byte("acc")}, withAccounts.Accounts, "the shared cached blob must never be mutated")
+	// the copy shares the other payloads (structural copy, not a deep clone)
+	require.Equal(t, withAccounts.Pools, stripped.Pools)
+	require.Equal(t, withAccounts.Block, stripped.Block)
+}
+
+// newTestAccountDeltaChain builds a real committed chain (ApplyBlock + Commit per block,
+// starting from newTestApplyBlockFixture) and returns the state machine plus the target
+// state version to diff. newTestApplyBlockFixture leaves sm.height=3 but store version 2,
+// so the helper commits once to align them before driving blocks 3, 4 and 5.
+//
+// Block 5 — the one the returned target height (6) diffs — exercises:
+//   - a brand-new account (added)
+//   - a balance change to an existing account (changed), sender and recipient
+//   - a net-unchanged account: a zero-fee self-send (must be dropped from both sides)
+//   - an account zeroed out, which deletes the key (removed)
+//   - a reward event naming an address the block never writes (non-compounding validator,
+//     tokens land on its output account) — the force-include must read it back on both sides
+func newTestAccountDeltaChain(t *testing.T) (*StateMachine, uint64) {
+	t.Helper()
+	fixture, _ := newTestApplyBlockFixture(t)
+	sm := &fixture
+	st := sm.store.(lib.StoreI)
+	// newTestApplyBlockFixture hand-sets sm.NetworkID rather than deriving it from Config, but
+	// TimeMachine builds its snapshot FSM through newStateMachine, which sets
+	// NetworkID = Config.P2PConfig.NetworkID. Left as-is, every transaction in the replayed
+	// block would fail the replay's network-id check -- a fixture artifact, not a production
+	// one (a live node derives both from the same config). Align them here -- on the config
+	// side, since a network id of 0 is rejected outright as "nil network id".
+	sm.Config.P2PConfig.NetworkID = uint64(sm.NetworkID)
+	// align the store version with sm.height (see the height convention note above)
+	_, e := st.Commit()
+	require.NoError(t, e)
+	require.Equal(t, sm.height, st.Version())
+
+	// send fee of zero, so the net-unchanged self-send below really is net-unchanged
+	require.NoError(t, sm.UpdateParam("fee", ParamSendFee, &lib.UInt64Wrapper{Value: 0}))
+	// funder pays for everything downstream
+	require.NoError(t, sm.AccountAdd(newTestAddress(t), 10_000_000))
+	// block 3: no transactions -- it exists so block 4's BeginBlock has a real committed
+	// predecessor block and certificate to load
+	testApplyAndCommitBlock(t, sm, nil)
+
+	// block 4: fund the accounts block 5 will change / zero / self-send
+	testApplyAndCommitBlock(t, sm, [][]byte{
+		testSendTxBytes(t, sm, 0, newTestAddress(t, 4), 5_000), // net-unchanged self-sender
+		testSendTxBytes(t, sm, 0, newTestAddress(t, 5), 3_000), // zeroed out in block 5
+		testSendTxBytes(t, sm, 0, newTestAddress(t, 6), 2_000), // changed in block 5
+		testSendTxBytes(t, sm, 0, newTestAddress(t, 3), 4_000), // reward-event recipient; untouched by block 5
+	})
+
+	// block 5: the measured block
+	brandNew := crypto.NewAddressFromBytes(bytes.Repeat([]byte{0xAB}, crypto.AddressSize))
+	testApplyAndCommitBlock(t, sm, [][]byte{
+		testSendTxBytes(t, sm, 0, brandNew, 1_500),             // brandNew added; kg0 changed
+		testSendTxBytes(t, sm, 6, newTestAddress(t, 7), 1_000), // kg6 changed; kg7 added (never funded)
+		testSendTxBytes(t, sm, 4, newTestAddress(t, 4), 5_000), // kg4 self-send: touched, net-unchanged
+		testSendTxBytes(t, sm, 5, newTestAddress(t, 6), 3_000), // kg5 sends its whole balance -> removed
+	})
+
+	// sm.height is now 6 and the store holds versions up to 6 with blocks 2..5 indexed, so
+	// both IndexerBlob(6) (state@6 + block 5) and IndexerBlob(5) (state@5 + block 4) resolve
+	return sm, sm.height
+}
+
+// TestAccountDelta_PoolAndValidatorWritesDoNotLeakIntoAccountCollector proves that when a
+// REAL applied block writes POOL and VALIDATOR entries alongside ACCOUNT entries, the
+// AccountChangeCollector captures only the account addresses.
+// TestStateMachine_SetDoesNotHookNonAccountKeys (fsm/state_test.go) already proves prefix
+// isolation at the Set() call level with a single hand-written write; this test's distinct
+// value is the integration level -- pool and validator writes here happen as a side effect of
+// the real BeginBlock/EndBlock committee-reward machinery (ApplyBlock), not a direct Set call.
+func TestAccountDelta_PoolAndValidatorWritesDoNotLeakIntoAccountCollector(t *testing.T) {
+	sm, targetHeight, validatorAddress := newTestPoolAndValidatorTouchingChain(t)
+	ctx := context.Background()
+
+	blockHeight := targetHeight - 1
+	blockResult, err := sm.store.(lib.StoreI).GetBlockByHeight(blockHeight)
+	require.NoError(t, err)
+	require.NotNil(t, blockResult)
+	block, err := blockResult.ToBlock()
+	require.NoError(t, err)
+	replaySM, err := sm.TimeMachine(blockHeight)
+	require.NoError(t, err)
+	defer replaySM.Discard()
+
+	// snapshot pre-state DAO pool balance and validator #3's stake from the SAME snapshot the
+	// replay below runs against, before ApplyBlock mutates it
+	prePool, err := replaySM.GetPool(lib.DAOPoolID)
+	require.NoError(t, err)
+	preValidator, err := replaySM.GetValidator(crypto.NewAddressFromBytes(validatorAddress))
+	require.NoError(t, err)
+
+	collector := NewAccountChangeCollector(replaySM.Get)
+	_, applyResult, err := replaySM.ReplayBlock(ctx, block, collector)
+	require.NoError(t, err)
+	require.Empty(t, applyResult.Failed)
+
+	// verify -- don't assume -- that the block genuinely wrote both a pool and a validator
+	// entry. The DAO pool is minted into every block unconditionally (FundCommitteeRewardPools,
+	// never debited back down), so a strict increase proves a real SetPool call happened, not
+	// just a Set(sameValue) no-op. Validator #3 was made compounding by the fixture below, so
+	// its committee reward in this block updates StakedAmount via UpdateValidatorStake ->
+	// SetValidator instead of the default non-compounding AccountAdd-to-output path -- a strict
+	// increase proves that write happened too. If the fixture regressed to stop touching either,
+	// this would fail instead of silently asserting nothing.
+	postPool, err := replaySM.GetPool(lib.DAOPoolID)
+	require.NoError(t, err)
+	require.Greater(t, postPool.Amount, prePool.Amount,
+		"fixture must actually mint into the DAO pool during the measured block")
+	postValidator, err := replaySM.GetValidator(crypto.NewAddressFromBytes(validatorAddress))
+	require.NoError(t, err)
+	require.Greater(t, postValidator.StakedAmount, preValidator.StakedAmount,
+		"fixture must actually write validator #3's stake (compounding reward) in the measured block")
+
+	delta := collector.Results()
+	require.NotNil(t, delta)
+	all := append(append(append([]*AccountChangeEntry{}, delta.Added...), delta.Changed...), delta.Removed...)
+	require.NotEmpty(t, all, "fixture must also touch at least one account, or this test can't distinguish account entries from a leak")
+
+	for _, e := range all {
+		// weak alone (a validator address is also crypto.AddressSize bytes), but catches a
+		// pool-prefix leak: pool keys carry no address-shaped payload at all, so a
+		// bytes.HasPrefix(k, PoolPrefix()) regression would produce garbage-length
+		// "addresses" here rather than passing silently
+		require.Len(t, e.Address, crypto.AddressSize, "captured entries must be account-sized addresses")
+
+		// catches a validator-prefix leak specifically, which the length check above cannot:
+		// validator #3's address is proven (above) to have been written in this very block, so
+		// if the hook regressed to also match bytes.HasPrefix(k, ValidatorPrefix()), that
+		// address would show up here -- assert it never does
+		require.NotEqual(t, validatorAddress, e.Address, "validator address must not leak into the account collector")
+
+		// positive check: every captured address must round-trip to the real KeyForAccount
+		// entry, proving it genuinely is an account key rather than merely address-shaped bytes
+		// living under some other prefix
+		key := KeyForAccount(crypto.NewAddressFromBytes(e.Address))
+		bz, gErr := replaySM.Get(key)
+		require.NoError(t, gErr)
+		if e.FinalValue != nil {
+			require.Equal(t, e.FinalValue, bz, "captured added/changed entry must match the live KeyForAccount value")
+		} else {
+			require.Empty(t, bz, "captured removed entry must correspond to an actually-deleted account key")
+		}
+	}
+}
+
+// newTestPoolAndValidatorTouchingChain builds a real committed chain (same base pattern as
+// newTestAccountDeltaChain) whose measured block writes an account (a send tx), a pool
+// (the automatic committee-reward mint every block) and a validator (a compounding
+// committee-reward payout, which routes through SetValidator instead of an account write).
+//
+// Validator #3, the certificate's reward recipient, is flipped to Compound=true before
+// block 4 is applied so the flip lands in the state@4 snapshot that block 5's replay reads.
+func newTestPoolAndValidatorTouchingChain(t *testing.T) (sm *StateMachine, targetHeight uint64, validatorAddress []byte) {
+	t.Helper()
+	fixture, _ := newTestApplyBlockFixture(t)
+	sm = &fixture
+	st := sm.store.(lib.StoreI)
+	sm.Config.P2PConfig.NetworkID = uint64(sm.NetworkID)
+	_, e := st.Commit()
+	require.NoError(t, e)
+	require.Equal(t, sm.height, st.Version())
+
+	require.NoError(t, sm.UpdateParam("fee", ParamSendFee, &lib.UInt64Wrapper{Value: 0}))
+	require.NoError(t, sm.AccountAdd(newTestAddress(t), 10_000_000))
+	// block 3: no transactions -- exists so block 4's BeginBlock has a real committed
+	// predecessor block and certificate to load
+	testApplyAndCommitBlock(t, sm, nil)
+
+	validator3, err := sm.GetValidator(newTestAddress(t, 3))
+	require.NoError(t, err)
+	require.False(t, validator3.Compound, "fixture assumption: validator #3 starts non-compounding")
+	validator3.Compound = true
+	require.NoError(t, sm.SetValidator(validator3))
+
+	// block 4: no new transactions of its own -- indexes the certificate (paying validator #3)
+	// that block 5's BeginBlock consumes
+	testApplyAndCommitBlock(t, sm, nil)
+
+	// block 5: the measured block. A send tx touches accounts; BeginBlock's automatic DAO pool
+	// mint and validator #3's now-compounding committee reward (from block 4's certificate)
+	// touch a pool and a validator in the same pass.
+	testApplyAndCommitBlock(t, sm, [][]byte{
+		testSendTxBytes(t, sm, 0, newTestAddress(t, 7), 1_000),
+	})
+
+	return sm, sm.height, newTestAddressBytes(t, 3)
+}
+
+// testApplyAndCommitBlock applies a block at sm.height with the given transactions, indexes
+// the resulting BlockResult and a signed certificate for that height, commits the store, and
+// advances the state machine -- the same order controller.CommitCertificate uses (apply,
+// IndexQC, IndexBlock, Commit, re-init FSM at the new version).
+func testApplyAndCommitBlock(t *testing.T, sm *StateMachine, txs [][]byte) {
+	t.Helper()
+	st := sm.store.(lib.StoreI)
+	height := sm.height
+	block := &lib.Block{
+		BlockHeader: &lib.BlockHeader{
+			Height:          height,
+			Time:            uint64(time.Date(2024, 02, 01, 0, 0, 0, 0, time.UTC).UnixMicro()) + height*1_000_000,
+			ProposerAddress: newTestAddressBytes(t),
+		},
+		Transactions: txs,
+	}
+	header, result, err := sm.ApplyBlock(context.Background(), block, false, nil, false)
+	require.NoError(t, err)
+	for _, f := range result.Failed {
+		t.Logf("FAILED TX at height %d: %s", height, f.Error.Error())
+	}
+	require.Empty(t, result.Failed, "block at height %d had failed transactions", height)
+	require.NoError(t, st.IndexQC(testAccountDeltaQC(t, sm, height)))
+	require.NoError(t, st.IndexBlock(&lib.BlockResult{
+		BlockHeader:  header,
+		Transactions: result.Results,
+		Events:       result.Events,
+	}))
+	_, e := st.Commit()
+	require.NoError(t, e)
+	sm.height++
+	sm.Reset()
+	require.Equal(t, sm.height, st.Version())
+}
+
+// testAccountDeltaQC builds a certificate for `height` signed by 3 of the fixture's 4
+// validators -- mirroring the QC newTestApplyBlockFixture indexes for height 2, but with the
+// chain ids it omits (see below). BeginBlock loads the previous height's certificate, so
+// every applied block needs one indexed for its own height.
+func testAccountDeltaQC(t *testing.T, sm *StateMachine, height uint64) *lib.QuorumCertificate {
+	t.Helper()
+	qc := &lib.QuorumCertificate{
+		// ChainId is what keys the committee data HandleCertificateResults updates and
+		// DistributeCommitteeRewards later pays out from -- without it the rewards land on
+		// committee 0, whose pool is never subsidized, and no reward event is ever emitted
+		Header: &lib.View{Height: height, ChainId: lib.CanopyChainId},
+		// PaymentPercents.ChainId must be set: CommitteeData.Combine drops every stub whose
+		// ChainId doesn't match, so an unset one silently yields no reward and no event.
+		// The recipient is validator #3, which takes part in no transaction below and is
+		// non-compounding -- so the reward is written to the validator's OUTPUT account (key
+		// group 0) while the reward EVENT names validator #3. That is exactly the
+		// force-include case: an address the collector never sees written, which both delta
+		// sides must nonetheless carry.
+		Results: &lib.CertificateResult{RewardRecipients: &lib.RewardRecipients{
+			PaymentPercents: []*lib.PaymentPercents{{
+				Address: newTestAddressBytes(t, 3),
+				Percent: 100,
+				ChainId: lib.CanopyChainId,
+			}},
+		}},
+	}
+	committee, err := sm.GetCommitteeMembers(lib.CanopyChainId)
+	require.NoError(t, err)
+	mk := committee.MultiKey.Copy()
+	for i := 0; i < 3; i++ {
+		privateKey := newTestKeyGroup(t, i).PrivateKey
+		for j, pubKey := range mk.PublicKeys() {
+			if privateKey.PublicKey().Equals(pubKey) {
+				require.NoError(t, mk.AddSigner(privateKey.Sign(qc.SignBytes()), j))
+			}
+		}
+	}
+	aggSig, e := mk.AggregateSignatures()
+	require.NoError(t, e)
+	qc.Signature = &lib.AggregateSignature{Signature: aggSig, Bitmap: mk.Bitmap()}
+	return qc
+}
+
+// testSendTxBytes builds a signed send transaction from test key group `fromKeyGroup`, valid
+// at the state machine's current height, with a zero fee (see newTestAccountDeltaChain).
+func testSendTxBytes(t *testing.T, sm *StateMachine, fromKeyGroup int, to crypto.AddressI, amount uint64) []byte {
+	t.Helper()
+	kg := newTestKeyGroup(t, fromKeyGroup)
+	tx, err := NewSendTransaction(kg.PrivateKey, to, amount, uint64(sm.NetworkID), sm.Config.ChainId, 0, sm.height, "")
+	require.NoError(t, err)
+	bz, err := lib.Marshal(tx)
+	require.NoError(t, err)
+	return bz
+}
+
 func mustMarshalProto(t *testing.T, message any) []byte {
 	t.Helper()
 	bz, err := lib.Marshal(message)
@@ -194,6 +689,31 @@ func requireEntriesAsSet(t *testing.T, got [][]byte, expected ...[]byte) {
 		expSet[string(entry)]++
 	}
 	require.Equal(t, expSet, gotSet)
+}
+
+// TestIndexerBlob_SkipAccountsLeavesAccountsNil and TestIndexerBlob_NoSkipStillScansAccounts
+// use newTestApplyBlockFixture (fsm/state_test.go) - the real helper used elsewhere in this
+// package to build a StateMachine with a committed block (height 2, indexed via IndexBlock)
+// and a funded account (via AccountAdd), then sm.height set to 3 and the store committed.
+// That leaves the state machine ready for IndexerBlob(ctx, 3, ...) without needing to
+// actually call ApplyBlock: the fixture's committed state at height 3 already pairs with
+// the indexed block at height 2 (blockHeight = height - 1), and its funded account guarantees
+// the accounts scan (when not skipped) has at least one real entry to assert on.
+func TestIndexerBlob_SkipAccountsLeavesAccountsNil(t *testing.T) {
+	sm, _ := newTestApplyBlockFixture(t)
+	blob, err := sm.IndexerBlob(context.Background(), 3, true)
+	require.NoError(t, err)
+	require.Nil(t, blob.Accounts)
+}
+
+func TestIndexerBlob_NoSkipStillScansAccounts(t *testing.T) {
+	sm, _ := newTestApplyBlockFixture(t)
+	blob, err := sm.IndexerBlob(context.Background(), 3, false)
+	require.NoError(t, err)
+	// the fixture funds an account via AccountAdd before committing, so the full scan
+	// (skipAccounts=false) must find and return it - a meaningful assertion rather than
+	// a vacuous non-nil check on the blob itself.
+	require.NotEmpty(t, blob.Accounts, "full scan with skipAccounts=false must still populate Accounts")
 }
 
 // TestDeltaIndexerBlobs_ZeroValuePoolAndAccount is a regression for the

--- a/fsm/state.go
+++ b/fsm/state.go
@@ -672,7 +672,9 @@ func (s *StateMachine) Iterator(key []byte) (lib.IteratorI, lib.ErrorI) {
 }
 
 // IteratorAndAppend() aggregates an array of raw bytes from an iterator
-func (s *StateMachine) IterateAndAppend(prefix []byte) (result [][]byte, err lib.ErrorI) {
+// ctx is checked every iteration so an abandoned caller (e.g. a disconnected RPC client)
+// stops this scan promptly instead of running it to completion.
+func (s *StateMachine) IterateAndAppend(ctx context.Context, prefix []byte) (result [][]byte, err lib.ErrorI) {
 	// iterate through the account prefix
 	it, err := s.Iterator(prefix)
 	if err != nil {
@@ -681,6 +683,9 @@ func (s *StateMachine) IterateAndAppend(prefix []byte) (result [][]byte, err lib
 	defer it.Close()
 	// for each item of the iterator
 	for ; it.Valid(); it.Next() {
+		if cErr := ctx.Err(); cErr != nil {
+			return nil, lib.ErrCancelled(cErr)
+		}
 		result = append(result, it.Value())
 	}
 	// return the result

--- a/fsm/state.go
+++ b/fsm/state.go
@@ -1,6 +1,7 @@
 package fsm
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"math"
@@ -38,6 +39,7 @@ type StateMachine struct {
 	cache              *cache                                  // the state machine cache
 	LastValidatorSet   map[uint64]map[uint64]*lib.ValidatorSet // reference to the last validator set saved in the controller
 	Plugin             *lib.Plugin                             // extensible plugin for the FSM
+	accountCollector   *AccountChangeCollector                 // set only during an ApplyBlock call that wants account-touch capture
 }
 
 type rootCacheStateStore interface {
@@ -137,7 +139,12 @@ func (s *StateMachine) Initialize(store lib.StoreI) (genesis bool, err lib.Error
 // NOTES:
 // - this function may be used to validate 'additional' transactions outside the normal block size as if they were to be included
 // - a list of failed transactions are returned
-func (s *StateMachine) ApplyBlock(ctx context.Context, b *lib.Block, allowOversize bool) (header *lib.BlockHeader, r *lib.ApplyBlockResults, err lib.ErrorI) {
+// collector, if non-nil, captures every account touched during this call (see
+// AccountChangeCollector) — only ever passed by ReplayBlock's on-demand replay, never by a
+// real block commit.
+// skipRoot, if true, skips store.Root() (the SMT/Merkle computation) — for throwaway
+// replay calls whose caller never inspects header.StateRoot or commits the result.
+func (s *StateMachine) ApplyBlock(ctx context.Context, b *lib.Block, allowOversize bool, collector *AccountChangeCollector, skipRoot bool) (header *lib.BlockHeader, r *lib.ApplyBlockResults, err lib.ErrorI) {
 	// catch in case there's a panic
 	defer func() {
 		if r := recover(); r != nil {
@@ -154,6 +161,9 @@ func (s *StateMachine) ApplyBlock(ctx context.Context, b *lib.Block, allowOversi
 	if !ok {
 		return nil, nil, ErrWrongStoreType()
 	}
+	// attach the account-change collector for the duration of this call only
+	s.accountCollector = collector
+	defer func() { s.accountCollector = nil }()
 	// automated execution at the 'beginning of a block'
 	beginBlockStartTime := time.Now()
 	events, err := s.BeginBlock()
@@ -201,20 +211,26 @@ func (s *StateMachine) ApplyBlock(ctx context.Context, b *lib.Block, allowOversi
 		return nil, nil, err
 	}
 	// calculate the merkle root of the state database to enable consensus on the result of the state after applying the block
-	rootWasCached := false
-	if cacheAwareStore, ok := store.(rootCacheStateStore); ok {
-		rootWasCached = cacheAwareStore.IsRootCached()
-	}
-	rootStartTime := time.Time{}
-	if !rootWasCached {
-		rootStartTime = time.Now()
-	}
-	stateRoot, err := store.Root()
-	if err != nil {
-		return nil, nil, err
-	}
-	if !rootStartTime.IsZero() {
-		s.Metrics.UpdateFSMApplyBlockRootTime(rootStartTime)
+	// skipRoot=true is only ever passed by a throwaway replay call (see Task 6) whose
+	// caller never commits and never inspects header.StateRoot/header.Hash for consensus
+	// purposes — skipping this is what removes the dominant cost of a replay-only call.
+	var stateRoot []byte
+	if !skipRoot {
+		rootWasCached := false
+		if cacheAwareStore, ok := store.(rootCacheStateStore); ok {
+			rootWasCached = cacheAwareStore.IsRootCached()
+		}
+		rootStartTime := time.Time{}
+		if !rootWasCached {
+			rootStartTime = time.Now()
+		}
+		stateRoot, err = store.Root()
+		if err != nil {
+			return nil, nil, err
+		}
+		if !rootStartTime.IsZero() {
+			s.Metrics.UpdateFSMApplyBlockRootTime(rootStartTime)
+		}
 	}
 	// load the last block from the indexer
 	lastBlock, err := s.LoadBlock(s.height - 1)
@@ -250,6 +266,14 @@ func (s *StateMachine) ApplyBlock(ctx context.Context, b *lib.Block, allowOversi
 	}
 	// exit
 	return
+}
+
+// ReplayBlock() re-applies an already-committed block against a throwaway snapshot to
+// capture its account delta: a convenience wrapper for ApplyBlock's replay-only argument
+// combo (allowOversize=false, skipRoot=true — the result is never committed and its
+// StateRoot is never inspected, so the SMT/Merkle computation is skipped).
+func (s *StateMachine) ReplayBlock(ctx context.Context, b *lib.Block, collector *AccountChangeCollector) (*lib.BlockHeader, *lib.ApplyBlockResults, lib.ErrorI) {
+	return s.ApplyBlock(ctx, b, false, collector, true)
 }
 
 // ApplyTransactions()
@@ -656,14 +680,36 @@ func (s *StateMachine) Copy() (*StateMachine, lib.ErrorI) {
 }
 
 // Set() upserts a key-value pair under a key
-func (s *StateMachine) Set(k, v []byte) (err lib.ErrorI) { return s.Store().Set(k, v) }
+func (s *StateMachine) Set(k, v []byte) (err lib.ErrorI) {
+	if s.accountCollector != nil && bytes.HasPrefix(k, accountKeyPrefix) {
+		// record BEFORE the write so the baseline read happens before this write shadows
+		// it; a collector is only ever attached during a throwaway replay (never a real
+		// commit, see ApplyBlock), so it's safe to propagate a failure here like any
+		// other error
+		if err = s.accountCollector.RecordSet(k, v); err != nil {
+			return err
+		}
+	}
+	return s.Store().Set(k, v)
+}
 
 // Get() retrieves a key-value pair under a key
 // NOTE: returns (nil, nil) if no value is found for that key
 func (s *StateMachine) Get(key []byte) (bz []byte, err lib.ErrorI) { return s.Store().Get(key) }
 
 // Delete() deletes a key-value pair under a key
-func (s *StateMachine) Delete(key []byte) lib.ErrorI { return s.Store().Delete(key) }
+func (s *StateMachine) Delete(key []byte) lib.ErrorI {
+	if s.accountCollector != nil && bytes.HasPrefix(key, accountKeyPrefix) {
+		// record BEFORE the delete so the baseline read happens before this delete shadows
+		// it; a collector is only ever attached during a throwaway replay (never a real
+		// commit, see ApplyBlock), so it's safe to propagate a failure here like any
+		// other error
+		if err := s.accountCollector.RecordDelete(key); err != nil {
+			return err
+		}
+	}
+	return s.Store().Delete(key)
+}
 
 // Iterator() creates and returns an iterator for the state machine's underlying store
 // starting at the specified key and iterating lexicographically

--- a/fsm/state_test.go
+++ b/fsm/state_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"os"
 	"slices"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -896,4 +897,60 @@ func TestConformStateToParamUpdate_MinimumStake_ViaMessageHandler(t *testing.T) 
 	val3, err := sm.GetValidator(crypto.NewAddressFromBytes(validators[3].Address))
 	require.NoError(t, err)
 	require.Equal(t, uint64(0), val3.UnstakingHeight, "delegate 3 should NOT be unstaking")
+}
+
+// countingCancelContext reports itself cancelled only after Err() has been called
+// cancelAfter times, so a test can force cancellation after a specific loop
+// iteration instead of racing a real timer.
+type countingCancelContext struct {
+	context.Context
+	cancelAfter int32
+	calls       int32
+}
+
+func (c *countingCancelContext) Err() error {
+	if atomic.AddInt32(&c.calls, 1) > c.cancelAfter {
+		return context.Canceled
+	}
+	return nil
+}
+
+func TestIterateAndAppend_AlreadyCancelled(t *testing.T) {
+	sm := newTestStateMachine(t)
+	require.NoError(t, sm.SetAccount(&Account{Address: newTestAddress(t).Bytes(), Amount: 1}))
+	require.NoError(t, sm.SetAccount(&Account{Address: newTestAddress(t, 1).Bytes(), Amount: 2}))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	result, err := sm.IterateAndAppend(ctx, AccountPrefix())
+	require.NotNil(t, err)
+	require.Equal(t, lib.CodeCancelled, err.Code())
+	require.Empty(t, result)
+}
+
+func TestIterateAndAppend_CancelledMidIterationStopsEarly(t *testing.T) {
+	sm := newTestStateMachine(t)
+	require.NoError(t, sm.SetAccount(&Account{Address: newTestAddress(t).Bytes(), Amount: 1}))
+	require.NoError(t, sm.SetAccount(&Account{Address: newTestAddress(t, 1).Bytes(), Amount: 2}))
+	require.NoError(t, sm.SetAccount(&Account{Address: newTestAddress(t, 2).Bytes(), Amount: 3}))
+
+	// cancelAfter: 1 means Err() returns nil on the first check (so the first
+	// item is yielded), then non-nil on every check after that.
+	ctx := &countingCancelContext{Context: context.Background(), cancelAfter: 1}
+
+	result, err := sm.IterateAndAppend(ctx, AccountPrefix())
+	require.NotNil(t, err)
+	require.Equal(t, lib.CodeCancelled, err.Code())
+	require.Less(t, len(result), 3, "should stop before visiting all 3 accounts")
+}
+
+func TestIterateAndAppend_NotCancelledCompletesNormally(t *testing.T) {
+	sm := newTestStateMachine(t)
+	require.NoError(t, sm.SetAccount(&Account{Address: newTestAddress(t).Bytes(), Amount: 1}))
+	require.NoError(t, sm.SetAccount(&Account{Address: newTestAddress(t, 1).Bytes(), Amount: 2}))
+
+	result, err := sm.IterateAndAppend(context.Background(), AccountPrefix())
+	require.Nil(t, err)
+	require.Len(t, result, 2)
 }

--- a/fsm/state_test.go
+++ b/fsm/state_test.go
@@ -269,7 +269,7 @@ func TestApplyBlock(t *testing.T) {
 				sm.ProtocolVersion = 1
 			}
 			// execute the function call
-			header, result, e := sm.ApplyBlock(context.Background(), test.block, false)
+			header, result, e := sm.ApplyBlock(context.Background(), test.block, false, nil, false)
 			// validate the expected error
 			require.Equal(t, test.error != "", e != nil || len(result.Failed) != 0, e)
 			if result != nil && len(result.Failed) != 0 {
@@ -285,6 +285,150 @@ func TestApplyBlock(t *testing.T) {
 			require.EqualExportedValues(t, test.expectedResults, result.Results[0])
 		})
 	}
+}
+
+// newTestApplyBlockFixture builds a state machine and a block ready for a successful
+// ApplyBlock() call containing one send-transaction that touches an account. It mirrors
+// the "successful apply block" case setup in TestApplyBlock above.
+func newTestApplyBlockFixture(t *testing.T) (StateMachine, *lib.Block) {
+	var timestamp = uint64(time.Date(2024, 02, 01, 0, 0, 0, 0, time.UTC).UnixMicro())
+	// define a key group to use in testing
+	kg := newTestKeyGroup(t)
+	// predefine a send-transaction to insert into the block
+	sendTx, err := NewSendTransaction(kg.PrivateKey, newTestAddress(t), 1, 1, 1, 1, 1, "")
+	require.NoError(t, err)
+	txn := sendTx.(*lib.Transaction)
+	// set the timestamp to a fixed time for validity checking
+	txn.Time = timestamp
+	// re-sign the tx
+	require.NoError(t, txn.Sign(kg.PrivateKey))
+	// convert the object to bytes
+	sendTxBytes, err := lib.Marshal(sendTx)
+	require.NoError(t, err)
+	block := &lib.Block{
+		BlockHeader: &lib.BlockHeader{
+			Height:          2,
+			NumTxs:          1,
+			Time:            timestamp,
+			TotalTxs:        1,
+			LastBlockHash:   crypto.Hash([]byte("block_hash")),
+			ProposerAddress: newTestAddressBytes(t),
+		},
+		Transactions: [][]byte{sendTxBytes},
+	}
+	// create a state machine instance with default parameters
+	sm := newTestStateMachine(t)
+	// preset the 'last block' in state
+	require.NoError(t, sm.store.(lib.StoreI).IndexBlock(&lib.BlockResult{
+		BlockHeader: &lib.BlockHeader{
+			Height: 2,
+			Hash:   block.BlockHeader.LastBlockHash,
+			Time:   timestamp,
+		},
+	}))
+	// set the minimum fee to 1 for send transactions
+	require.NoError(t, sm.UpdateParam("fee", ParamSendFee, &lib.UInt64Wrapper{Value: 1}))
+	// preset the account with funds
+	require.NoError(t, sm.AccountAdd(newTestAddress(t), 2))
+	qc := &lib.QuorumCertificate{
+		Header: &lib.View{Height: 2},
+		Results: &lib.CertificateResult{RewardRecipients: &lib.RewardRecipients{
+			PaymentPercents: []*lib.PaymentPercents{{
+				Address: newTestAddressBytes(t),
+				Percent: 100,
+			}},
+		}},
+	}
+	// track the supply
+	supply := &Supply{}
+	// for 4 validators
+	for i := 0; i < 4; i++ {
+		// set the validator
+		require.NoError(t, sm.SetValidators([]*Validator{{
+			Address:      newTestAddressBytes(t, i),
+			PublicKey:    newTestPublicKeyBytes(t, i),
+			StakedAmount: 100,
+			Committees:   []uint64{lib.CanopyChainId},
+			Output:       newTestAddressBytes(t),
+		}}, supply))
+		// set the committee member
+		require.NoError(t, sm.SetCommitteeMember(newTestAddress(t, i), lib.CanopyChainId, 100))
+	}
+	// set the supply in state
+	require.NoError(t, sm.SetSupply(supply))
+	// create an aggregate signature
+	// get the committee members
+	committee, er := sm.GetCommitteeMembers(lib.CanopyChainId)
+	require.NoError(t, er)
+	// create a copy of the multikey
+	mk := committee.MultiKey.Copy()
+	// only sign with 3/4 to test the non-signer reduction
+	for i := 0; i < 3; i++ {
+		privateKey := newTestKeyGroup(t, i).PrivateKey
+		// search for the proper index for the signer
+		for j, pubKey := range mk.PublicKeys() {
+			// if found, add the signer
+			if privateKey.PublicKey().Equals(pubKey) {
+				// sign the qc
+				require.NoError(t, mk.AddSigner(privateKey.Sign(qc.SignBytes()), j))
+			}
+		}
+	}
+	// aggregate the signature
+	aggSig, e := mk.AggregateSignatures()
+	require.NoError(t, e)
+	// attach the signature to the message
+	qc.Signature = &lib.AggregateSignature{
+		Signature: aggSig,
+		Bitmap:    mk.Bitmap(),
+	}
+	require.NoError(t, sm.store.(lib.StoreI).IndexQC(qc))
+	// setup for a 'last validator set' for apply block
+	sm.height = 3
+	// commit here to have a 'last validator set' for apply block
+	_, err = sm.store.(lib.StoreI).Commit()
+	require.NoError(t, err)
+	// set the protocol version to not trigger an error
+	sm.ProtocolVersion = 1
+	return sm, block
+}
+
+func TestApplyBlock_SkipRootLeavesStateRootNil(t *testing.T) {
+	sm, block := newTestApplyBlockFixture(t)
+	header, result, err := sm.ApplyBlock(context.Background(), block, false, nil, true)
+	require.NoError(t, err)
+	require.Empty(t, result.Failed)
+	require.Nil(t, header.StateRoot)
+	require.NotNil(t, header.Hash) // header must still hash successfully with an empty state root
+}
+
+func TestApplyBlock_CollectorCapturesTouchedAccounts(t *testing.T) {
+	sm, block := newTestApplyBlockFixture(t)
+	collector := NewAccountChangeCollector(sm.Get)
+	_, result, err := sm.ApplyBlock(context.Background(), block, false, collector, false)
+	require.NoError(t, err)
+	require.Empty(t, result.Failed)
+	delta := collector.Results()
+	require.NotNil(t, delta)
+	// the fixture block's single transaction is key group 0's self-send of 1 with a fee of
+	// 1: sender and recipient are the SAME account, so exactly one account changes (only
+	// the fee leaves it, 2 -> 1) and nothing is added or removed. The fixture QC carries no
+	// chain id, so no committee reward reaches any account (see testAccountDeltaQC's note).
+	require.Empty(t, delta.Added)
+	require.Empty(t, delta.Removed)
+	require.Len(t, delta.Changed, 1)
+	entry := delta.Changed[0]
+	require.Equal(t, newTestAddressBytes(t), entry.Address)
+	require.Equal(t, mustMarshalProto(t, &Account{Address: newTestAddressBytes(t), Amount: 2}), entry.PrevValue)
+	require.Equal(t, mustMarshalProto(t, &Account{Address: newTestAddressBytes(t), Amount: 1}), entry.FinalValue)
+}
+
+func TestApplyBlock_NilCollectorSkipRootFalseIsUnchanged(t *testing.T) {
+	sm, block := newTestApplyBlockFixture(t)
+	header, result, err := sm.ApplyBlock(context.Background(), block, false, nil, false)
+	require.NoError(t, err)
+	require.Empty(t, result.Failed)
+	require.NotNil(t, header.StateRoot) // unchanged default behavior
 }
 
 func TestApplyTransactions_DoesNotReturnCheckErrors(t *testing.T) {
@@ -953,4 +1097,81 @@ func TestIterateAndAppend_NotCancelledCompletesNormally(t *testing.T) {
 	result, err := sm.IterateAndAppend(context.Background(), AccountPrefix())
 	require.Nil(t, err)
 	require.Len(t, result, 2)
+}
+
+func TestStateMachine_SetHooksAccountCollector(t *testing.T) {
+	sm := newTestStateMachine(t)
+	collector := NewAccountChangeCollector(sm.Get)
+	sm.accountCollector = collector
+	address := newTestAddress(t)
+	require.NoError(t, sm.Set(KeyForAccount(address), []byte("v1")))
+	delta := collector.Results()
+	require.NotNil(t, delta)
+	added, changed, removed := delta.Added, delta.Changed, delta.Removed
+	require.Len(t, added, 1)
+	require.Empty(t, changed)
+	require.Empty(t, removed)
+	require.Equal(t, address.Bytes(), added[0].Address)
+}
+
+func TestStateMachine_DeleteHooksAccountCollector(t *testing.T) {
+	sm := newTestStateMachine(t)
+	address := newTestAddress(t)
+	// write the key directly, before the collector is attached, so it establishes a real
+	// pre-block baseline rather than being captured as part of this call
+	require.NoError(t, sm.Set(KeyForAccount(address), []byte("v1")))
+	collector := NewAccountChangeCollector(sm.Get)
+	sm.accountCollector = collector
+	require.NoError(t, sm.Delete(KeyForAccount(address)))
+	delta := collector.Results()
+	require.NotNil(t, delta)
+	added, changed, removed := delta.Added, delta.Changed, delta.Removed
+	require.Empty(t, added)
+	require.Empty(t, changed)
+	require.Len(t, removed, 1)
+	require.Equal(t, address.Bytes(), removed[0].Address)
+	require.Equal(t, []byte("v1"), removed[0].PrevValue)
+	require.Nil(t, removed[0].FinalValue)
+}
+
+func TestStateMachine_DeleteDoesNotHookNonAccountKeys(t *testing.T) {
+	sm := newTestStateMachine(t)
+	require.NoError(t, sm.Set(KeyForPool(1), []byte("v1")))
+	collector := NewAccountChangeCollector(sm.Get)
+	sm.accountCollector = collector
+	require.NoError(t, sm.Delete(KeyForPool(1)))
+	delta := collector.Results()
+	require.NotNil(t, delta)
+	added, changed, removed := delta.Added, delta.Changed, delta.Removed
+	require.Empty(t, added)
+	require.Empty(t, changed)
+	require.Empty(t, removed)
+}
+
+func TestStateMachine_DeleteNilCollectorIsNoOp(t *testing.T) {
+	sm := newTestStateMachine(t)
+	address := newTestAddress(t)
+	require.NoError(t, sm.Set(KeyForAccount(address), []byte("v1")))
+	require.Nil(t, sm.accountCollector)
+	require.NoError(t, sm.Delete(KeyForAccount(address))) // must not panic
+}
+
+func TestStateMachine_SetDoesNotHookNonAccountKeys(t *testing.T) {
+	sm := newTestStateMachine(t)
+	collector := NewAccountChangeCollector(sm.Get)
+	sm.accountCollector = collector
+	require.NoError(t, sm.Set(KeyForPool(1), []byte("v1")))
+	delta := collector.Results()
+	require.NotNil(t, delta)
+	added, changed, removed := delta.Added, delta.Changed, delta.Removed
+	require.Empty(t, added)
+	require.Empty(t, changed)
+	require.Empty(t, removed)
+}
+
+func TestStateMachine_SetNilCollectorIsNoOp(t *testing.T) {
+	sm := newTestStateMachine(t)
+	require.Nil(t, sm.accountCollector)
+	address := newTestAddress(t)
+	require.NoError(t, sm.Set(KeyForAccount(address), []byte("v1"))) // must not panic
 }

--- a/lib/error.go
+++ b/lib/error.go
@@ -350,6 +350,7 @@ const (
 	CodeHttpStatus        ErrorCode   = 7
 	CodeReadBody          ErrorCode   = 8
 	CodeStringToCommittee ErrorCode   = 9
+	CodeCancelled         ErrorCode   = 10
 )
 
 // error implementations below for the `types` package
@@ -808,6 +809,10 @@ func ErrNewStore(err error) ErrorI {
 
 func ErrTimeMachine(err error) ErrorI {
 	return NewError(CodeTimeMachine, RPCModule, fmt.Sprintf("fsm.TimeMachine() failed with err: %s", err.Error()))
+}
+
+func ErrCancelled(err error) ErrorI {
+	return NewError(CodeCancelled, RPCModule, fmt.Sprintf("request cancelled: %s", err.Error()))
 }
 
 func ErrPostRequest(err error) ErrorI {

--- a/lib/metrics.go
+++ b/lib/metrics.go
@@ -72,6 +72,20 @@ type Metrics struct {
 	FSMMetrics     // fsm telemetry
 	StoreMetrics   // persistence telemetry
 	MempoolMetrics // tx memory pool telemetry
+	IndexerMetrics // indexer-blobs rpc endpoint telemetry
+}
+
+// IndexerMetrics represents telemetry for the /v1/query/indexer-blobs RPC endpoint and its cache.
+type IndexerMetrics struct {
+	IndexerBlobColdReadTime prometheus.Histogram // how long does an indexer-blobs cache-miss (cold store read) take?
+	IndexerBlobCacheHits    prometheus.Counter   // how many indexer-blobs requests were served from cache?
+	IndexerBlobCacheMisses  prometheus.Counter   // how many indexer-blobs requests required a cold store read?
+	IndexerBlobCacheSize    prometheus.Gauge     // how many entries are currently in the indexer-blobs cache?
+	// IndexerBlobStepTime breaks the cold read down by step (time_machine, block_fetch,
+	// accounts_iterate, ... -- see fsm/indexer.go), most of which are direct pebbledb
+	// reads/iterations at a historical version. Lets a slow cold read be attributed to
+	// the specific store call responsible instead of only seeing the total.
+	IndexerBlobStepTime *prometheus.HistogramVec
 }
 
 // NodeMetrics represents general telemetry for the node's health
@@ -686,6 +700,29 @@ func NewMetricsServer(nodeAddress crypto.AddressI, chainID float64, softwareVers
 				Help: "Execution time of NewCertificateResults during CheckMempool proposal building",
 			}),
 		},
+		// INDEXER
+		IndexerMetrics: IndexerMetrics{
+			IndexerBlobColdReadTime: promauto.NewHistogram(prometheus.HistogramOpts{
+				Name: "canopy_indexer_blob_cold_read_time",
+				Help: "The time it takes to serve an indexer-blobs request that misses the cache (cold store read)",
+			}),
+			IndexerBlobCacheHits: promauto.NewCounter(prometheus.CounterOpts{
+				Name: "canopy_indexer_blob_cache_hits_total",
+				Help: "Total indexer-blobs requests served from the in-memory cache",
+			}),
+			IndexerBlobCacheMisses: promauto.NewCounter(prometheus.CounterOpts{
+				Name: "canopy_indexer_blob_cache_misses_total",
+				Help: "Total indexer-blobs requests that required a cold store read",
+			}),
+			IndexerBlobCacheSize: promauto.NewGauge(prometheus.GaugeOpts{
+				Name: "canopy_indexer_blob_cache_size",
+				Help: "Current number of entries in the indexer-blobs cache",
+			}),
+			IndexerBlobStepTime: promauto.NewHistogramVec(prometheus.HistogramOpts{
+				Name: "canopy_indexer_blob_step_time",
+				Help: "The time each step of an indexer-blobs cold read takes, by step name",
+			}, []string{"step"}),
+		},
 	}
 }
 
@@ -918,6 +955,44 @@ func (m *Metrics) UpdateStoreJobMetrics(LSScompactionTime, HSSCompactionTime, ba
 		// update the backup time metric
 		m.DBBackupTime.Observe(backupTime.Seconds())
 	}
+}
+
+// RecordIndexerBlobCacheHit() records an indexer-blobs request served from cache.
+func (m *Metrics) RecordIndexerBlobCacheHit() {
+	// exit if empty
+	if m == nil {
+		return
+	}
+	m.IndexerBlobCacheHits.Inc()
+}
+
+// RecordIndexerBlobCacheMiss() records an indexer-blobs request that required a cold store read
+// and how long that read took.
+func (m *Metrics) RecordIndexerBlobCacheMiss(startTime time.Time) {
+	// exit if empty
+	if m == nil || startTime.IsZero() {
+		return
+	}
+	m.IndexerBlobCacheMisses.Inc()
+	m.IndexerBlobColdReadTime.Observe(time.Since(startTime).Seconds())
+}
+
+// UpdateIndexerBlobCacheSize() updates the current entry count of the indexer-blobs cache.
+func (m *Metrics) UpdateIndexerBlobCacheSize(size int) {
+	// exit if empty
+	if m == nil {
+		return
+	}
+	m.IndexerBlobCacheSize.Set(float64(size))
+}
+
+// ObserveIndexerBlobStep() records how long a single step of an indexer-blobs cold read took.
+func (m *Metrics) ObserveIndexerBlobStep(step string, startTime time.Time) {
+	// exit if empty
+	if m == nil || startTime.IsZero() {
+		return
+	}
+	m.IndexerBlobStepTime.WithLabelValues(step).Observe(time.Since(startTime).Seconds())
 }
 
 // UpdateStoreRootTime() updates the time it took to compute an uncached store root.

--- a/lib/metrics.go
+++ b/lib/metrics.go
@@ -4,9 +4,11 @@ import (
 	"bytes"
 	"context"
 	"net/http"
+	"strconv"
 	"time"
 
 	"github.com/canopy-network/canopy/lib/crypto"
+	"github.com/cockroachdb/pebble/v2"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
@@ -81,6 +83,13 @@ type IndexerMetrics struct {
 	IndexerBlobCacheHits    prometheus.Counter   // how many indexer-blobs requests were served from cache?
 	IndexerBlobCacheMisses  prometheus.Counter   // how many indexer-blobs requests required a cold store read?
 	IndexerBlobCacheSize    prometheus.Gauge     // how many entries are currently in the indexer-blobs cache?
+	// IndexerBlobPreviousReuseHits/Misses track a distinct reuse path from IndexerBlobCacheHits/Misses:
+	// on a cache miss for `height`, the "previous" (height-1) blob is either reused from the prior
+	// request's already-cached `current` (hit) or requires its own fresh cold read (miss). This is
+	// invisible to IndexerBlobCacheHits/Misses, which only tracks the outer per-height delta cache -
+	// a forward-only reader never repeats a height, so that counter alone can't show this reuse.
+	IndexerBlobPreviousReuseHits   prometheus.Counter // how many "previous" blobs were reused from the prior request's cached current?
+	IndexerBlobPreviousReuseMisses prometheus.Counter // how many "previous" blobs required their own fresh cold read?
 	// IndexerBlobStepTime breaks the cold read down by step (time_machine, block_fetch,
 	// accounts_iterate, ... -- see fsm/indexer.go), most of which are direct pebbledb
 	// reads/iterations at a historical version. Lets a slow cold read be attributed to
@@ -220,6 +229,20 @@ type StoreMetrics struct {
 	DBBackupTime         prometheus.Histogram // how long does the db backup take?
 	DBLSSCompactionTime  prometheus.Histogram // how long does the db LSS compaction take?
 	DBHSSCompactionTime  prometheus.Histogram // how long does the db HSS compaction take?
+	// pebble's own internal LSM-tree state - unlike DBLSSCompactionTime/DBHSSCompactionTime
+	// (which only track canopy's own periodic MaybeCompact() job), these reflect pebble's
+	// automatic background compaction, which runs independently and is otherwise invisible
+	PebbleReadAmp             prometheus.Gauge     // pebble's current read amplification
+	PebbleDiskUsageBytes      prometheus.Gauge     // total on-disk size of all sstables
+	PebbleCompactionCount     prometheus.Gauge     // total pebble-initiated compactions since process start
+	PebbleCompactionDebtBytes prometheus.Gauge     // estimated bytes still needing compaction to reach a stable LSM state
+	PebbleFlushCount          prometheus.Gauge     // total memtable flushes since process start
+	PebbleMemtableSizeBytes   prometheus.Gauge     // bytes held in memtables (incl. large flushable batches)
+	PebbleBlockCacheSizeBytes prometheus.Gauge     // bytes held in the block cache
+	PebbleBlockCacheHits      prometheus.Gauge     // cumulative block cache hits
+	PebbleBlockCacheMisses    prometheus.Gauge     // cumulative block cache misses
+	PebbleLevelTableCount     *prometheus.GaugeVec // sstable count, labeled by LSM level
+	PebbleLevelSizeBytes      *prometheus.GaugeVec // sstable bytes, labeled by LSM level
 }
 
 // MempoolMetrics represents the telemetry of the memory pool of pending transactions
@@ -676,6 +699,50 @@ func NewMetricsServer(nodeAddress crypto.AddressI, chainID float64, softwareVers
 				Name: "canopy_store_hss_compaction_time",
 				Help: "Execution time of HSS database compaction",
 			}),
+			PebbleReadAmp: promauto.NewGauge(prometheus.GaugeOpts{
+				Name: "canopy_store_pebble_read_amplification",
+				Help: "Pebble's current read amplification",
+			}),
+			PebbleDiskUsageBytes: promauto.NewGauge(prometheus.GaugeOpts{
+				Name: "canopy_store_pebble_disk_usage_bytes",
+				Help: "Total on-disk size of all sstables",
+			}),
+			PebbleCompactionCount: promauto.NewGauge(prometheus.GaugeOpts{
+				Name: "canopy_store_pebble_compaction_count",
+				Help: "Total pebble-initiated compactions since process start",
+			}),
+			PebbleCompactionDebtBytes: promauto.NewGauge(prometheus.GaugeOpts{
+				Name: "canopy_store_pebble_compaction_debt_bytes",
+				Help: "Estimated bytes still needing compaction to reach a stable LSM state",
+			}),
+			PebbleFlushCount: promauto.NewGauge(prometheus.GaugeOpts{
+				Name: "canopy_store_pebble_flush_count",
+				Help: "Total memtable flushes since process start",
+			}),
+			PebbleMemtableSizeBytes: promauto.NewGauge(prometheus.GaugeOpts{
+				Name: "canopy_store_pebble_memtable_size_bytes",
+				Help: "Bytes held in memtables, including large flushable batches",
+			}),
+			PebbleBlockCacheSizeBytes: promauto.NewGauge(prometheus.GaugeOpts{
+				Name: "canopy_store_pebble_block_cache_size_bytes",
+				Help: "Bytes held in the block cache",
+			}),
+			PebbleBlockCacheHits: promauto.NewGauge(prometheus.GaugeOpts{
+				Name: "canopy_store_pebble_block_cache_hits",
+				Help: "Cumulative block cache hits",
+			}),
+			PebbleBlockCacheMisses: promauto.NewGauge(prometheus.GaugeOpts{
+				Name: "canopy_store_pebble_block_cache_misses",
+				Help: "Cumulative block cache misses",
+			}),
+			PebbleLevelTableCount: promauto.NewGaugeVec(prometheus.GaugeOpts{
+				Name: "canopy_store_pebble_level_table_count",
+				Help: "Sstable count, labeled by LSM level",
+			}, []string{"level"}),
+			PebbleLevelSizeBytes: promauto.NewGaugeVec(prometheus.GaugeOpts{
+				Name: "canopy_store_pebble_level_size_bytes",
+				Help: "Sstable bytes, labeled by LSM level",
+			}, []string{"level"}),
 		},
 		// MEMPOOL
 		MempoolMetrics: MempoolMetrics{
@@ -717,6 +784,14 @@ func NewMetricsServer(nodeAddress crypto.AddressI, chainID float64, softwareVers
 			IndexerBlobCacheSize: promauto.NewGauge(prometheus.GaugeOpts{
 				Name: "canopy_indexer_blob_cache_size",
 				Help: "Current number of entries in the indexer-blobs cache",
+			}),
+			IndexerBlobPreviousReuseHits: promauto.NewCounter(prometheus.CounterOpts{
+				Name: "canopy_indexer_blob_previous_reuse_hits_total",
+				Help: "Total indexer-blobs requests whose 'previous' blob was reused from the prior request's cached current",
+			}),
+			IndexerBlobPreviousReuseMisses: promauto.NewCounter(prometheus.CounterOpts{
+				Name: "canopy_indexer_blob_previous_reuse_misses_total",
+				Help: "Total indexer-blobs requests whose 'previous' blob required its own fresh cold read",
 			}),
 			IndexerBlobStepTime: promauto.NewHistogramVec(prometheus.HistogramOpts{
 				Name: "canopy_indexer_blob_step_time",
@@ -937,6 +1012,31 @@ func (m *Metrics) UpdateStoreMetrics(size, entries int64, startTime time.Time, s
 	}
 }
 
+// UpdatePebbleMetrics() refreshes the pebble LSM-tree gauges from a live db.Metrics() snapshot.
+// Unlike UpdateStoreJobMetrics() (which only observes canopy's own periodic MaybeCompact() job),
+// this reflects pebble's automatic background compaction, which runs independently and would
+// otherwise be invisible to telemetry.
+func (m *Metrics) UpdatePebbleMetrics(pm *pebble.Metrics) {
+	// exit if empty
+	if m == nil || pm == nil {
+		return
+	}
+	m.PebbleReadAmp.Set(float64(pm.ReadAmp()))
+	m.PebbleDiskUsageBytes.Set(float64(pm.DiskSpaceUsage()))
+	m.PebbleCompactionCount.Set(float64(pm.Compact.Count))
+	m.PebbleCompactionDebtBytes.Set(float64(pm.Compact.EstimatedDebt))
+	m.PebbleFlushCount.Set(float64(pm.Flush.Count))
+	m.PebbleMemtableSizeBytes.Set(float64(pm.MemTable.Size))
+	m.PebbleBlockCacheSizeBytes.Set(float64(pm.BlockCache.Size))
+	m.PebbleBlockCacheHits.Set(float64(pm.BlockCache.Hits))
+	m.PebbleBlockCacheMisses.Set(float64(pm.BlockCache.Misses))
+	for i, lvl := range pm.Levels {
+		level := strconv.Itoa(i)
+		m.PebbleLevelTableCount.WithLabelValues(level).Set(float64(lvl.TablesCount))
+		m.PebbleLevelSizeBytes.WithLabelValues(level).Set(float64(lvl.TablesSize))
+	}
+}
+
 // UpdateStoreJobMetrics() updates the store jobs telemery
 func (m *Metrics) UpdateStoreJobMetrics(LSScompactionTime, HSSCompactionTime, backupTime time.Duration) {
 	// exit if empty
@@ -975,6 +1075,26 @@ func (m *Metrics) RecordIndexerBlobCacheMiss(startTime time.Time) {
 	}
 	m.IndexerBlobCacheMisses.Inc()
 	m.IndexerBlobColdReadTime.Observe(time.Since(startTime).Seconds())
+}
+
+// RecordIndexerBlobPreviousReuseHit() records a "previous" blob reused from the prior request's
+// cached current, avoiding its own fresh cold read.
+func (m *Metrics) RecordIndexerBlobPreviousReuseHit() {
+	// exit if empty
+	if m == nil {
+		return
+	}
+	m.IndexerBlobPreviousReuseHits.Inc()
+}
+
+// RecordIndexerBlobPreviousReuseMiss() records a "previous" blob that required its own fresh
+// cold read because it wasn't already cached as a prior request's current.
+func (m *Metrics) RecordIndexerBlobPreviousReuseMiss() {
+	// exit if empty
+	if m == nil {
+		return
+	}
+	m.IndexerBlobPreviousReuseMisses.Inc()
 }
 
 // UpdateIndexerBlobCacheSize() updates the current entry count of the indexer-blobs cache.

--- a/lib/metrics.go
+++ b/lib/metrics.go
@@ -90,6 +90,7 @@ type IndexerMetrics struct {
 	// a forward-only reader never repeats a height, so that counter alone can't show this reuse.
 	IndexerBlobPreviousReuseHits   prometheus.Counter // how many "previous" blobs were reused from the prior request's cached current?
 	IndexerBlobPreviousReuseMisses prometheus.Counter // how many "previous" blobs required their own fresh cold read?
+	IndexerBlobCancelled           prometheus.Counter // how many indexer-blobs cold reads were aborted early because the client disconnected?
 	// IndexerBlobStepTime breaks the cold read down by step (time_machine, block_fetch,
 	// accounts_iterate, ... -- see fsm/indexer.go), most of which are direct pebbledb
 	// reads/iterations at a historical version. Lets a slow cold read be attributed to
@@ -781,6 +782,10 @@ func NewMetricsServer(nodeAddress crypto.AddressI, chainID float64, softwareVers
 				Name: "canopy_indexer_blob_cache_misses_total",
 				Help: "Total indexer-blobs requests that required a cold store read",
 			}),
+			IndexerBlobCancelled: promauto.NewCounter(prometheus.CounterOpts{
+				Name: "canopy_indexer_blob_cancelled_total",
+				Help: "Total indexer-blobs cold reads aborted early because the client disconnected",
+			}),
 			IndexerBlobCacheSize: promauto.NewGauge(prometheus.GaugeOpts{
 				Name: "canopy_indexer_blob_cache_size",
 				Help: "Current number of entries in the indexer-blobs cache",
@@ -1095,6 +1100,16 @@ func (m *Metrics) RecordIndexerBlobPreviousReuseMiss() {
 		return
 	}
 	m.IndexerBlobPreviousReuseMisses.Inc()
+}
+
+// RecordIndexerBlobCancelled() records an indexer-blobs cold read that was aborted early
+// because the requesting client disconnected.
+func (m *Metrics) RecordIndexerBlobCancelled() {
+	// exit if empty
+	if m == nil {
+		return
+	}
+	m.IndexerBlobCancelled.Inc()
 }
 
 // UpdateIndexerBlobCacheSize() updates the current entry count of the indexer-blobs cache.

--- a/store/store.go
+++ b/store/store.go
@@ -288,6 +288,10 @@ func (s *Store) Commit() (root []byte, err lib.ErrorI) {
 	s.MaybeCompact()
 	// backup if enabled
 	s.MaybeBackup()
+	// refresh pebble's own LSM-tree telemetry - cheap (in-memory counters only), so safe on
+	// every commit, and deliberately not gated on s.syncing like MaybeCompact() since LSM
+	// shape visibility matters most exactly when the node is catching up
+	s.metrics.UpdatePebbleMetrics(s.db.Metrics())
 	// return the root
 	return
 }


### PR DESCRIPTION
## Summary

The indexer-blobs endpoint previously computed its account delta by prefix-scanning the entire account set (~1.35M accounts) at both the current and previous heights and diffing the results — the dominant cost of every cache-miss request. This PR sources the account delta by replaying the single block that produced the requested height instead, plus a set of perf/observability improvements to the same endpoint.

## Account-delta fast path

- **fsm**: `AccountChangeCollector` classifies every account touched during one `ApplyBlock` call into added/changed/removed against the height-1 baseline (captured on first touch, before the block's own writes shadow it). `ApplyBlock` gains `collector`/`skipRoot` params — used only by throwaway replays, never by a real commit.
- **fsm**: `IndexerBlob` gains `skipAccounts`; `AssembleAccountDeltaSides` rebuilds the wire-ready sides, reproducing the reward/slash force-include and ascending-address ordering the full scan provided for free.
- **controller**: `GetAccountDelta` replays the block against a `TimeMachine` snapshot, restoring the root DEX cache from the committed certificate exactly as the live commit path does (required for nested-chain correctness).
- **rpc**: `IndexerBlobsCached` sources account deltas from the fast path. Height 2 keeps the full-scan fallback so its response stays byte-identical (there is no previous height to diff against).

## Perf / observability

- Sorted merge walk replaces the map-diff in `DeltaIndexerBlobs`
- Cold-read visibility: log + `canopy_indexer_blob_cold_read_time` for cache-miss reads that outlive the RPC write deadline
- Cancel in-flight scans on client disconnect instead of computing and caching a response nobody is waiting for
- Pebble LSM-tree metrics, previous-blob reuse counters, and per-step timing for delta compute/marshal

## Testing

- Differential regression test pinning the fast path byte-for-byte, order-for-order to the old full-scan-and-diff on the same committed chain
- Force-include coverage for reward/slash accounts the block never writes
- Prefix-leak, replay-QC-variant, and pool/validator-touching regression tests
- `go build ./...` and `fsm`/`controller`/`cmd/rpc` suites pass with `-count=1`

🤖 Generated with [Claude Code](https://claude.com/claude-code)