### PR TITLE
feat(rpc): return all failed txs when address is omitted

### DIFF
--- a/cmd/rpc/query.go
+++ b/cmd/rpc/query.go
@@ -554,12 +554,23 @@ func (s *Server) TransactionsByRecipient(w http.ResponseWriter, r *http.Request,
 	})
 }
 
-// FailedTxs returns a list of failed mempool transactions for the specified address
+// FailedTxs returns a list of failed mempool transactions for the specified address, or for all addresses if none is given
 func (s *Server) FailedTxs(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
-	// Invoke helper with the HTTP request, response writer and an inline callback
-	s.addrIndexer(w, r, func(_ lib.StoreI, address crypto.AddressI, p lib.PageParams) (any, lib.ErrorI) {
-		return s.controller.GetFailedTxsPage(address.String(), p)
-	})
+	req := new(paginatedAddressRequest)
+	if ok := unmarshal(w, r, req); !ok {
+		return
+	}
+	// an empty address string means 'all addresses' to the failed tx cache
+	address := ""
+	if req.Address != nil {
+		address = crypto.NewAddressFromBytes(req.Address).String()
+	}
+	p, err := s.controller.GetFailedTxsPage(address, req.PageParams)
+	if err != nil {
+		write(w, err, http.StatusBadRequest)
+		return
+	}
+	write(w, p, http.StatusOK)
 }
 
 // Proposals returns the proposals present

--- a/cmd/rpc/query_test.go
+++ b/cmd/rpc/query_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"reflect"
+	"sync"
 	"testing"
 	"time"
 	"unsafe"
@@ -326,6 +327,69 @@ func TestAccountsQueryReturnsVestingBreakdowns(t *testing.T) {
 	require.Equal(t, uint64(1), vestedAccount.VestingStartHeight)
 	require.Equal(t, uint64(2), vestedAccount.VestingCliffHeight)
 	require.Equal(t, uint64(6), vestedAccount.VestingEndHeight)
+}
+
+func TestFailedTxsReturnsAllWhenAddressOmitted(t *testing.T) {
+	addrA := crypto.NewAddress(bytes.Repeat([]byte{0x11}, crypto.AddressSize))
+	addrB := crypto.NewAddress(bytes.Repeat([]byte{0x22}, crypto.AddressSize))
+	server := newTestFailedTxServer(t, []*lib.FailedTx{
+		{Hash: "hashA", Address: addrA.String()},
+		{Hash: "hashB", Address: addrB.String()},
+	})
+
+	// no address in the request body means 'return every cached failed tx'
+	req := httptest.NewRequest(http.MethodPost, FailedTxRoutePath, bytes.NewBufferString(`{"pageNumber":1,"perPage":20}`))
+	rec := httptest.NewRecorder()
+
+	server.FailedTxs(rec, req, nil)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	var got struct {
+		Results []lib.FailedTx `json:"results"`
+	}
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &got))
+	require.Len(t, got.Results, 2)
+}
+
+func TestFailedTxsFiltersByAddressWhenGiven(t *testing.T) {
+	addrA := crypto.NewAddress(bytes.Repeat([]byte{0x11}, crypto.AddressSize))
+	addrB := crypto.NewAddress(bytes.Repeat([]byte{0x22}, crypto.AddressSize))
+	server := newTestFailedTxServer(t, []*lib.FailedTx{
+		{Hash: "hashA", Address: addrA.String()},
+		{Hash: "hashB", Address: addrB.String()},
+	})
+
+	req := httptest.NewRequest(http.MethodPost, FailedTxRoutePath, bytes.NewBufferString(
+		`{"address":"`+addrA.String()+`","pageNumber":1,"perPage":20}`,
+	))
+	rec := httptest.NewRecorder()
+
+	server.FailedTxs(rec, req, nil)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	var got struct {
+		Results []lib.FailedTx `json:"results"`
+	}
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &got))
+	require.Len(t, got.Results, 1)
+	require.Equal(t, "hashA", got.Results[0].Hash)
+}
+
+// newTestFailedTxServer builds a Server backed by a real Mempool whose failed-tx cache is pre-seeded with entries
+func newTestFailedTxServer(t *testing.T, entries []*lib.FailedTx) *Server {
+	t.Helper()
+
+	mempool := &controller.Mempool{}
+	cache := lib.NewFailedTxCache()
+	for _, entry := range entries {
+		cache.Add(entry)
+	}
+	setUnexportedField(t, mempool, "cachedFailedTxs", cache)
+
+	return &Server{
+		controller: &controller.Controller{Mutex: &sync.Mutex{}, Mempool: mempool},
+		logger:     lib.NewDefaultLogger(),
+	}
 }
 
 func newTestIndexerBlobServer(t *testing.T) *Server {

--- a/controller/tx.go
+++ b/controller/tx.go
@@ -464,7 +464,7 @@ func normalizeTxHash(hash string) string {
 	return strings.TrimPrefix(strings.ToLower(hash), "0x")
 }
 
-// GetFailedTxsPage() returns a list of failed mempool transactions
+// GetFailedTxsPage() returns a list of failed mempool transactions for the given address, or all cached failed transactions if address is empty
 func (c *Controller) GetFailedTxsPage(address string, p lib.PageParams) (page *lib.Page, err lib.ErrorI) {
 	// try to acquire the lock without blocking — return empty if block processing holds it
 	if !c.TryLock() {

--- a/lib/mempool.go
+++ b/lib/mempool.go
@@ -400,6 +400,7 @@ func (f *FailedTxCache) Get(txHash string) (failedTx *FailedTx, found bool) {
 }
 
 // GetFailedForAddress() returns all the failed transactions in the cache for a given address
+// if address is empty, all failed transactions in the cache are returned
 func (f *FailedTxCache) GetFailedForAddress(address string) (failedTxs []*FailedTx) {
 	// lock for thread safety
 	f.l.Lock()
@@ -407,8 +408,8 @@ func (f *FailedTxCache) GetFailedForAddress(address string) (failedTxs []*Failed
 	defer f.l.Unlock()
 	// for each failed transaction in the cache
 	for _, failed := range f.cache {
-		// if the address matches
-		if failed.Address == address {
+		// if no address was specified or the address matches
+		if address == "" || failed.Address == address {
 			// add to the list
 			failedTxs = append(failedTxs, failed)
 		}

--- a/lib/mempool_test.go
+++ b/lib/mempool_test.go
@@ -582,3 +582,18 @@ func TestFailedTxCache(t *testing.T) {
 		})
 	}
 }
+
+func TestFailedTxCacheGetFailedForAddressEmptyReturnsAll(t *testing.T) {
+	cache := NewFailedTxCache()
+	// add two failed transactions from different addresses
+	failedTx1 := &FailedTx{Hash: "hash1", Address: "address1"}
+	failedTx2 := &FailedTx{Hash: "hash2", Address: "address2"}
+	require.True(t, cache.Add(failedTx1))
+	require.True(t, cache.Add(failedTx2))
+
+	// filtering by a specific address only returns that address' failed tx
+	require.ElementsMatch(t, []*FailedTx{failedTx1}, cache.GetFailedForAddress("address1"))
+
+	// an empty address returns every failed tx in the cache, regardless of address
+	require.ElementsMatch(t, []*FailedTx{failedTx1, failedTx2}, cache.GetFailedForAddress(""))
+}


### PR DESCRIPTION
## Summary
- Return all failed txs when address is omitted in the FailedTxs RPC handler
- Add test coverage for FailedTxs handler for omitted and specific address

## Commits
- feat(rpc): return all failed txs when address is omitted
- test(rpc): cover FailedTxs handler for omitted and specific address