### PR TITLE
feat(store): add pebble LSM-tree, write-stall, and disk-slow metrics

### DIFF
--- a/lib/metrics.go
+++ b/lib/metrics.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/canopy-network/canopy/lib/crypto"
 	"github.com/cockroachdb/pebble/v2"
+	"github.com/cockroachdb/pebble/v2/vfs"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
@@ -69,6 +70,9 @@ type Metrics struct {
 
 	pebbleStallMu    sync.Mutex // guards pebbleStallStart against concurrent WriteStallBegin/End
 	pebbleStallStart time.Time  // set on WriteStallBegin, cleared on WriteStallEnd
+
+	pebbleDiskSlowMu      sync.Mutex // guards pebbleDiskSlowMaxSecs against concurrent onSlowDisk callbacks
+	pebbleDiskSlowMaxSecs float64    // highest single disk-op duration observed, mirrors PebbleDiskSlowMaxDurationS
 
 	NodeMetrics    // general telemetry about the node
 	BlockMetrics   // block telemetry
@@ -233,6 +237,11 @@ type StoreMetrics struct {
 	// below accumulate into these from that listener, wired in store/store.go NewStore().
 	PebbleWriteStallCount        prometheus.Counter // cumulative number of writes pebble has stalled for LSM backpressure
 	PebbleWriteStallDurationSecs prometheus.Counter // cumulative time (seconds) writes have spent stalled for LSM backpressure
+	// direct disk-health signal - canopy has no equivalent of CockroachDB's fsync-stall detector
+	// (which treats a stalled write as fatal); this starts with visibility only (log + count),
+	// see store/store.go's diskSlowThreshold comment for why it's not wired to anything fatal yet
+	PebbleDiskSlowCount        prometheus.Counter // cumulative count of individual disk write ops slower than diskSlowThreshold
+	PebbleDiskSlowMaxDurationS prometheus.Gauge   // duration (seconds) of the single slowest disk op observed since process start
 }
 
 // MempoolMetrics represents the telemetry of the memory pool of pending transactions
@@ -741,6 +750,14 @@ func NewMetricsServer(nodeAddress crypto.AddressI, chainID float64, softwareVers
 				Name: "canopy_store_pebble_write_stall_duration_seconds",
 				Help: "Cumulative time (seconds) writes have spent stalled for LSM backpressure",
 			}),
+			PebbleDiskSlowCount: promauto.NewCounter(prometheus.CounterOpts{
+				Name: "canopy_store_pebble_disk_slow_count",
+				Help: "Cumulative count of individual disk write ops slower than the configured disk-slow threshold",
+			}),
+			PebbleDiskSlowMaxDurationS: promauto.NewGauge(prometheus.GaugeOpts{
+				Name: "canopy_store_pebble_disk_slow_max_duration_seconds",
+				Help: "Duration (seconds) of the single slowest disk op observed since process start",
+			}),
 		},
 		// MEMPOOL
 		MempoolMetrics: MempoolMetrics{
@@ -1041,6 +1058,28 @@ func (m *Metrics) RecordPebbleWriteStallEnd() {
 		return
 	}
 	m.PebbleWriteStallDurationSecs.Add(time.Since(start).Seconds())
+}
+
+// RecordPebbleDiskSlow() records a single disk write op that exceeded store.go's
+// diskSlowThreshold - visibility-only for now (log + count), not wired to anything fatal. See
+// store.go's diskSlowThreshold comment for why: unlike CockroachDB's ~20s stall detector (which
+// kills the process), canopy has no precedent for a fatal disk-health path yet. Wired into
+// vfs.WithDiskHealthChecks()'s onSlowDisk callback in store/store.go NewStore().
+func (m *Metrics) RecordPebbleDiskSlow(info vfs.DiskSlowInfo) {
+	// exit if empty
+	if m == nil {
+		return
+	}
+	m.log.Warnf("Pebble disk op slow: op=%s path=%s writeSize=%d duration=%s",
+		info.OpType, info.Path, info.WriteSize, info.Duration)
+	m.PebbleDiskSlowCount.Inc()
+	seconds := info.Duration.Seconds()
+	m.pebbleDiskSlowMu.Lock()
+	defer m.pebbleDiskSlowMu.Unlock()
+	if seconds > m.pebbleDiskSlowMaxSecs {
+		m.pebbleDiskSlowMaxSecs = seconds
+		m.PebbleDiskSlowMaxDurationS.Set(seconds)
+	}
 }
 
 // UpdateStoreJobMetrics() updates the store jobs telemery

--- a/lib/metrics.go
+++ b/lib/metrics.go
@@ -4,9 +4,12 @@ import (
 	"bytes"
 	"context"
 	"net/http"
+	"strconv"
+	"sync"
 	"time"
 
 	"github.com/canopy-network/canopy/lib/crypto"
+	"github.com/cockroachdb/pebble/v2"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
@@ -63,6 +66,9 @@ type Metrics struct {
 	nodeAddress     []byte        // the node's address
 	log             LoggerI       // the logger
 	startupBlockSet bool          // flag to ensure startup block is only set once
+
+	pebbleStallMu    sync.Mutex // guards pebbleStallStart against concurrent WriteStallBegin/End
+	pebbleStallStart time.Time  // set on WriteStallBegin, cleared on WriteStallEnd
 
 	NodeMetrics    // general telemetry about the node
 	BlockMetrics   // block telemetry
@@ -206,6 +212,27 @@ type StoreMetrics struct {
 	DBBackupTime         prometheus.Histogram // how long does the db backup take?
 	DBLSSCompactionTime  prometheus.Histogram // how long does the db LSS compaction take?
 	DBHSSCompactionTime  prometheus.Histogram // how long does the db HSS compaction take?
+	// pebble's own internal LSM-tree state - unlike DBLSSCompactionTime/DBHSSCompactionTime
+	// (which only track canopy's own periodic MaybeCompact() job), these reflect pebble's
+	// automatic background compaction, which runs independently and is otherwise invisible
+	PebbleReadAmp             prometheus.Gauge     // pebble's current read amplification
+	PebbleDiskUsageBytes      prometheus.Gauge     // total on-disk size of all sstables
+	PebbleCompactionCount     prometheus.Gauge     // total pebble-initiated compactions since process start
+	PebbleCompactionDebtBytes prometheus.Gauge     // estimated bytes still needing compaction to reach a stable LSM state
+	PebbleFlushCount          prometheus.Gauge     // total memtable flushes since process start
+	PebbleMemtableSizeBytes   prometheus.Gauge     // bytes held in memtables (incl. large flushable batches)
+	PebbleBlockCacheSizeBytes prometheus.Gauge     // bytes held in the block cache
+	PebbleBlockCacheHits      prometheus.Gauge     // cumulative block cache hits
+	PebbleBlockCacheMisses    prometheus.Gauge     // cumulative block cache misses
+	PebbleLevelTableCount     *prometheus.GaugeVec // sstable count, labeled by LSM level
+	PebbleLevelSizeBytes      *prometheus.GaugeVec // sstable bytes, labeled by LSM level
+	// direct evidence of L0StopWritesThreshold/L0CompactionThreshold backpressure actually
+	// firing - see store/store.go NewStore() thresholds. Absent these, L0 table count is only
+	// an indirect proxy. pebble.Metrics doesn't expose stall count/duration directly (v2 moved
+	// this to EventListener.WriteStallBegin/End callbacks) - RecordPebbleWriteStallBegin/End
+	// below accumulate into these from that listener, wired in store/store.go NewStore().
+	PebbleWriteStallCount        prometheus.Counter // cumulative number of writes pebble has stalled for LSM backpressure
+	PebbleWriteStallDurationSecs prometheus.Counter // cumulative time (seconds) writes have spent stalled for LSM backpressure
 }
 
 // MempoolMetrics represents the telemetry of the memory pool of pending transactions
@@ -662,6 +689,58 @@ func NewMetricsServer(nodeAddress crypto.AddressI, chainID float64, softwareVers
 				Name: "canopy_store_hss_compaction_time",
 				Help: "Execution time of HSS database compaction",
 			}),
+			PebbleReadAmp: promauto.NewGauge(prometheus.GaugeOpts{
+				Name: "canopy_store_pebble_read_amplification",
+				Help: "Pebble's current read amplification",
+			}),
+			PebbleDiskUsageBytes: promauto.NewGauge(prometheus.GaugeOpts{
+				Name: "canopy_store_pebble_disk_usage_bytes",
+				Help: "Total on-disk size of all sstables",
+			}),
+			PebbleCompactionCount: promauto.NewGauge(prometheus.GaugeOpts{
+				Name: "canopy_store_pebble_compaction_count",
+				Help: "Total pebble-initiated compactions since process start",
+			}),
+			PebbleCompactionDebtBytes: promauto.NewGauge(prometheus.GaugeOpts{
+				Name: "canopy_store_pebble_compaction_debt_bytes",
+				Help: "Estimated bytes still needing compaction to reach a stable LSM state",
+			}),
+			PebbleFlushCount: promauto.NewGauge(prometheus.GaugeOpts{
+				Name: "canopy_store_pebble_flush_count",
+				Help: "Total memtable flushes since process start",
+			}),
+			PebbleMemtableSizeBytes: promauto.NewGauge(prometheus.GaugeOpts{
+				Name: "canopy_store_pebble_memtable_size_bytes",
+				Help: "Bytes held in memtables, including large flushable batches",
+			}),
+			PebbleBlockCacheSizeBytes: promauto.NewGauge(prometheus.GaugeOpts{
+				Name: "canopy_store_pebble_block_cache_size_bytes",
+				Help: "Bytes held in the block cache",
+			}),
+			PebbleBlockCacheHits: promauto.NewGauge(prometheus.GaugeOpts{
+				Name: "canopy_store_pebble_block_cache_hits",
+				Help: "Cumulative block cache hits",
+			}),
+			PebbleBlockCacheMisses: promauto.NewGauge(prometheus.GaugeOpts{
+				Name: "canopy_store_pebble_block_cache_misses",
+				Help: "Cumulative block cache misses",
+			}),
+			PebbleLevelTableCount: promauto.NewGaugeVec(prometheus.GaugeOpts{
+				Name: "canopy_store_pebble_level_table_count",
+				Help: "Sstable count, labeled by LSM level",
+			}, []string{"level"}),
+			PebbleLevelSizeBytes: promauto.NewGaugeVec(prometheus.GaugeOpts{
+				Name: "canopy_store_pebble_level_size_bytes",
+				Help: "Sstable bytes, labeled by LSM level",
+			}, []string{"level"}),
+			PebbleWriteStallCount: promauto.NewCounter(prometheus.CounterOpts{
+				Name: "canopy_store_pebble_write_stall_count",
+				Help: "Cumulative number of writes pebble has stalled for LSM backpressure (e.g. L0StopWritesThreshold)",
+			}),
+			PebbleWriteStallDurationSecs: promauto.NewCounter(prometheus.CounterOpts{
+				Name: "canopy_store_pebble_write_stall_duration_seconds",
+				Help: "Cumulative time (seconds) writes have spent stalled for LSM backpressure",
+			}),
 		},
 		// MEMPOOL
 		MempoolMetrics: MempoolMetrics{
@@ -898,6 +977,70 @@ func (m *Metrics) UpdateStoreMetrics(size, entries int64, startTime time.Time, s
 		// update the processing time in seconds
 		m.DBCommitTime.Observe(time.Since(startFlushTime).Seconds())
 	}
+}
+
+// UpdatePebbleMetrics() refreshes the pebble LSM-tree gauges from a live db.Metrics() snapshot.
+// Unlike UpdateStoreJobMetrics() (which only observes canopy's own periodic MaybeCompact() job),
+// this reflects pebble's automatic background compaction, which runs independently and would
+// otherwise be invisible to telemetry.
+func (m *Metrics) UpdatePebbleMetrics(pm *pebble.Metrics) {
+	// exit if empty
+	if m == nil || pm == nil {
+		return
+	}
+	m.PebbleReadAmp.Set(float64(pm.ReadAmp()))
+	m.PebbleDiskUsageBytes.Set(float64(pm.DiskSpaceUsage()))
+	m.PebbleCompactionCount.Set(float64(pm.Compact.Count))
+	m.PebbleCompactionDebtBytes.Set(float64(pm.Compact.EstimatedDebt))
+	m.PebbleFlushCount.Set(float64(pm.Flush.Count))
+	m.PebbleMemtableSizeBytes.Set(float64(pm.MemTable.Size))
+	m.PebbleBlockCacheSizeBytes.Set(float64(pm.BlockCache.Size))
+	m.PebbleBlockCacheHits.Set(float64(pm.BlockCache.Hits))
+	m.PebbleBlockCacheMisses.Set(float64(pm.BlockCache.Misses))
+	for i, lvl := range pm.Levels {
+		level := strconv.Itoa(i)
+		m.PebbleLevelTableCount.WithLabelValues(level).Set(float64(lvl.TablesCount))
+		m.PebbleLevelSizeBytes.WithLabelValues(level).Set(float64(lvl.TablesSize))
+	}
+}
+
+// RecordPebbleWriteStallBegin() records the start of a pebble write stall - direct evidence of
+// L0StopWritesThreshold/L0CompactionThreshold backpressure actually firing (store/store.go
+// NewStore()), unlike the L0 table count/debt gauges above which are only an indirect proxy.
+// Wired into pebble.Options.EventListener.WriteStallBegin; `reason` (e.g. "L0 too many files",
+// "memtable count limit reached") is pebble's own free-form description and is not currently
+// recorded as a label to avoid unbounded cardinality if pebble's reason strings ever vary by
+// value (e.g. embedding a byte count).
+func (m *Metrics) RecordPebbleWriteStallBegin(reason string) {
+	// exit if empty
+	if m == nil {
+		return
+	}
+	m.log.Debugf("Pebble write stall began: %s", reason)
+	m.PebbleWriteStallCount.Inc()
+	m.pebbleStallMu.Lock()
+	defer m.pebbleStallMu.Unlock()
+	m.pebbleStallStart = time.Now()
+}
+
+// RecordPebbleWriteStallEnd() records the end of a pebble write stall, adding its duration to
+// the cumulative PebbleWriteStallDurationSecs counter. Wired into
+// pebble.Options.EventListener.WriteStallEnd.
+func (m *Metrics) RecordPebbleWriteStallEnd() {
+	// exit if empty
+	if m == nil {
+		return
+	}
+	m.pebbleStallMu.Lock()
+	start := m.pebbleStallStart
+	m.pebbleStallStart = time.Time{}
+	m.pebbleStallMu.Unlock()
+	// guard against an End with no matching Begin (shouldn't happen per pebble's contract, but
+	// a zero start would otherwise add a huge bogus duration via time.Since)
+	if start.IsZero() {
+		return
+	}
+	m.PebbleWriteStallDurationSecs.Add(time.Since(start).Seconds())
 }
 
 // UpdateStoreJobMetrics() updates the store jobs telemery

--- a/lib/metrics.go
+++ b/lib/metrics.go
@@ -72,7 +72,7 @@ type Metrics struct {
 	pebbleStallStart time.Time  // set on WriteStallBegin, cleared on WriteStallEnd
 
 	pebbleDiskSlowMu      sync.Mutex // guards pebbleDiskSlowMaxSecs against concurrent onSlowDisk callbacks
-	pebbleDiskSlowMaxSecs float64    // highest single disk-op duration observed, mirrors PebbleDiskSlowMaxDurationS
+	pebbleDiskSlowMaxSecs float64    // highest single disk-op duration observed, mirrors PebbleDiskSlowMaxDurationSecs
 
 	NodeMetrics    // general telemetry about the node
 	BlockMetrics   // block telemetry
@@ -240,8 +240,8 @@ type StoreMetrics struct {
 	// direct disk-health signal - canopy has no equivalent of CockroachDB's fsync-stall detector
 	// (which treats a stalled write as fatal); this starts with visibility only (log + count),
 	// see store/store.go's diskSlowThreshold comment for why it's not wired to anything fatal yet
-	PebbleDiskSlowCount        prometheus.Counter // cumulative count of individual disk write ops slower than diskSlowThreshold
-	PebbleDiskSlowMaxDurationS prometheus.Gauge   // duration (seconds) of the single slowest disk op observed since process start
+	PebbleDiskSlowCount           prometheus.Counter // cumulative count of individual disk write ops slower than diskSlowThreshold
+	PebbleDiskSlowMaxDurationSecs prometheus.Gauge   // duration (seconds) of the single slowest disk op observed since process start
 }
 
 // MempoolMetrics represents the telemetry of the memory pool of pending transactions
@@ -754,7 +754,7 @@ func NewMetricsServer(nodeAddress crypto.AddressI, chainID float64, softwareVers
 				Name: "canopy_store_pebble_disk_slow_count",
 				Help: "Cumulative count of individual disk write ops slower than the configured disk-slow threshold",
 			}),
-			PebbleDiskSlowMaxDurationS: promauto.NewGauge(prometheus.GaugeOpts{
+			PebbleDiskSlowMaxDurationSecs: promauto.NewGauge(prometheus.GaugeOpts{
 				Name: "canopy_store_pebble_disk_slow_max_duration_seconds",
 				Help: "Duration (seconds) of the single slowest disk op observed since process start",
 			}),
@@ -1078,7 +1078,7 @@ func (m *Metrics) RecordPebbleDiskSlow(info vfs.DiskSlowInfo) {
 	defer m.pebbleDiskSlowMu.Unlock()
 	if seconds > m.pebbleDiskSlowMaxSecs {
 		m.pebbleDiskSlowMaxSecs = seconds
-		m.PebbleDiskSlowMaxDurationS.Set(seconds)
+		m.PebbleDiskSlowMaxDurationSecs.Set(seconds)
 	}
 }
 

--- a/scripts/deploy-node-image.sh
+++ b/scripts/deploy-node-image.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+#
+# Build the canopy-core docker image from the current checkout, import it
+# directly into a k3s node's containerd store (no registry involved -- k3s
+# supports `ctr images import` for exactly this), and optionally patch a
+# StatefulSet in the cluster to roll out the new tag.
+#
+# Usage:
+#   scripts/deploy-node-image.sh [--statefulset NAME] [--image NAME] [--skip-patch] [--no-wait]
+#
+# Flags (each overrides the matching env var below):
+#   -s, --statefulset NAME   StatefulSet to patch
+#   -i, --image NAME         docker image repo name
+#
+# Configuration (env vars, all optional):
+#   IMAGE_NAME    docker image repo name              (default: canopy-lp-cap)
+#   TAG           image tag                           (default: current git short sha)
+#   DOCKERFILE    Dockerfile to build                 (default: .docker/Dockerfile)
+#   NODE          SSH host of the target k3s node     (default: val-b)
+#   KUBE_HOST     SSH host with kubectl access         (default: staging)
+#   NAMESPACE     kubernetes namespace                (default: staging)
+#   STATEFULSET   StatefulSet to patch                (default: localnet-2-localnet)
+#   CONTAINER     container name inside the pod       (default: canopy)
+#   WAIT_TIMEOUT  seconds to wait for pod readiness    (default: 120)
+#
+# Example:
+#   NODE=val-a scripts/deploy-node-image.sh --statefulset localnet-1-localnet
+#   scripts/deploy-node-image.sh -s localnet-1-localnet -i canopy-lp-cap
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO_ROOT"
+
+IMAGE_NAME="${IMAGE_NAME:-canopy-lp-cap}"
+TAG="${TAG:-$(git rev-parse --short HEAD)}"
+DOCKERFILE="${DOCKERFILE:-.docker/Dockerfile}"
+NODE="${NODE:-val-b}"
+KUBE_HOST="${KUBE_HOST:-staging}"
+NAMESPACE="${NAMESPACE:-staging}"
+STATEFULSET="${STATEFULSET:-localnet-2-localnet}"
+CONTAINER="${CONTAINER:-canopy}"
+WAIT_TIMEOUT="${WAIT_TIMEOUT:-120}"
+
+SKIP_PATCH=0
+NO_WAIT=0
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --skip-patch) SKIP_PATCH=1; shift ;;
+    --no-wait) NO_WAIT=1; shift ;;
+    -s|--statefulset)
+      STATEFULSET="$2"
+      shift 2
+      ;;
+    -i|--image)
+      IMAGE_NAME="$2"
+      shift 2
+      ;;
+    -h|--help)
+      grep '^#' "${BASH_SOURCE[0]}" | tail -n +2 | sed 's/^# \{0,1\}//'
+      exit 0
+      ;;
+    *)
+      echo "unknown argument: $1" >&2
+      exit 1
+      ;;
+  esac
+done
+
+IMAGE_REF="${IMAGE_NAME}:${TAG}"
+TAR_NAME="${IMAGE_NAME}-${TAG}.tar"
+LOCAL_TAR="$(mktemp -t "${TAR_NAME}.XXXXXX")"
+REMOTE_TAR="/tmp/${TAR_NAME}"
+
+cleanup() {
+  rm -f "$LOCAL_TAR"
+}
+trap cleanup EXIT
+
+echo "==> building ${IMAGE_REF} from ${DOCKERFILE}"
+docker build -f "$DOCKERFILE" -t "$IMAGE_REF" .
+
+echo "==> saving image to ${LOCAL_TAR}"
+docker save "$IMAGE_REF" -o "$LOCAL_TAR"
+
+echo "==> copying image to ${NODE}:${REMOTE_TAR}"
+scp "$LOCAL_TAR" "${NODE}:${REMOTE_TAR}"
+
+echo "==> importing image into ${NODE}'s containerd via k3s ctr"
+ssh "$NODE" "k3s ctr images import '${REMOTE_TAR}' && rm -f '${REMOTE_TAR}'"
+
+if [ "$SKIP_PATCH" -eq 1 ]; then
+  echo "==> --skip-patch set, image imported but no deployment was changed"
+  exit 0
+fi
+
+echo "==> patching statefulset/${STATEFULSET} (container ${CONTAINER}) to ${IMAGE_REF} in namespace ${NAMESPACE}"
+ssh "$KUBE_HOST" "kubectl set image statefulset/${STATEFULSET} ${CONTAINER}=${IMAGE_REF} -n ${NAMESPACE}"
+
+if [ "$NO_WAIT" -eq 1 ]; then
+  echo "==> --no-wait set, not waiting for pod readiness"
+  exit 0
+fi
+
+echo "==> waiting up to ${WAIT_TIMEOUT}s for ${STATEFULSET}-0's pod to become ready"
+ssh "$KUBE_HOST" "kubectl rollout status statefulset/${STATEFULSET} -n ${NAMESPACE} --timeout=${WAIT_TIMEOUT}s"
+
+echo "==> done: ${STATEFULSET} is running ${IMAGE_REF}"

--- a/store/store.go
+++ b/store/store.go
@@ -135,6 +135,17 @@ func NewStore(config lib.Config, path string, metrics *lib.Metrics, log lib.Logg
 		WALMinSyncInterval: func() time.Duration {
 			return time.Millisecond * 2
 		},
+		// surfaces L0StopWritesThreshold/L0CompactionThreshold backpressure actually firing -
+		// see lib.Metrics.RecordPebbleWriteStallBegin/End for why this can't come from
+		// db.Metrics() alone on this pebble version
+		EventListener: &pebble.EventListener{
+			WriteStallBegin: func(info pebble.WriteStallBeginInfo) {
+				metrics.RecordPebbleWriteStallBegin(info.Reason)
+			},
+			WriteStallEnd: func() {
+				metrics.RecordPebbleWriteStallEnd()
+			},
+		},
 	})
 	if err != nil {
 		return nil, ErrOpenDB(err)
@@ -288,6 +299,10 @@ func (s *Store) Commit() (root []byte, err lib.ErrorI) {
 	s.MaybeCompact()
 	// backup if enabled
 	s.MaybeBackup()
+	// refresh pebble's own LSM-tree telemetry - cheap (in-memory counters only), so safe on
+	// every commit, and deliberately not gated on s.syncing like MaybeCompact() since LSM
+	// shape visibility matters most exactly when the node is catching up
+	s.metrics.UpdatePebbleMetrics(s.db.Metrics())
 	// return the root
 	return
 }

--- a/store/store.go
+++ b/store/store.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"io"
 	"math"
 	"os"
 	"path/filepath"
@@ -82,6 +83,9 @@ type Store struct {
 	compaction atomic.Bool   // atomic boolean for compaction status
 	backup     atomic.Bool   // atomic boolean for backup status
 	isTxn      bool          // flag indicating if the store is in transaction mode
+	// stops the background goroutine vfs.WithDiskHealthChecks() spawns to monitor for slow
+	// disk ops; nil for the in-memory store and any Store built directly via NewStoreWithDB()
+	diskHealthCloser io.Closer
 }
 
 // New() creates a new instance of a StoreI either in memory or an actual disk DB
@@ -92,10 +96,23 @@ func New(config lib.Config, metrics *lib.Metrics, l lib.LoggerI) (lib.StoreI, li
 	return NewStore(config, filepath.Join(config.DataDirPath, config.DBName), metrics, l)
 }
 
+// diskSlowThreshold is how long a single disk write op must take before it's reported as slow via
+// vfs.WithDiskHealthChecks() below. Deliberately conservative (log + count only, not fatal) - unlike
+// CockroachDB's ~20s stall detector, which kills the process outright, canopy has no precedent for a
+// fatal disk-health path yet, so start with visibility and revisit once real data exists.
+const diskSlowThreshold = 2 * time.Second
+
 // NewStore() creates a new instance of a disk DB˙
 func NewStore(config lib.Config, path string, metrics *lib.Metrics, log lib.LoggerI) (lib.StoreI, lib.ErrorI) {
 	cache := pebble.NewCache(256 << 20) // 256 MB cache
 	defer cache.Unref()
+	// wraps the OS filesystem so slow write-oriented ops (fsync, write, etc.) are reported
+	// instead of hanging silently - Options.FS is otherwise left unset (bare vfs.Default),
+	// which does no such monitoring
+	healthCheckedFS, diskHealthCloser := vfs.WithDiskHealthChecks(vfs.Default, diskSlowThreshold, nil,
+		func(info vfs.DiskSlowInfo) {
+			metrics.RecordPebbleDiskSlow(info)
+		})
 	lvl := pebble.LevelOptions{
 		BlockSize:      64 << 10, // 64 KB data blocks
 		IndexBlockSize: 32 << 10, // 32 KB index blocks
@@ -108,6 +125,7 @@ func NewStore(config lib.Config, path string, metrics *lib.Metrics, log lib.Logg
 		},
 	}
 	db, err := pebble.Open(path, &pebble.Options{
+		FS:                    healthCheckedFS,             // OS filesystem wrapped with slow-disk-op detection
 		MemTableSize:          64 << 20,                    // larger memtable to reduce flushes
 		L0CompactionThreshold: 6,                           // keep L0 small to avoid read amplification
 		L0StopWritesThreshold: 12,                          // stop writes when L0 reaches this size
@@ -148,9 +166,16 @@ func NewStore(config lib.Config, path string, metrics *lib.Metrics, log lib.Logg
 		},
 	})
 	if err != nil {
+		_ = diskHealthCloser.Close() // pebble.Open failed - stop the monitoring goroutine, nothing will own it otherwise
 		return nil, ErrOpenDB(err)
 	}
-	return NewStoreWithDB(config, db, metrics, log)
+	s, storeErr := NewStoreWithDB(config, db, metrics, log)
+	if storeErr != nil {
+		_ = diskHealthCloser.Close()
+		return nil, storeErr
+	}
+	s.diskHealthCloser = diskHealthCloser
+	return s, nil
 }
 
 // NewStoreInMemory() creates a new instance of a mem DB
@@ -602,6 +627,11 @@ func (s *Store) Close() lib.ErrorI {
 	}
 	if err := s.db.Close(); err != nil {
 		return ErrCloseDB(err)
+	}
+	if s.diskHealthCloser != nil {
+		if err := s.diskHealthCloser.Close(); err != nil {
+			return ErrCloseDB(fmt.Errorf("disk health checker close error: %v", err))
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
## Summary

Adds direct observability for two Pebble backpressure/health signals that were previously invisible on canopy nodes, plus a deploy script used to test this on staging.

- **Pebble LSM-tree metrics** — read amplification, disk usage, compaction count/debt, flush count, memtable/block-cache size, per-level table count/size, refreshed every `Commit()`. Unlike the existing `DBLSSCompactionTime`/`DBHSSCompactionTime` histograms (which only cover canopy's own periodic `MaybeCompact()` job), this reflects Pebble's automatic background compaction.
- **Write-stall detection** — `canopy_store_pebble_write_stall_count` / `_duration_seconds`. Direct evidence of `L0StopWritesThreshold`/`L0CompactionThreshold` backpressure actually firing (`store/store.go` `NewStore()`), not just an indirect proxy via L0 table count. This pebble version (`v2`) doesn't expose stall count/duration on `db.Metrics()` directly — it moved to `EventListener.WriteStallBegin`/`WriteStallEnd` callbacks, wired here.
- **Disk-slow-write detection** — `canopy_store_pebble_disk_slow_count` / `_max_duration_seconds`. `Options.FS` was previously left unset (bare `vfs.Default`), which does no health monitoring at all — a hanging/slow disk write would go unnoticed. Wraps the FS with `vfs.WithDiskHealthChecks()` at a conservative 2s threshold (visibility only — log + count, not fatal; canopy has no precedent for a fatal disk-health path like CockroachDB's ~20s stall-kill, so this starts observational and can graduate later).
- **`scripts/deploy-node-image.sh`** — pulled from `chore/deploy-script-and-timeouts` (that branch's unrelated Makefile/timeout changes left behind). Builds the current checkout's image, imports it directly into a target k3s node's containerd (no registry hop), patches a StatefulSet, waits for rollout. Used to deploy and verify this branch on staging's `localnet-2-localnet`.

## Verification

- `go build ./...`, `go vet`, `go test ./lib/... ./store/...` all clean (pre-existing protobuf lock-copy vet warnings unrelated to this diff).
- Deployed to staging's `localnet-2-localnet` (val-b) via the new script; confirmed all new metrics live on `/metrics`, pod healthy (0 restarts), height progressing normally. Checked repeatedly over several hours under real write load — write-stall and disk-slow counters both stayed at 0, L0 table count stayed well under the 6/12 thresholds.
- Companion Grafana panels ("Pebble LSM" row: write-stall rate/time-fraction, L0 table count with 6/12 threshold lines, compaction debt, read amp, block cache hit ratio, disk-slow rate/max-duration) added to the `canopy-node` dashboard in `superapp-deployments` (separate repo, already merged to local `main`).

Research: pebbledb/flow-migration