### PR TITLE
add tier label to LoadCommittee's stage-time metric

### DIFF
--- a/fsm/state.go
+++ b/fsm/state.go
@@ -445,9 +445,15 @@ func (s *StateMachine) TimeMachine(height uint64) (*StateMachine, lib.ErrorI) {
 // LoadCommittee() loads the committee validators for a particular committee at a particular height
 func (s *StateMachine) LoadCommittee(chainId uint64, height uint64) (lib.ValidatorSet, lib.ErrorI) {
 	startTime := time.Now()
+	// tier: lss = live tip (cheap), hss = everything else (full committee scan + BLS rebuild) -
+	// an lss call in its own slow tail signals resource contention with concurrent hss traffic.
+	tier := "hss"
+	if height == s.height {
+		tier = "lss"
+	}
 	observeStage := func(stage string, stageStartTime time.Time) {
 		if s.Metrics != nil {
-			s.Metrics.LoadCommitteeStageTime.WithLabelValues(stage).Observe(time.Since(stageStartTime).Seconds())
+			s.Metrics.LoadCommitteeStageTime.WithLabelValues(stage, tier).Observe(time.Since(stageStartTime).Seconds())
 		}
 	}
 	defer observeStage("total", startTime)

--- a/lib/metrics.go
+++ b/lib/metrics.go
@@ -579,8 +579,8 @@ func NewMetricsServer(nodeAddress crypto.AddressI, chainID float64, softwareVers
 			}),
 			LoadCommitteeStageTime: promauto.NewHistogramVec(prometheus.HistogramOpts{
 				Name: "canopy_fsm_load_committee_stage_time",
-				Help: "Execution time of LoadCommittee stages",
-			}, []string{"stage"}),
+				Help: "Execution time of LoadCommittee stages, by tier (lss=live tip, hss=every other height) - an lss call in its own slow tail signals resource contention with concurrent hss traffic",
+			}, []string{"stage", "tier"}),
 			GetValidatorSetStageTime: promauto.NewHistogramVec(prometheus.HistogramOpts{
 				Name: "canopy_fsm_get_validator_set_stage_time",
 				Help: "Execution time of getValidatorSet stages",


### PR DESCRIPTION
Stacked on #507 (targets `committee-membership-cache`, not `main` — merge order: #505 -> #506 -> #507 -> this).

## Background

While validating #507's committee cache on staging, we saw periodic 500-900ms fetch-time spikes on otherwise-fast headscan requests (~40-90ms typical), every ~4-6 blocks. Root-caused with temporary debug logging (per-call hit/miss/duration, not shipped) directly on staging:

- The committee cache itself is confirmed working exactly as designed — every headscan request shows precisely one structural miss (`Current`, always a brand-new height) and one hit (`Previous`, always reusing the prior request's `Current`), with zero exceptions once past the initial cold-start.
- The structural miss is normally near-free (~1-2ms) because it's a live-tip (`lss`) read.
- The spikes are **resource contention**: when a live-tip miss happens to land while a burst of concurrent backfill (`hss`, ~500-700ms each — the real cost of a full committee scan + BLS `MultiKey` rebuild) is in flight on the same pod, it pays that contention cost too. Confirmed directly: isolated `lss` misses measured 1-2ms; one caught between three back-to-back `hss` misses measured 612ms.

No fix needed for the contention itself — backfill is a transient, not steady-state, condition; once it drains, this goes away on its own.

## What this PR does

Makes that split observable permanently, so a future occurrence doesn't need ad-hoc debug logging to diagnose again:

- Adds a `tier` label (`lss`/`hss`, same check `indexerBlob` already uses) to the existing `canopy_fsm_load_committee_stage_time` histogram — the metric already timed every stage for all 6 of `LoadCommittee`'s callers (consensus-critical and indexer alike), it just couldn't distinguish cheap live-tip reads from expensive historical ones.
- An `lss`-tier call landing in its own slow tail is now the direct, queryable signature of contention with concurrent `hss` traffic.

Single call site (`LoadCommittee` itself in `fsm/state.go`) feeds all 6 callers; no dashboard/alert configs in this repo reference the metric today, so nothing else needed updating.