### PR TITLE
Make tx-by-hash say when a tx is committed

### DIFF
--- a/cmd/rpc/README.md
+++ b/cmd/rpc/README.md
@@ -2449,8 +2449,9 @@ $ curl -X POST localhost:50002/v1/query/txs-by-rec \
 - **sender**: `hex-string` - the address of the user sending the transaction
 - **recipient**: `hex-string` - the address of the user receiving the transaction
 - **messageType**: `string` - the name of the of the message like 'send' or 'stake'
-- **height**: `uint64` - the block height at which the transaction was included
-- **index**: `uint64` - the position of the transaction within the block
+- **committed**: `bool` - `true` when the transaction has been included in a block or `false` when it is still in the mempool
+- **height**: `uint64` - the committed block height, or the candidate block height when `committed` is `false`
+- **index**: `uint64` - the committed transaction position, or the candidate position when `committed` is `false`
 - **transaction**: `object` - original transaction object
   - **messageType**: `string` - type of the transaction like 'send' or 'stake'
   - **msg**: `object` - the actual transaction message payload, which is encapsulated in a generic message format.
@@ -2542,6 +2543,7 @@ $ curl -X POST localhost:50002/v1/query/tx-by-hash \
   "sender": "502c0b3d6ccd1c6f164aa5536b2ba2cb9e80c711",
   "recipient": "502c0b3d6ccd1c6f164aa5536b2ba2cb9e80c711",
   "messageType": "send",
+  "committed": true,
   "height": 17585,
   "transaction": {
     "type": "send",

--- a/cmd/rpc/query.go
+++ b/cmd/rpc/query.go
@@ -432,11 +432,17 @@ func (s *Server) TransactionByHash(w http.ResponseWriter, r *http.Request, _ htt
 		return
 	}
 	if tx != nil && tx.GetTxHash() != "" {
-		write(w, tx, http.StatusOK)
+		response := *tx
+		committed := true
+		response.Committed = &committed
+		write(w, &response, http.StatusOK)
 		return
 	}
 	if pendingTx, found := s.controller.GetPendingTxByHash(req.Hash); found {
-		write(w, pendingTx, http.StatusOK)
+		response := *pendingTx
+		committed := false
+		response.Committed = &committed
+		write(w, &response, http.StatusOK)
 		return
 	}
 	write(w, map[string]string{"error": "transaction not found"}, http.StatusNotFound)

--- a/cmd/rpc/query_test.go
+++ b/cmd/rpc/query_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"reflect"
+	"sync"
 	"testing"
 	"time"
 	"unsafe"
@@ -18,6 +19,38 @@ import (
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/proto"
 )
+
+func TestTransactionByHashStatus(t *testing.T) {
+	server := newTestIndexerBlobServer(t)
+	committedHash := crypto.HashString([]byte("committed"))
+	db := server.controller.FSM.Store().(lib.StoreI)
+	require.NoError(t, db.IndexTx(&lib.TxResult{TxHash: committedHash}))
+	_, err := db.Commit()
+	require.NoError(t, err)
+
+	pendingHash := crypto.HashString([]byte("pending"))
+	pending := &lib.TxResult{TxHash: pendingHash}
+	mempool := &controller.Mempool{L: &sync.Mutex{}}
+	setUnexportedField(t, mempool, "cachedResults", lib.TxResults{pending})
+	server.controller.Mempool = mempool
+
+	for _, test := range []struct {
+		name, hash string
+		committed  bool
+	}{{"committed", committedHash, true}, {"pending", pendingHash, false}} {
+		t.Run(test.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodPost, TxByHashRoutePath, bytes.NewBufferString(`{"hash":"`+test.hash+`"}`))
+			rec := httptest.NewRecorder()
+			server.TransactionByHash(rec, req, nil)
+			require.Equal(t, http.StatusOK, rec.Code)
+			result := new(lib.TxResult)
+			require.NoError(t, json.Unmarshal(rec.Body.Bytes(), result))
+			require.NotNil(t, result.Committed)
+			require.Equal(t, test.committed, *result.Committed)
+		})
+	}
+	require.Nil(t, pending.Committed)
+}
 
 func TestIndexerBlobs_IgnoresLegacyDeltaField(t *testing.T) {
 	server := newTestIndexerBlobServer(t)

--- a/lib/.proto/tx.proto
+++ b/lib/.proto/tx.proto
@@ -61,6 +61,8 @@ message TxResult {
   Transaction transaction = 6;
   // tx_hash: The unique hash that identifies the transaction
   string tx_hash = 7; // @gotags: json:"txHash"
+  // committed: Whether the transaction has been included in a committed block
+  optional bool committed = 8;
 }
 // A Signature is a digital signature is a cryptographic "fingerprint" created with a private key,
 // allowing others to verify the authenticity and integrity of a message using the corresponding public key

--- a/lib/tx.go
+++ b/lib/tx.go
@@ -339,6 +339,7 @@ type jsonTxResult struct {
 	Index       uint64       `json:"index,omitempty"`
 	Transaction *Transaction `json:"transaction,omitempty"`
 	TxHash      string       `json:"txHash,omitempty"`
+	Committed   *bool        `json:"committed,omitempty"`
 }
 
 // MarshalJSON() satisfies the json.Marshaller interface
@@ -351,6 +352,7 @@ func (x TxResult) MarshalJSON() ([]byte, error) {
 		Index:       x.Index,
 		Transaction: x.Transaction,
 		TxHash:      x.TxHash,
+		Committed:   x.Committed,
 	})
 }
 
@@ -372,6 +374,7 @@ func (x *TxResult) UnmarshalJSON(jsonBytes []byte) (err error) {
 		Index:       j.Index,
 		Transaction: j.Transaction,
 		TxHash:      j.TxHash,
+		Committed:   j.Committed,
 	}
 	// exit
 	return

--- a/lib/tx.pb.go
+++ b/lib/tx.pb.go
@@ -182,7 +182,9 @@ type TxResult struct {
 	// transaction: The original transaction object
 	Transaction *Transaction `protobuf:"bytes,6,opt,name=transaction,proto3" json:"transaction,omitempty"`
 	// tx_hash: The unique hash that identifies the transaction
-	TxHash        string `protobuf:"bytes,7,opt,name=tx_hash,json=txHash,proto3" json:"txHash"` // @gotags: json:"txHash"
+	TxHash string `protobuf:"bytes,7,opt,name=tx_hash,json=txHash,proto3" json:"txHash"` // @gotags: json:"txHash"
+	// committed: Whether the transaction has been included in a committed block
+	Committed     *bool `protobuf:"varint,8,opt,name=committed,proto3,oneof" json:"committed,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -266,6 +268,13 @@ func (x *TxResult) GetTxHash() string {
 	return ""
 }
 
+func (x *TxResult) GetCommitted() bool {
+	if x != nil && x.Committed != nil {
+		return *x.Committed
+	}
+	return false
+}
+
 // A Signature is a digital signature is a cryptographic "fingerprint" created with a private key,
 // allowing others to verify the authenticity and integrity of a message using the corresponding public key
 type Signature struct {
@@ -339,7 +348,7 @@ const file_tx_proto_rawDesc = "" +
 	"network_id\x18\b \x01(\x04R\tnetworkId\x12\x19\n" +
 	"\bchain_id\x18\t \x01(\x04R\achainId\x12\x14\n" +
 	"\x05nonce\x18\n" +
-	" \x01(\x04R\x05nonce\"\xe0\x01\n" +
+	" \x01(\x04R\x05nonce\"\x91\x02\n" +
 	"\bTxResult\x12\x16\n" +
 	"\x06sender\x18\x01 \x01(\fR\x06sender\x12\x1c\n" +
 	"\trecipient\x18\x02 \x01(\fR\trecipient\x12!\n" +
@@ -347,7 +356,10 @@ const file_tx_proto_rawDesc = "" +
 	"\x06height\x18\x04 \x01(\x04R\x06height\x12\x14\n" +
 	"\x05index\x18\x05 \x01(\x04R\x05index\x124\n" +
 	"\vtransaction\x18\x06 \x01(\v2\x12.types.TransactionR\vtransaction\x12\x17\n" +
-	"\atx_hash\x18\a \x01(\tR\x06txHash\"H\n" +
+	"\atx_hash\x18\a \x01(\tR\x06txHash\x12!\n" +
+	"\tcommitted\x18\b \x01(\bH\x00R\tcommitted\x88\x01\x01B\f\n" +
+	"\n" +
+	"_committed\"H\n" +
 	"\tSignature\x12\x1d\n" +
 	"\n" +
 	"public_key\x18\x01 \x01(\fR\tpublicKey\x12\x1c\n" +
@@ -388,6 +400,7 @@ func file_tx_proto_init() {
 	if File_tx_proto != nil {
 		return
 	}
+	file_tx_proto_msgTypes[1].OneofWrappers = []any{}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
 		File: protoimpl.DescBuilder{


### PR DESCRIPTION
Small follow-up to make native tx lookups a little less ambiguous.

The endpoint can return either an indexed tx or a mempool tx, so this adds a committed boolean to make that distinction explicit. It is true for the store-backed path and false for the mempool fallback. The field stays optional internally so older responses remain distinguishable from an explicit false.

Also added coverage for both paths and updated the RPC example.

Tested with: go test ./...