### PR TITLE
Use journal keys for validator and non-signer indexer blobs

### DIFF
--- a/cmd/rpc/query_test.go
+++ b/cmd/rpc/query_test.go
@@ -126,6 +126,67 @@ func TestIndexerBlobsCached_JournalPathIncludesUnchangedRewardAccount(t *testing
 	require.Nil(t, entry.current)
 }
 
+func TestIndexerBlobsCached_JournalPathUsesValidatorAndNonSignerKeys(t *testing.T) {
+	server := newTestIndexerBlobServerWithHeights(t, 4)
+	sm := server.controller.FSM
+	db := sm.Store().(lib.StoreI)
+	validatorAddress := crypto.NewAddress(bytes.Repeat([]byte{0x31}, crypto.AddressSize))
+	nonSignerAddress := crypto.NewAddress(bytes.Repeat([]byte{0x32}, crypto.AddressSize))
+	rewardAddress := bytes.Repeat([]byte{0x33}, crypto.AddressSize)
+
+	validatorBz, err := lib.Marshal(&fsm.Validator{Address: validatorAddress.Bytes(), Output: rewardAddress})
+	require.NoError(t, err)
+	nonSignerBz, err := lib.Marshal(&fsm.NonSigner{Address: nonSignerAddress.Bytes(), Counter: 1})
+	require.NoError(t, err)
+	require.NoError(t, sm.Set(fsm.KeyForValidator(validatorAddress), validatorBz))
+	require.NoError(t, sm.Set(fsm.KeyForNonSigner(nonSignerAddress.Bytes()), nonSignerBz))
+	require.NoError(t, db.IndexBlock(&lib.BlockResult{BlockHeader: &lib.BlockHeader{
+		Height: 4,
+		Hash:   crypto.Hash([]byte("block-4-journal-entities")),
+		Time:   uint64(time.Now().UnixMicro()),
+	}}))
+	_, err = db.Commit()
+	require.NoError(t, err)
+	setFSMHeight(t, sm, 5)
+
+	changed, _, err := server.IndexerBlobsCached(5)
+	require.NoError(t, err)
+	require.Len(t, changed.Current.Validators, 1)
+	require.Len(t, changed.Current.NonSigners, 1)
+	require.Equal(t, uint32(1), changed.Current.TotalValidatorsActive)
+
+	require.NoError(t, db.IndexBlock(&lib.BlockResult{BlockHeader: &lib.BlockHeader{
+		Height: 5,
+		Hash:   crypto.Hash([]byte("block-5-validator-reward")),
+		Time:   uint64(time.Now().UnixMicro()),
+	}, Events: []*lib.Event{{EventType: string(lib.EventTypeReward), Address: rewardAddress}}}))
+	_, err = db.Commit()
+	require.NoError(t, err)
+	setFSMHeight(t, sm, 6)
+
+	rewarded, _, err := server.IndexerBlobsCached(6)
+	require.NoError(t, err)
+	require.Len(t, rewarded.Current.Validators, 1)
+	require.Len(t, rewarded.Previous.Validators, 1)
+	require.Empty(t, rewarded.Current.NonSigners)
+	require.Equal(t, uint32(1), rewarded.Current.TotalValidatorsActive)
+
+	require.NoError(t, db.IndexBlock(&lib.BlockResult{BlockHeader: &lib.BlockHeader{
+		Height: 6,
+		Hash:   crypto.Hash([]byte("block-6-no-entity-changes")),
+		Time:   uint64(time.Now().UnixMicro()),
+	}}))
+	_, err = db.Commit()
+	require.NoError(t, err)
+	setFSMHeight(t, sm, 7)
+
+	unchanged, _, err := server.IndexerBlobsCached(7)
+	require.NoError(t, err)
+	require.Empty(t, unchanged.Current.Validators)
+	require.Empty(t, unchanged.Current.NonSigners)
+	require.Equal(t, uint32(1), unchanged.Current.TotalValidatorsActive)
+}
+
 func TestIndexerBlobsCached_HeightTwoPreservesGenesisAccounts(t *testing.T) {
 	log := lib.NewDefaultLogger()
 	db, err := store.NewStoreInMemory(log)

--- a/fsm/indexer.go
+++ b/fsm/indexer.go
@@ -31,10 +31,10 @@ func (s *StateMachine) IndexerBlobs(height uint64) (b *IndexerBlobs, err lib.Err
 
 // IndexerBlob() retrieves the protobuf blobs for a blockchain indexer
 func (s *StateMachine) IndexerBlob(height uint64) (b *IndexerBlob, err lib.ErrorI) {
-	return s.indexerBlob(height, nil, false, false)
+	return s.indexerBlob(height, nil, false, nil)
 }
 
-// IndexerBlobsFromStateChanges builds an account-sparse delta using the state
+// IndexerBlobsFromStateChanges builds a state-sparse delta using the state
 // keys journaled for height. available=false means the height predates the
 // journal and callers must use the legacy full-snapshot comparison.
 func (s *StateMachine) IndexerBlobsFromStateChanges(height uint64) (b *IndexerBlobs, available bool, err lib.ErrorI) {
@@ -52,26 +52,25 @@ func (s *StateMachine) IndexerBlobsFromStateChanges(height uint64) (b *IndexerBl
 	if !ok {
 		return nil, false, nil
 	}
-	accountKeys, available, err := st.StateChangeKeys(height, AccountPrefix())
+	stateKeys, available, err := st.StateChangeKeys(height, AccountPrefix())
 	if err != nil || !available {
 		return nil, available, err
 	}
+	for _, prefix := range [][]byte{ValidatorPrefix(), NonSignerPrefix()} {
+		keys, _, keyErr := st.StateChangeKeys(height, prefix)
+		if keyErr != nil {
+			return nil, true, keyErr
+		}
+		stateKeys = append(stateKeys, keys...)
+	}
 
 	b = &IndexerBlobs{}
-	b.Current, err = s.indexerBlob(height, accountKeys, true, true)
+	b.Current, err = s.indexerBlob(height, stateKeys, true, nil)
 	if err != nil {
 		return nil, true, err
 	}
-	// Reward/slash events can require an unchanged account in the delta. Use
-	// the current block's event addresses for both snapshots so the previous
-	// side cannot look like an unrelated account deletion.
-	eventAccountKeys, eventErr := rewardSlashAccountStateKeys(b.Current.Block)
-	if eventErr != nil {
-		return nil, true, eventErr
-	}
-	accountKeys = append(accountKeys, eventAccountKeys...)
 	if height > 2 {
-		b.Previous, err = s.indexerBlob(height-1, accountKeys, true, false)
+		b.Previous, err = s.indexerBlob(height-1, stateKeys, true, b.Current.Block)
 		if err != nil {
 			return nil, true, err
 		}
@@ -80,7 +79,7 @@ func (s *StateMachine) IndexerBlobsFromStateChanges(height uint64) (b *IndexerBl
 	return b, true, err
 }
 
-func (s *StateMachine) indexerBlob(height uint64, accountKeys [][]byte, selectiveAccounts, includeBlockEventAccounts bool) (b *IndexerBlob, err lib.ErrorI) {
+func (s *StateMachine) indexerBlob(height uint64, stateKeys [][]byte, selectiveState bool, eventBlockBz []byte) (b *IndexerBlob, err lib.ErrorI) {
 	if height == 0 || height > s.height {
 		height = s.height
 	}
@@ -113,25 +112,25 @@ func (s *StateMachine) indexerBlob(height uint64, accountKeys [][]byte, selectiv
 	if block.BlockHeader.Height == 0 || block.BlockHeader.Height != blockHeight {
 		return nil, lib.ErrWrongBlockHeight(block.BlockHeader.Height, blockHeight)
 	}
+	blockBz, err := lib.Marshal(block)
+	if err != nil {
+		return nil, err
+	}
+	if selectiveState && len(eventBlockBz) == 0 {
+		eventBlockBz = blockBz
+	}
 	// use sm for consistent snapshot reads at the requested height
-	// retrieve either the complete account snapshot (legacy path) or only the
-	// keys touched by the requested commit (journal path).
+	// retrieve either complete snapshots (legacy path) or journaled state
+	// entries (journal path).
 	var accounts [][]byte
-	if !selectiveAccounts {
+	if !selectiveState {
 		accounts, err = sm.IterateAndAppend(AccountPrefix())
 	} else {
-		if includeBlockEventAccounts {
-			blockBz, marshalErr := lib.Marshal(block)
-			if marshalErr != nil {
-				return nil, marshalErr
-			}
-			eventAccountKeys, eventErr := rewardSlashAccountStateKeys(blockBz)
-			if eventErr != nil {
-				return nil, eventErr
-			}
-			accountKeys = append(accountKeys, eventAccountKeys...)
+		eventAccountKeys, eventErr := rewardSlashAccountStateKeys(eventBlockBz)
+		if eventErr != nil {
+			return nil, eventErr
 		}
-		accounts, err = sm.valuesForStateKeys(accountKeys, AccountPrefix())
+		accounts, err = sm.valuesForStateKeys(append(stateKeys, eventAccountKeys...), AccountPrefix())
 	}
 	if err != nil {
 		return nil, err
@@ -142,9 +141,20 @@ func (s *StateMachine) indexerBlob(height uint64, accountKeys [][]byte, selectiv
 		return nil, err
 	}
 	// retrieve validators
-	validators, err := sm.IterateAndAppend(ValidatorPrefix())
+	allValidators, err := sm.IterateAndAppend(ValidatorPrefix())
 	if err != nil {
 		return nil, err
+	}
+	validators := allValidators
+	if selectiveState {
+		eventValidatorKeys, eventErr := validatorForceStateKeys(eventBlockBz, allValidators)
+		if eventErr != nil {
+			return nil, eventErr
+		}
+		validators, err = sm.valuesForStateKeys(append(stateKeys, eventValidatorKeys...), ValidatorPrefix())
+		if err != nil {
+			return nil, err
+		}
 	}
 	// retrieve dex prices
 	dexPrices, err := sm.GetDexPrices()
@@ -152,7 +162,12 @@ func (s *StateMachine) indexerBlob(height uint64, accountKeys [][]byte, selectiv
 		return nil, err
 	}
 	// retrieve nonSigners
-	nonSigners, err := sm.IterateAndAppend(NonSignerPrefix())
+	var nonSigners [][]byte
+	if selectiveState {
+		nonSigners, err = sm.valuesForStateKeys(stateKeys, NonSignerPrefix())
+	} else {
+		nonSigners, err = sm.IterateAndAppend(NonSignerPrefix())
+	}
 	if err != nil {
 		return nil, err
 	}
@@ -206,11 +221,6 @@ func (s *StateMachine) indexerBlob(height uint64, accountKeys [][]byte, selectiv
 	if err != nil {
 		return nil, err
 	}
-	// marshal block to bytes
-	blockBz, err := lib.Marshal(block)
-	if err != nil {
-		return nil, err
-	}
 	// marshal dex prices to bytes
 	var dexPricesBz [][]byte
 	for _, price := range dexPrices {
@@ -241,7 +251,7 @@ func (s *StateMachine) indexerBlob(height uint64, accountKeys [][]byte, selectiv
 	}
 	// calculate validator/delegator status totals from the full snapshot
 	totalValidatorsActive, totalValidatorsPaused, totalValidatorsUnstaking,
-		totalDelegatesActive, totalDelegatesPaused, totalDelegatesUnstaking, err := validatorTotals(validators)
+		totalDelegatesActive, totalDelegatesPaused, totalDelegatesUnstaking, err := validatorTotals(allValidators)
 	if err != nil {
 		return nil, err
 	}
@@ -548,6 +558,24 @@ func rewardSlashAccountStateKeys(blockBz []byte) ([][]byte, lib.ErrorI) {
 	keys := make([][]byte, 0, len(addresses))
 	for address := range addresses {
 		keys = append(keys, lib.JoinLenPrefix(accountPrefix, []byte(address)))
+	}
+	return keys, nil
+}
+
+func validatorForceStateKeys(blockBz []byte, validators [][]byte) ([][]byte, lib.ErrorI) {
+	_, validatorMap, outputIndex, err := validatorEntries(validators)
+	if err != nil {
+		return nil, err
+	}
+	forced, err := validatorForceKeys(blockBz, outputIndex, nil)
+	if err != nil {
+		return nil, err
+	}
+	keys := make([][]byte, 0, len(forced))
+	for address := range forced {
+		if _, ok := validatorMap[address]; ok {
+			keys = append(keys, lib.JoinLenPrefix(validatorPrefix, []byte(address)))
+		}
 	}
 	return keys, nil
 }

--- a/fsm/indexer_test.go
+++ b/fsm/indexer_test.go
@@ -115,6 +115,32 @@ func TestDeltaIndexerBlobs_ForceIncludeValidatorByRewardOutput(t *testing.T) {
 	requireEntriesAsSet(t, delta.Previous.Validators, valPrev)
 }
 
+func TestValidatorForceStateKeys_Events(t *testing.T) {
+	address := bytes.Repeat([]byte{12}, 20)
+	output := bytes.Repeat([]byte{13}, 20)
+	validator := mustMarshalProto(t, &Validator{Address: address, Output: output})
+
+	for _, event := range []struct {
+		typ     lib.EventType
+		address []byte
+	}{
+		{lib.EventTypeReward, address},
+		{lib.EventTypeReward, output},
+		{lib.EventTypeSlash, address},
+		{lib.EventTypeAutoPause, address},
+		{lib.EventTypeAutoBeginUnstaking, address},
+		{lib.EventTypeFinishUnstaking, address},
+	} {
+		block := mustMarshalProto(t, &lib.BlockResult{Events: []*lib.Event{{
+			EventType: string(event.typ),
+			Address:   event.address,
+		}}})
+		keys, err := validatorForceStateKeys(block, [][]byte{validator})
+		require.NoError(t, err)
+		require.Equal(t, [][]byte{lib.JoinLenPrefix(validatorPrefix, address)}, keys)
+	}
+}
+
 func TestDeltaIndexerBlobs_NoPreviousKeepsCurrent(t *testing.T) {
 	acc := mustMarshalProto(t, &Account{Address: bytes.Repeat([]byte{10}, 20), Amount: 42})
 	pool := mustMarshalProto(t, &Pool{Id: 42, Amount: 42})


### PR DESCRIPTION
The journal-backed indexer path was only using account keys, even though validator and non-signer changes were already being recorded. This updates the blob query to read those touched entries from the journal too.

I kept the rest of the blob fields as they are since several of them are full snapshots or aggregate values. Validator totals still come from the full validator set, and event-linked accounts and validators are still included even when their stored value did not change. That includes rewards by output address, slashes, pauses, and unstaking lifecycle events.

Added coverage for journaled validator/non-signer changes, unchanged reward validators, and the validator event cases.