### PR TITLE
fix: make cli params go to binary with auto update

### DIFF
--- a/.docker/auto-update/entrypoint.sh
+++ b/.docker/auto-update/entrypoint.sh
@@ -20,9 +20,11 @@ for arg in "$@"; do
   esac
   prev="$arg"
 done
-echo "using data directory $DATA_DIR"
-
 mkdir -p "$DATA_DIR"
+# normalize to an absolute path so relative values (e.g. ./data) don't create a
+# dangling symlink at $BIN_PATH (symlink targets resolve relative to the link)
+DATA_DIR=$(cd "$DATA_DIR" && pwd) || { echo "failed to resolve data dir: $DATA_DIR"; exit 1; }
+echo "using data directory $DATA_DIR"
 
 # Persisting current version
 # Check if it exist

--- a/.docker/auto-update/entrypoint.sh
+++ b/.docker/auto-update/entrypoint.sh
@@ -8,14 +8,30 @@ else
   echo "using existing BIN_PATH $BIN_PATH"
 fi
 
+# resolve data dir: --data-dir flag, then DATA_DIR env, then default
+DATA_DIR="${DATA_DIR:-${HOME:-/root}/.canopy}"
+prev=""
+for arg in "$@"; do
+  case "$prev" in
+    --data-dir) DATA_DIR="$arg" ;;
+  esac
+  case "$arg" in
+    --data-dir=*) DATA_DIR="${arg#--data-dir=}" ;;
+  esac
+  prev="$arg"
+done
+echo "using data directory $DATA_DIR"
+
+mkdir -p "$DATA_DIR"
+
 # Persisting current version
 # Check if it exist
-if [ -f "/root/.canopy/cli" ]; then
+if [ -f "$DATA_DIR/cli" ]; then
   echo "Found existing persistent cli version"
 else
   echo "Persisting build version for current cli"
-  cp "$BIN_PATH" /root/.canopy/cli
+  cp "$BIN_PATH" "$DATA_DIR/cli"
 fi
-ln -sf /root/.canopy/cli "$BIN_PATH"
+ln -sf "$DATA_DIR/cli" "$BIN_PATH"
 
 exec /app/canopy "$@"

--- a/cmd/auto-update/coordinator.go
+++ b/cmd/auto-update/coordinator.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"syscall"
@@ -26,16 +27,18 @@ type Supervisor struct {
 	exit           chan error           // channel to notify listeners when process exits
 	unexpectedExit chan error           // channel to notify listeners when process exits unexpectedly
 	pluginConfig   *PluginReleaseConfig // optional plugin configuration
+	childArgs      []string             // global flags forwarded to the CLI child process
 	log            lib.LoggerI          // logger instance
 }
 
 // NewSupervisor creates a new ProcessSupervisor instance
-func NewSupervisor(logger lib.LoggerI, pluginConfig *PluginReleaseConfig) *Supervisor {
+func NewSupervisor(logger lib.LoggerI, pluginConfig *PluginReleaseConfig, childArgs []string) *Supervisor {
 	return &Supervisor{
 		log:            logger,
 		exit:           make(chan error, 1),
 		unexpectedExit: make(chan error, 1),
 		pluginConfig:   pluginConfig,
+		childArgs:      childArgs,
 	}
 }
 
@@ -48,9 +51,10 @@ func (s *Supervisor) Start(binPath string) error {
 	if s.running.Load() && s.cmd != nil {
 		return errors.New("process already running")
 	}
-	s.log.Infof("starting CLI process: %s", binPath)
-	// setup the process to start
-	s.cmd = exec.Command(binPath, "start")
+	// setup the process to start, forwarding the global flags to the child
+	args := append([]string{"start"}, s.childArgs...)
+	s.log.Infof("starting CLI process: %s %s", binPath, strings.Join(args, " "))
+	s.cmd = exec.Command(binPath, args...)
 	s.cmd.Stdout = os.Stdout
 	s.cmd.Stderr = os.Stderr
 	// make sure the process is in a new process group, this is important for

--- a/cmd/auto-update/main.go
+++ b/cmd/auto-update/main.go
@@ -80,10 +80,15 @@ var (
 )
 
 func main() {
+	// parse global flags up front so they resolve the config and get forwarded
+	positionalArgs, err := cli.ParseGlobalFlags(os.Args[1:])
+	if err != nil {
+		lib.NewDefaultLogger().Fatalf("failed to parse flags: %v", err)
+	}
 	// get configs and logger
 	configs, logger := getConfigs()
 	// check if no start was called, this means it was just called as config
-	if len(os.Args) < 2 || os.Args[1] != "start" {
+	if len(positionalArgs) == 0 || positionalArgs[0] != "start" {
 		// TODO: This message is partly misleading due to the fact that the only place that it would
 		// make sense to have a setup complete message is on the context of the deployments repository.
 		// The actual behavior of this program should be to only start the CLI directly, not perform
@@ -121,10 +126,11 @@ func main() {
 			configs.PluginUpdater.RepoOwner,
 			configs.PluginUpdater.RepoName)
 	}
-	supervisor := NewSupervisor(logger, pluginConfig)
+	// forward the resolved global flags (data-dir, url overrides) to the child
+	supervisor := NewSupervisor(logger, pluginConfig, cli.GlobalFlagArgs())
 	coordinator := NewCoordinator(configs.Coordinator, updater, pluginUpdater, supervisor, snapshot, logger)
 	// start the update loop
-	err := coordinator.UpdateLoop(sigChan)
+	err = coordinator.UpdateLoop(sigChan)
 	if err != nil {
 		exitCode, exitCodeStr := 1, "unknown"
 		// try to extract the exit code from the error
@@ -155,7 +161,7 @@ func getConfigs() (*Configs, lib.LoggerI) {
 		Level:      canopyConfig.GetLogLevel(),
 		Structured: canopyConfig.Structured,
 		JSON:       canopyConfig.JSON,
-	})
+	}, canopyConfig.DataDirPath)
 
 	binPath := envOrDefault("BIN_PATH", defaultBinPath)
 	githubToken := envOrDefault("CANOPY_GITHUB_API_TOKEN", "")
@@ -252,7 +258,9 @@ func getSoftwareVersion(autoUpdate bool, binPath string) string {
 	if !autoUpdate {
 		return rpc.SoftwareVersion
 	}
-	out, err := exec.Command(binPath, "version").Output()
+	// forward the global flags so 'version' targets the same data directory
+	versionArgs := append([]string{"version"}, cli.GlobalFlagArgs()...)
+	out, err := exec.Command(binPath, versionArgs...).Output()
 	if err != nil {
 		panic(fmt.Sprintf("failed to get software version from binary: %v", err))
 	}

--- a/cmd/cli/cli.go
+++ b/cmd/cli/cli.go
@@ -21,6 +21,7 @@ import (
 	"github.com/canopy-network/canopy/lib/crypto"
 	"github.com/canopy-network/canopy/store"
 	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 	"golang.org/x/term"
 	"golang.org/x/text/language"
 	"golang.org/x/text/message"
@@ -35,7 +36,7 @@ var rootCmd = &cobra.Command{
 			Level:      config.GetLogLevel(),
 			Structured: config.Structured,
 			JSON:       config.JSON,
-		})
+		}, config.DataDirPath)
 		if rpcURLFlag != "" {
 			config.RPCUrl = rpcURLFlag
 		}
@@ -92,9 +93,41 @@ func init() {
 	rootCmd.AddCommand(newValidatorKeyCmd)
 	autoCompleteCmd.AddCommand(generateCompleteCmd)
 	autoCompleteCmd.AddCommand(autoCompleteInstallCmd)
-	rootCmd.PersistentFlags().StringVar(&DataDir, "data-dir", lib.DefaultDataDirPath(), "custom data directory location")
-	rootCmd.PersistentFlags().StringVar(&rpcURLFlag, "rpc-url", "", "override the RPC URL from config")
-	rootCmd.PersistentFlags().StringVar(&adminURLFlag, "admin-url", "", "override the admin RPC URL from config")
+	registerPersistentFlags(rootCmd.PersistentFlags())
+}
+
+// registerPersistentFlags binds the global persistent flags onto the given flag
+// set, shared by the CLI and the standalone auto-updater.
+func registerPersistentFlags(fs *pflag.FlagSet) {
+	fs.StringVar(&DataDir, "data-dir", lib.DefaultDataDirPath(), "custom data directory location")
+	fs.StringVar(&rpcURLFlag, "rpc-url", "", "override the RPC URL from config")
+	fs.StringVar(&adminURLFlag, "admin-url", "", "override the admin RPC URL from config")
+}
+
+// ParseGlobalFlags parses the global flags from args, populates the package-level
+// flag values, and returns the remaining positional arguments. It lets consumers
+// outside of cobra (e.g. the auto-updater) honor them.
+func ParseGlobalFlags(args []string) ([]string, error) {
+	fs := pflag.NewFlagSet("canopy", pflag.ContinueOnError)
+	fs.ParseErrorsAllowlist.UnknownFlags = true
+	registerPersistentFlags(fs)
+	if err := fs.Parse(args); err != nil {
+		return nil, err
+	}
+	return fs.Args(), nil
+}
+
+// GlobalFlagArgs reconstructs the global flags as arguments to forward to a child
+// canopy process. Data-dir is always emitted; URL overrides only when set.
+func GlobalFlagArgs() []string {
+	args := []string{"--data-dir", DataDir}
+	if rpcURLFlag != "" {
+		args = append(args, "--rpc-url", rpcURLFlag)
+	}
+	if adminURLFlag != "" {
+		args = append(args, "--admin-url", adminURLFlag)
+	}
+	return args
 }
 
 func Execute() {

--- a/cmd/cli/cli_test.go
+++ b/cmd/cli/cli_test.go
@@ -1,0 +1,53 @@
+package cli
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/canopy-network/canopy/lib"
+)
+
+func TestParseGlobalFlags(t *testing.T) {
+	tests := []struct {
+		name         string
+		args         []string
+		wantDataDir  string
+		wantRPC      string
+		wantAdmin    string
+		wantPosition []string
+	}{
+		{"defaults", []string{"start"}, lib.DefaultDataDirPath(), "", "", []string{"start"}},
+		{"flag before subcmd", []string{"--data-dir", "/custom", "start"}, "/custom", "", "", []string{"start"}},
+		{"flag after subcmd", []string{"start", "--data-dir", "/custom"}, "/custom", "", "", []string{"start"}},
+		{"equals form", []string{"--data-dir=/custom", "start"}, "/custom", "", "", []string{"start"}},
+		{"url overrides", []string{"start", "--rpc-url", "http://x:1", "--admin-url", "http://x:2"}, lib.DefaultDataDirPath(), "http://x:1", "http://x:2", []string{"start"}},
+		{"unknown flag tolerated", []string{"start", "--headless"}, lib.DefaultDataDirPath(), "", "", []string{"start"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			DataDir, rpcURLFlag, adminURLFlag = "", "", ""
+			pos, err := ParseGlobalFlags(tt.args)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if DataDir != tt.wantDataDir || rpcURLFlag != tt.wantRPC || adminURLFlag != tt.wantAdmin {
+				t.Fatalf("got dir=%q rpc=%q admin=%q", DataDir, rpcURLFlag, adminURLFlag)
+			}
+			if !reflect.DeepEqual(pos, tt.wantPosition) {
+				t.Fatalf("positional = %v, want %v", pos, tt.wantPosition)
+			}
+		})
+	}
+}
+
+func TestGlobalFlagArgs(t *testing.T) {
+	DataDir, rpcURLFlag, adminURLFlag = "/custom", "", ""
+	if got := GlobalFlagArgs(); !reflect.DeepEqual(got, []string{"--data-dir", "/custom"}) {
+		t.Fatalf("got %v", got)
+	}
+	DataDir, rpcURLFlag, adminURLFlag = "/custom", "http://r", "http://a"
+	want := []string{"--data-dir", "/custom", "--rpc-url", "http://r", "--admin-url", "http://a"}
+	if got := GlobalFlagArgs(); !reflect.DeepEqual(got, want) {
+		t.Fatalf("got %v, want %v", got, want)
+	}
+}


### PR DESCRIPTION
## Summary
Make `--data-dir` (and the other global flags `--rpc-url` / `--admin-url`) work end-to-end with the auto-updater and Docker. Previously they were honored only by the standalone CLI; under the auto-updater everything fell back to `~/.canopy`.

## Changes
- **cli**: extract shared flag registration; add `ParseGlobalFlags` (parse flags outside cobra) and `GlobalFlagArgs` (reconstruct flags for the child); pass the resolved data dir to the logger so logs land in the custom dir.
- **auto-update**: parse global flags on startup, resolve the updater's own config against them, and forward them to the child process (`start`) and the `version` check.
- **entrypoint.sh**: resolve the data dir from `--data-dir` (or `DATA_DIR`) instead of hardcoding `/root/.canopy`.
- **tests**: unit tests for `ParseGlobalFlags` / `GlobalFlagArgs`.