### PR TITLE
Add a small offline native transaction signer

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,6 +34,10 @@ jobs:
           GOARCH=amd64 CGO_ENABLED=0 GOOS=linux go build -a -o dist/cli-linux-amd64 ./cmd/main/...
           GOARCH=arm64 CGO_ENABLED=0 GOOS=linux go build -a -o dist/cli-linux-arm64 ./cmd/main/...
           GOARCH=arm64 CGO_ENABLED=0 GOOS=darwin go build -a -o dist/cli-darwin-arm64 ./cmd/main/...
+          GOARCH=amd64 CGO_ENABLED=0 GOOS=linux go build -a -o dist/signer-linux-amd64 ./cmd/signer/...
+          GOARCH=arm64 CGO_ENABLED=0 GOOS=linux go build -a -o dist/signer-linux-arm64 ./cmd/signer/...
+          GOARCH=arm64 CGO_ENABLED=0 GOOS=darwin go build -a -o dist/signer-darwin-arm64 ./cmd/signer/...
+          sha256sum dist/cli-* dist/signer-* > dist/SHA256SUMS
 
       - name: Create GitHub release
         uses: softprops/action-gh-release@v3
@@ -44,6 +48,10 @@ jobs:
             dist/cli-linux-amd64
             dist/cli-linux-arm64
             dist/cli-darwin-arm64
+            dist/signer-linux-amd64
+            dist/signer-linux-arm64
+            dist/signer-darwin-arm64
+            dist/SHA256SUMS
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@
 *.so
 *.dylib
 /main
+/signer
 .cache
 # Test binary, built with `go test -c`
 *.test

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 # Variables
 GO_BIN_DIR := ~/go/bin
 CLI_DIR := ./cmd/main/...
+SIGNER_DIR := ./cmd/signer/...
 AUTO_UPDATE_DIR := ./cmd/auto-update/...
 WALLET_DIR := ./cmd/rpc/web/wallet
 EXPLORER_DIR := ./cmd/rpc/web/explorer
@@ -17,7 +18,7 @@ help:
 	@sed -n 's/^##//p' ${MAKEFILE_LIST} | column -t -s ':' |  sed -e 's/^/ /'
 
 # Targets, this is a list of all available commands which can be executed using the make command.
-.PHONY: build/canopy build/canopy-full build/wallet build/explorer build/auto-update build/auto-update-local run/auto-update run/auto-update-build run/auto-update-test test/all dev/deps docker/up \
+.PHONY: build/canopy build/canopy-full build/signer build/wallet build/explorer build/auto-update build/auto-update-local run/auto-update run/auto-update-build run/auto-update-test test/all dev/deps docker/up \
 	docker/down docker/build docker/up-fast docker/down docker/logs \
 	build/plugin build/kotlin-plugin build/go-plugin build/all-plugins docker/plugin \
 	docker/run docker/run-kotlin docker/run-go docker/run-typescript docker/run-python docker/run-csharp \
@@ -33,6 +34,10 @@ build/canopy: build/wallet build/explorer
 
 ## build/canopy-full: build the canopy binary and its wallet and explorer altogether
 build/canopy-full: build/canopy
+
+## build/signer: build the offline native transaction signer into the GO_BIN_DIR
+build/signer:
+	go build -o $(GO_BIN_DIR)/signer $(SIGNER_DIR)
 
 ## build/wallet: build the canopy's wallet project
 build/wallet:

--- a/cmd/signer/main.go
+++ b/cmd/signer/main.go
@@ -20,17 +20,22 @@ import (
 
 const maxInputBytes = 1 << 20
 
+// main() executes the offline signer command
 func main() {
+	// run the command and print any returned error
 	if err := run(os.Args[1:], os.Stdin, os.Stdout, os.Stderr); err != nil {
 		_, _ = fmt.Fprintf(os.Stderr, "signer: %v\n", err)
 		os.Exit(1)
 	}
 }
 
+// run() routes the command-line arguments to the selected signer command
 func run(args []string, stdin *os.File, stdout, stderr io.Writer) error {
+	// print usage when no command was provided
 	if len(args) == 0 {
 		return usage(stderr)
 	}
+	// execute the selected command
 	switch args[0] {
 	case "sign-send":
 		return signSend(args[1:], stdin, stdout, stderr)
@@ -43,6 +48,7 @@ func run(args []string, stdin *os.File, stdout, stderr io.Writer) error {
 	}
 }
 
+// usage() prints the signer command usage
 func usage(w io.Writer) error {
 	_, _ = fmt.Fprintln(w, `Usage:
   signer sign-send --keystore-dir DIR --key ADDRESS_OR_NICKNAME REQUEST.json
@@ -53,7 +59,9 @@ standard input when piped. The signed /v1/tx JSON is written to standard output.
 	return nil
 }
 
+// signSend() parses a send request, unlocks its key, and writes the signed transaction
 func signSend(args []string, stdin *os.File, stdout, stderr io.Writer) error {
+	// define and parse the sign-send flags
 	flags := flag.NewFlagSet("sign-send", flag.ContinueOnError)
 	flags.SetOutput(stderr)
 	keystoreDir := flags.String("keystore-dir", "", "directory containing keystore.json")
@@ -61,67 +69,86 @@ func signSend(args []string, stdin *os.File, stdout, stderr io.Writer) error {
 	if err := flags.Parse(args); err != nil {
 		return err
 	}
+	// validate the required flags and request file
 	if *keystoreDir == "" || *keySelector == "" || flags.NArg() != 1 {
 		return fmt.Errorf("sign-send requires --keystore-dir, --key, and one request file")
 	}
+	// decode the send request
 	request := new(signer.SendRequest)
 	if err := decodeFile(flags.Arg(0), request); err != nil {
 		return fmt.Errorf("read request: %w", err)
 	}
+	// read the keystore password without echo when using a terminal
 	password, err := readPassword(stdin, stderr)
 	if err != nil {
 		return err
 	}
+	// load the keystore from disk
 	keystore, err := crypto.NewKeystoreFromFile(*keystoreDir)
 	if err != nil {
 		return fmt.Errorf("read keystore: %w", err)
 	}
+	// select the key by nickname unless the selector is a valid address
 	options := crypto.GetKeyGroupOpts{Nickname: *keySelector}
 	if address, addressErr := crypto.NewAddressFromString(*keySelector); addressErr == nil && len(address.Bytes()) == crypto.AddressSize {
 		options = crypto.GetKeyGroupOpts{Address: address.Bytes()}
 	}
+	// unlock the selected key
 	key, err := keystore.GetKeyGroup(password, options)
 	if err != nil {
 		return fmt.Errorf("unlock key: %w", err)
 	}
+	// build and sign the native send
 	transaction, err := signer.SignSend(*request, key.PrivateKey)
 	if err != nil {
 		return err
 	}
+	// write the signed transaction as JSON
 	return writeJSON(stdout, transaction)
 }
 
+// inspect() verifies a signed transaction and writes its auditable details
 func inspect(args []string, stdout io.Writer) error {
+	// parse the inspect arguments without writing flag errors to stdout
 	flags := flag.NewFlagSet("inspect", flag.ContinueOnError)
 	flags.SetOutput(io.Discard)
 	if err := flags.Parse(args); err != nil {
 		return err
 	}
+	// validate the required signed transaction file
 	if flags.NArg() != 1 {
 		return fmt.Errorf("inspect requires one signed transaction file")
 	}
+	// decode the signed transaction
 	transaction := new(lib.Transaction)
 	if err := decodeFile(flags.Arg(0), transaction); err != nil {
 		return fmt.Errorf("read transaction: %w", err)
 	}
+	// verify and inspect the transaction
 	details, err := signer.Inspect(transaction)
 	if err != nil {
 		return err
 	}
+	// write the verified details as JSON
 	return writeJSON(stdout, details)
 }
 
+// decodeFile() decodes exactly one size-limited JSON value from a file
 func decodeFile(path string, destination any) error {
+	// open the source file
 	file, err := os.Open(path)
 	if err != nil {
 		return err
 	}
+	// ensure the source file is closed before returning
 	defer func() { _ = file.Close() }()
+	// decode the size-limited JSON and reject unknown fields
 	decoder := json.NewDecoder(io.LimitReader(file, maxInputBytes))
 	decoder.DisallowUnknownFields()
 	if err = decoder.Decode(destination); err != nil {
 		return err
 	}
+	// reject any additional JSON values after the first value
 	var trailing any
 	if err = decoder.Decode(&trailing); !errors.Is(err, io.EOF) {
 		return fmt.Errorf("file must contain exactly one JSON value")
@@ -129,7 +156,9 @@ func decodeFile(path string, destination any) error {
 	return nil
 }
 
+// readPassword() reads a password from a terminal or piped standard input
 func readPassword(input *os.File, prompt io.Writer) (string, error) {
+	// read from the terminal without echo when one is attached
 	if term.IsTerminal(int(input.Fd())) {
 		_, _ = fmt.Fprint(prompt, "Keystore password: ")
 		password, err := term.ReadPassword(int(input.Fd()))
@@ -137,27 +166,34 @@ func readPassword(input *os.File, prompt io.Writer) (string, error) {
 		if err != nil {
 			return "", fmt.Errorf("read password: %w", err)
 		}
+		// reject empty terminal passwords
 		if len(password) == 0 {
 			return "", fmt.Errorf("password cannot be empty")
 		}
 		return string(password), nil
 	}
+	// limit a piped password to 4096 bytes plus one byte for overflow detection
 	reader := bufio.NewReader(io.LimitReader(input, 4097))
 	password, err := io.ReadAll(reader)
 	if err != nil {
 		return "", fmt.Errorf("read password: %w", err)
 	}
+	// reject a piped password that exceeds the size limit
 	if len(password) > 4096 {
 		return "", fmt.Errorf("password exceeds 4096 bytes")
 	}
+	// remove one trailing line ending from the piped password
 	value := strings.TrimSuffix(strings.TrimSuffix(string(password), "\n"), "\r")
+	// reject empty piped passwords
 	if value == "" {
 		return "", fmt.Errorf("password cannot be empty")
 	}
 	return value, nil
 }
 
+// writeJSON() writes an indented JSON value to the destination
 func writeJSON(output io.Writer, value any) error {
+	// configure and execute the JSON encoder
 	encoder := json.NewEncoder(output)
 	encoder.SetIndent("", "  ")
 	return encoder.Encode(value)

--- a/cmd/signer/main.go
+++ b/cmd/signer/main.go
@@ -1,0 +1,164 @@
+// signer is an offline command for signing and inspecting native Canopy
+// sends. It intentionally contains no networking code.
+package main
+
+import (
+	"bufio"
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/canopy-network/canopy/lib"
+	"github.com/canopy-network/canopy/lib/crypto"
+	"github.com/canopy-network/canopy/lib/crypto/signer"
+	"golang.org/x/term"
+)
+
+const maxInputBytes = 1 << 20
+
+func main() {
+	if err := run(os.Args[1:], os.Stdin, os.Stdout, os.Stderr); err != nil {
+		_, _ = fmt.Fprintf(os.Stderr, "signer: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+func run(args []string, stdin *os.File, stdout, stderr io.Writer) error {
+	if len(args) == 0 {
+		return usage(stderr)
+	}
+	switch args[0] {
+	case "sign-send":
+		return signSend(args[1:], stdin, stdout, stderr)
+	case "inspect":
+		return inspect(args[1:], stdout)
+	case "help", "-h", "--help":
+		return usage(stderr)
+	default:
+		return fmt.Errorf("unknown command %q", args[0])
+	}
+}
+
+func usage(w io.Writer) error {
+	_, _ = fmt.Fprintln(w, `Usage:
+  signer sign-send --keystore-dir DIR --key ADDRESS_OR_NICKNAME REQUEST.json
+  signer inspect SIGNED.json
+
+sign-send reads the keystore password from a terminal without echo, or from
+standard input when piped. The signed /v1/tx JSON is written to standard output.`)
+	return nil
+}
+
+func signSend(args []string, stdin *os.File, stdout, stderr io.Writer) error {
+	flags := flag.NewFlagSet("sign-send", flag.ContinueOnError)
+	flags.SetOutput(stderr)
+	keystoreDir := flags.String("keystore-dir", "", "directory containing keystore.json")
+	keySelector := flags.String("key", "", "key address or nickname")
+	if err := flags.Parse(args); err != nil {
+		return err
+	}
+	if *keystoreDir == "" || *keySelector == "" || flags.NArg() != 1 {
+		return fmt.Errorf("sign-send requires --keystore-dir, --key, and one request file")
+	}
+	request := new(signer.SendRequest)
+	if err := decodeFile(flags.Arg(0), request); err != nil {
+		return fmt.Errorf("read request: %w", err)
+	}
+	password, err := readPassword(stdin, stderr)
+	if err != nil {
+		return err
+	}
+	keystore, err := crypto.NewKeystoreFromFile(*keystoreDir)
+	if err != nil {
+		return fmt.Errorf("read keystore: %w", err)
+	}
+	options := crypto.GetKeyGroupOpts{Nickname: *keySelector}
+	if address, addressErr := crypto.NewAddressFromString(*keySelector); addressErr == nil && len(address.Bytes()) == crypto.AddressSize {
+		options = crypto.GetKeyGroupOpts{Address: address.Bytes()}
+	}
+	key, err := keystore.GetKeyGroup(password, options)
+	if err != nil {
+		return fmt.Errorf("unlock key: %w", err)
+	}
+	transaction, err := signer.SignSend(*request, key.PrivateKey)
+	if err != nil {
+		return err
+	}
+	return writeJSON(stdout, transaction)
+}
+
+func inspect(args []string, stdout io.Writer) error {
+	flags := flag.NewFlagSet("inspect", flag.ContinueOnError)
+	flags.SetOutput(io.Discard)
+	if err := flags.Parse(args); err != nil {
+		return err
+	}
+	if flags.NArg() != 1 {
+		return fmt.Errorf("inspect requires one signed transaction file")
+	}
+	transaction := new(lib.Transaction)
+	if err := decodeFile(flags.Arg(0), transaction); err != nil {
+		return fmt.Errorf("read transaction: %w", err)
+	}
+	details, err := signer.Inspect(transaction)
+	if err != nil {
+		return err
+	}
+	return writeJSON(stdout, details)
+}
+
+func decodeFile(path string, destination any) error {
+	file, err := os.Open(path)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = file.Close() }()
+	decoder := json.NewDecoder(io.LimitReader(file, maxInputBytes))
+	decoder.DisallowUnknownFields()
+	if err = decoder.Decode(destination); err != nil {
+		return err
+	}
+	var trailing any
+	if err = decoder.Decode(&trailing); !errors.Is(err, io.EOF) {
+		return fmt.Errorf("file must contain exactly one JSON value")
+	}
+	return nil
+}
+
+func readPassword(input *os.File, prompt io.Writer) (string, error) {
+	if term.IsTerminal(int(input.Fd())) {
+		_, _ = fmt.Fprint(prompt, "Keystore password: ")
+		password, err := term.ReadPassword(int(input.Fd()))
+		_, _ = fmt.Fprintln(prompt)
+		if err != nil {
+			return "", fmt.Errorf("read password: %w", err)
+		}
+		if len(password) == 0 {
+			return "", fmt.Errorf("password cannot be empty")
+		}
+		return string(password), nil
+	}
+	reader := bufio.NewReader(io.LimitReader(input, 4097))
+	password, err := io.ReadAll(reader)
+	if err != nil {
+		return "", fmt.Errorf("read password: %w", err)
+	}
+	if len(password) > 4096 {
+		return "", fmt.Errorf("password exceeds 4096 bytes")
+	}
+	value := strings.TrimSuffix(strings.TrimSuffix(string(password), "\n"), "\r")
+	if value == "" {
+		return "", fmt.Errorf("password cannot be empty")
+	}
+	return value, nil
+}
+
+func writeJSON(output io.Writer, value any) error {
+	encoder := json.NewEncoder(output)
+	encoder.SetIndent("", "  ")
+	return encoder.Encode(value)
+}

--- a/cmd/signer/main_test.go
+++ b/cmd/signer/main_test.go
@@ -13,12 +13,15 @@ import (
 )
 
 func TestSignSendAndInspect(t *testing.T) {
+	// initialize a temporary keystore location and password
 	directory := t.TempDir()
 	password := "test-password"
+	// generate a private key for the test keystore
 	key, err := crypto.NewBLS12381PrivateKey()
 	if err != nil {
 		t.Fatal(err)
 	}
+	// import the key with a nickname and persist the keystore
 	keystore := crypto.NewKeystoreInMemory()
 	address, err := keystore.ImportRaw(key.Bytes(), password, crypto.ImportRawOpts{Nickname: "withdrawal"})
 	if err != nil {
@@ -27,6 +30,7 @@ func TestSignSendAndInspect(t *testing.T) {
 	if err = keystore.SaveToFile(directory); err != nil {
 		t.Fatal(err)
 	}
+	// define a valid offline send request
 	request := signer.SendRequest{
 		Recipient:     "502c0b3d6ccd1c6f164aa5536b2ba2cb9e80c711",
 		AmountUCNPY:   1_000_000,
@@ -36,6 +40,7 @@ func TestSignSendAndInspect(t *testing.T) {
 		ChainID:       1,
 		Time:          1_786_569_463_230_678,
 	}
+	// encode the request and write it to disk
 	requestJSON, err := json.Marshal(request)
 	if err != nil {
 		t.Fatal(err)
@@ -44,21 +49,26 @@ func TestSignSendAndInspect(t *testing.T) {
 	if err = os.WriteFile(requestPath, requestJSON, 0600); err != nil {
 		t.Fatal(err)
 	}
+	// create a pipe that simulates a password supplied through standard input
 	inputReader, inputWriter, err := os.Pipe()
 	if err != nil {
 		t.Fatal(err)
 	}
+	// write the password into the pipe
 	if _, err = inputWriter.WriteString(password + "\n"); err != nil {
 		t.Fatal(err)
 	}
+	// close both ends of the password pipe when they are no longer needed
 	_ = inputWriter.Close()
 	defer func() { _ = inputReader.Close() }()
+	// execute sign-send using the key nickname
 	var signedJSON, errorOutput bytes.Buffer
 	if err = run([]string{
 		"sign-send", "--keystore-dir", directory, "--key", "withdrawal", requestPath,
 	}, inputReader, &signedJSON, &errorOutput); err != nil {
 		t.Fatalf("sign: %v; stderr: %s", err, errorOutput.String())
 	}
+	// decode and inspect the signed transaction
 	transaction := new(lib.Transaction)
 	if err = json.Unmarshal(signedJSON.Bytes(), transaction); err != nil {
 		t.Fatal(err)
@@ -67,18 +77,22 @@ func TestSignSendAndInspect(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	// validate the signed transaction details
 	if details.Sender != address || details.AmountUCNPY != request.AmountUCNPY {
 		t.Fatalf("unexpected signed details: %+v", details)
 	}
 
+	// write the signed transaction to disk for the inspect command
 	signedPath := filepath.Join(directory, "signed.json")
 	if err = os.WriteFile(signedPath, signedJSON.Bytes(), 0600); err != nil {
 		t.Fatal(err)
 	}
+	// execute inspect on the signed transaction
 	var inspectedJSON bytes.Buffer
 	if err = run([]string{"inspect", signedPath}, inputReader, &inspectedJSON, &errorOutput); err != nil {
 		t.Fatal(err)
 	}
+	// decode and validate the inspected details
 	inspected := new(signer.Details)
 	if err = json.Unmarshal(inspectedJSON.Bytes(), inspected); err != nil {
 		t.Fatal(err)
@@ -89,16 +103,20 @@ func TestSignSendAndInspect(t *testing.T) {
 }
 
 func TestSignSendRejectsUnknownRequestField(t *testing.T) {
+	// write a request containing an unsupported JSON field
 	path := filepath.Join(t.TempDir(), "request.json")
 	if err := os.WriteFile(path, []byte(`{"unknown":true}`), 0600); err != nil {
 		t.Fatal(err)
 	}
+	// create an empty password input pipe
 	input, output, err := os.Pipe()
 	if err != nil {
 		t.Fatal(err)
 	}
+	// close both ends of the pipe when they are no longer needed
 	_ = output.Close()
 	defer func() { _ = input.Close() }()
+	// ensure strict request decoding rejects the unknown field
 	if err = run([]string{"sign-send", "--keystore-dir", t.TempDir(), "--key", "key", path}, input, &bytes.Buffer{}, &bytes.Buffer{}); err == nil {
 		t.Fatal("expected request decoding error")
 	}

--- a/cmd/signer/main_test.go
+++ b/cmd/signer/main_test.go
@@ -1,0 +1,105 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/canopy-network/canopy/lib"
+	"github.com/canopy-network/canopy/lib/crypto"
+	"github.com/canopy-network/canopy/lib/crypto/signer"
+)
+
+func TestSignSendAndInspect(t *testing.T) {
+	directory := t.TempDir()
+	password := "test-password"
+	key, err := crypto.NewBLS12381PrivateKey()
+	if err != nil {
+		t.Fatal(err)
+	}
+	keystore := crypto.NewKeystoreInMemory()
+	address, err := keystore.ImportRaw(key.Bytes(), password, crypto.ImportRawOpts{Nickname: "withdrawal"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err = keystore.SaveToFile(directory); err != nil {
+		t.Fatal(err)
+	}
+	request := signer.SendRequest{
+		Recipient:     "502c0b3d6ccd1c6f164aa5536b2ba2cb9e80c711",
+		AmountUCNPY:   1_000_000,
+		FeeUCNPY:      10_000,
+		CreatedHeight: 2_044_370,
+		NetworkID:     1,
+		ChainID:       1,
+		Time:          1_786_569_463_230_678,
+	}
+	requestJSON, err := json.Marshal(request)
+	if err != nil {
+		t.Fatal(err)
+	}
+	requestPath := filepath.Join(directory, "request.json")
+	if err = os.WriteFile(requestPath, requestJSON, 0600); err != nil {
+		t.Fatal(err)
+	}
+	inputReader, inputWriter, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err = inputWriter.WriteString(password + "\n"); err != nil {
+		t.Fatal(err)
+	}
+	_ = inputWriter.Close()
+	defer func() { _ = inputReader.Close() }()
+	var signedJSON, errorOutput bytes.Buffer
+	if err = run([]string{
+		"sign-send", "--keystore-dir", directory, "--key", "withdrawal", requestPath,
+	}, inputReader, &signedJSON, &errorOutput); err != nil {
+		t.Fatalf("sign: %v; stderr: %s", err, errorOutput.String())
+	}
+	transaction := new(lib.Transaction)
+	if err = json.Unmarshal(signedJSON.Bytes(), transaction); err != nil {
+		t.Fatal(err)
+	}
+	details, err := signer.Inspect(transaction)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if details.Sender != address || details.AmountUCNPY != request.AmountUCNPY {
+		t.Fatalf("unexpected signed details: %+v", details)
+	}
+
+	signedPath := filepath.Join(directory, "signed.json")
+	if err = os.WriteFile(signedPath, signedJSON.Bytes(), 0600); err != nil {
+		t.Fatal(err)
+	}
+	var inspectedJSON bytes.Buffer
+	if err = run([]string{"inspect", signedPath}, inputReader, &inspectedJSON, &errorOutput); err != nil {
+		t.Fatal(err)
+	}
+	inspected := new(signer.Details)
+	if err = json.Unmarshal(inspectedJSON.Bytes(), inspected); err != nil {
+		t.Fatal(err)
+	}
+	if *inspected != *details {
+		t.Fatalf("inspect mismatch: got %+v want %+v", inspected, details)
+	}
+}
+
+func TestSignSendRejectsUnknownRequestField(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "request.json")
+	if err := os.WriteFile(path, []byte(`{"unknown":true}`), 0600); err != nil {
+		t.Fatal(err)
+	}
+	input, output, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = output.Close()
+	defer func() { _ = input.Close() }()
+	if err = run([]string{"sign-send", "--keystore-dir", t.TempDir(), "--key", "key", path}, input, &bytes.Buffer{}, &bytes.Buffer{}); err == nil {
+		t.Fatal("expected request decoding error")
+	}
+}

--- a/lib/crypto/signer/README.md
+++ b/lib/crypto/signer/README.md
@@ -1,0 +1,126 @@
+# Native transaction signer
+
+This package is the intentionally small, offline signing boundary for native
+Canopy transfers. It can be imported by custody software or used through the
+`signer` executable. Both paths call the same implementation.
+
+The package performs no network or filesystem operations. It constructs the
+same protobuf transaction accepted by `POST /v1/tx`, signs the canonical bytes
+returned by `Transaction.GetSignBytes`, and immediately verifies the result.
+
+## Security boundary
+
+The online system supplies these non-secret fields:
+
+- recipient;
+- amount and fee in integer `uCNPY`;
+- recent chain height;
+- network ID and chain ID;
+- a stable Unix-microsecond timestamp;
+- optional memo.
+
+The offline system must display or otherwise authorize those fields before
+signing. The `inspect` command independently derives them from a signed
+transaction and verifies its signature.
+
+The signer deliberately does not:
+
+- contact an RPC server;
+- choose a recipient, amount, or fee;
+- decide whether a height is current;
+- decide whether a fee satisfies current governance parameters;
+- broadcast a transaction;
+- determine whether a submitted transaction committed.
+
+Those stateful checks remain with the synchronized node. A native transaction's
+`createdHeight` must normally be within the protocol acceptance range when it is
+submitted.
+
+## Package use
+
+Pass an existing Canopy `crypto.PrivateKeyI`, such as a key returned by the
+encrypted keystore:
+
+```go
+request := signer.SendRequest{
+    Recipient:     "502c0b3d6ccd1c6f164aa5536b2ba2cb9e80c711",
+    AmountUCNPY:   1_000_000,
+    FeeUCNPY:      10_000,
+    CreatedHeight: 2_044_370,
+    NetworkID:     1,
+    ChainID:       1,
+    Time:          1_786_569_463_230_678,
+}
+
+tx, err := signer.SignSend(request, key)
+if err != nil {
+    return err
+}
+
+details, err := signer.Inspect(tx)
+```
+
+`SendRequest.Time` is required. Persist the signed transaction and its hash in
+the withdrawal record before broadcast; every retry must reuse those exact
+signed bytes rather than call `SignSend` again. The memo values `RLP` and
+`RLP.V2` are reserved for Ethereum transaction wrappers and are rejected by the
+native signer.
+
+## Command-line use
+
+Build the standalone executable:
+
+```sh
+go build -o signer ./cmd/signer
+```
+
+Prepare `request.json`. All integers are quoted decimal strings to preserve
+full `uint64` precision across languages:
+
+```json
+{
+  "recipient": "502c0b3d6ccd1c6f164aa5536b2ba2cb9e80c711",
+  "amountUCNPY": "1000000",
+  "feeUCNPY": "10000",
+  "createdHeight": "2044370",
+  "networkID": "1",
+  "chainID": "1",
+  "time": "1786569463230678",
+  "memo": "withdrawal-123"
+}
+```
+
+Sign using an existing encrypted Canopy `keystore.json`. The key selector may
+be an address or nickname. The password is read from a terminal without echo;
+for an automated offline process it may be supplied on standard input.
+
+```sh
+signer sign-send \
+  --keystore-dir /secure/canopy \
+  --key withdrawal \
+  request.json > signed.json
+```
+
+Only the bare signed transaction is written to standard output, allowing the
+calling custody system to store or broadcast it directly. Every retry must use
+that same output rather than invoke the signer again:
+
+```sh
+curl -X POST "$CANOPY_RPC/v1/tx" \
+  -H 'Content-Type: application/json' \
+  --data-binary @signed.json
+```
+
+Before releasing it from the offline environment, inspect and verify it:
+
+```sh
+signer inspect signed.json
+```
+
+The resulting audit summary contains the native transaction hash, sender,
+recipient, amount, fee, height, IDs, memo, and timestamp. `inspect` exits with a
+non-zero status if any signed byte was altered.
+
+Never provide a password or raw private key as a command-line argument or an
+environment variable. Both commonly leak through process inspection, logs, or
+diagnostic capture.

--- a/lib/crypto/signer/signer.go
+++ b/lib/crypto/signer/signer.go
@@ -15,66 +15,75 @@ import (
 	"github.com/canopy-network/canopy/lib/crypto"
 )
 
-// SendRequest contains every operator-controlled field of a native send.
+// SendRequest contains every operator-controlled field of a native send
 // AmountUCNPY and FeeUCNPY are integer micro-CNPY values. Time is a required
 // Unix-microsecond value that must remain stable for every retry.
 //
 // Integer fields are JSON strings so values retain full uint64 precision in
 // every language that invokes the command-line signer.
 type SendRequest struct {
-	Recipient     string `json:"recipient"`
-	AmountUCNPY   uint64 `json:"amountUCNPY,string"`
-	FeeUCNPY      uint64 `json:"feeUCNPY,string"`
-	CreatedHeight uint64 `json:"createdHeight,string"`
-	NetworkID     uint64 `json:"networkID,string"`
-	ChainID       uint64 `json:"chainID,string"`
-	Memo          string `json:"memo,omitempty"`
-	Time          uint64 `json:"time,string"`
+	Recipient     string `json:"recipient"`            // recipient address in hexadecimal format
+	AmountUCNPY   uint64 `json:"amountUCNPY,string"`   // amount to send in micro-CNPY
+	FeeUCNPY      uint64 `json:"feeUCNPY,string"`      // transaction fee in micro-CNPY
+	CreatedHeight uint64 `json:"createdHeight,string"` // recent chain height used to create the transaction
+	NetworkID     uint64 `json:"networkID,string"`     // destination network identifier
+	ChainID       uint64 `json:"chainID,string"`       // destination chain identifier
+	Memo          string `json:"memo,omitempty"`       // optional transaction memo
+	Time          uint64 `json:"time,string"`          // transaction time in Unix microseconds
 }
 
-// Details is an auditable summary derived from a verified signed transaction.
+// Details is an auditable summary derived from a verified signed transaction
 type Details struct {
-	TransactionHash string `json:"transactionHash"`
-	Sender          string `json:"sender"`
-	Recipient       string `json:"recipient"`
-	AmountUCNPY     uint64 `json:"amountUCNPY,string"`
-	FeeUCNPY        uint64 `json:"feeUCNPY,string"`
-	CreatedHeight   uint64 `json:"createdHeight,string"`
-	NetworkID       uint64 `json:"networkID,string"`
-	ChainID         uint64 `json:"chainID,string"`
-	Memo            string `json:"memo,omitempty"`
-	Time            uint64 `json:"time,string"`
+	TransactionHash string `json:"transactionHash"`      // hash of the signed transaction in hexadecimal format
+	Sender          string `json:"sender"`               // address derived from the signing public key
+	Recipient       string `json:"recipient"`            // recipient address in hexadecimal format
+	AmountUCNPY     uint64 `json:"amountUCNPY,string"`   // amount sent in micro-CNPY
+	FeeUCNPY        uint64 `json:"feeUCNPY,string"`      // transaction fee in micro-CNPY
+	CreatedHeight   uint64 `json:"createdHeight,string"` // chain height used to create the transaction
+	NetworkID       uint64 `json:"networkID,string"`     // destination network identifier
+	ChainID         uint64 `json:"chainID,string"`       // destination chain identifier
+	Memo            string `json:"memo,omitempty"`       // optional transaction memo
+	Time            uint64 `json:"time,string"`          // transaction time in Unix microseconds
 }
 
-// BuildSend constructs an unsigned native send using Canopy's canonical
+// BuildSend() constructs an unsigned native send using Canopy's canonical
 // protobuf types. It does not check the governance-controlled minimum fee or
 // whether CreatedHeight is recent; those checks require current chain state.
 func BuildSend(request SendRequest, publicKey crypto.PublicKeyI) (*lib.Transaction, error) {
+	// validate the public key
 	if publicKey == nil {
 		return nil, fmt.Errorf("public key is nil")
 	}
+	// validate the created height
 	if request.CreatedHeight == 0 {
 		return nil, fmt.Errorf("createdHeight must be greater than zero")
 	}
+	// validate the network identifier
 	if request.NetworkID == 0 {
 		return nil, fmt.Errorf("networkID must be greater than zero")
 	}
+	// validate the chain identifier
 	if request.ChainID == 0 {
 		return nil, fmt.Errorf("chainID must be greater than zero")
 	}
+	// validate the transaction time
 	if request.Time == 0 {
 		return nil, fmt.Errorf("time must be greater than zero")
 	}
+	// enforce the maximum memo length
 	if len(request.Memo) > 200 {
 		return nil, fmt.Errorf("memo exceeds 200 bytes")
 	}
+	// prevent native sends from using reserved Ethereum memo prefixes
 	if lib.IsRLPMemo(request.Memo) {
 		return nil, fmt.Errorf("memo %q is reserved for Ethereum transactions", request.Memo)
 	}
+	// decode and validate the recipient address
 	recipient, err := crypto.NewAddressFromString(request.Recipient)
 	if err != nil || len(recipient.Bytes()) != crypto.AddressSize {
 		return nil, fmt.Errorf("recipient must be exactly 40 hexadecimal characters")
 	}
+	// create and validate the canonical send message
 	message := &fsm.MessageSend{
 		FromAddress: publicKey.Address().Bytes(),
 		ToAddress:   recipient.Bytes(),
@@ -83,10 +92,12 @@ func BuildSend(request SendRequest, publicKey crypto.PublicKeyI) (*lib.Transacti
 	if checkErr := message.Check(); checkErr != nil {
 		return nil, checkErr
 	}
+	// wrap the send message in its protobuf Any container
 	anyMessage, anyErr := lib.NewAny(message)
 	if anyErr != nil {
 		return nil, anyErr
 	}
+	// assemble and return the unsigned transaction
 	return &lib.Transaction{
 		MessageType:   fsm.MessageSendName,
 		Msg:           anyMessage,
@@ -99,80 +110,99 @@ func BuildSend(request SendRequest, publicKey crypto.PublicKeyI) (*lib.Transacti
 	}, nil
 }
 
-// SignSend builds and signs a native send, then verifies the resulting
+// SignSend() builds and signs a native send, then verifies the resulting
 // signature and signed fields before returning it.
 func SignSend(request SendRequest, privateKey crypto.PrivateKeyI) (*lib.Transaction, error) {
+	// validate the private key
 	if privateKey == nil {
 		return nil, fmt.Errorf("private key is nil")
 	}
+	// retrieve and validate the paired public key
 	publicKey := privateKey.PublicKey()
 	if publicKey == nil {
 		return nil, fmt.Errorf("private key public key is nil")
 	}
+	// build the unsigned send transaction
 	transaction, err := BuildSend(request, publicKey)
 	if err != nil {
 		return nil, err
 	}
+	// create the canonical transaction sign bytes
 	signBytes, signErr := transaction.GetSignBytes()
 	if signErr != nil {
 		return nil, signErr
 	}
+	// sign the transaction and ensure the signer returned a signature
 	signature := privateKey.Sign(signBytes)
 	if len(signature) == 0 {
 		return nil, fmt.Errorf("signer returned an empty signature")
 	}
+	// attach the public key and signature to the transaction
 	transaction.Signature = &lib.Signature{
 		PublicKey: publicKey.Bytes(),
 		Signature: signature,
 	}
+	// verify the complete transaction before returning it
 	if _, err = Inspect(transaction); err != nil {
 		return nil, fmt.Errorf("verify signed transaction: %w", err)
 	}
 	return transaction, nil
 }
 
-// Inspect verifies a signed native send and returns the exact fields covered by
+// Inspect() verifies a signed native send and returns the exact fields covered by
 // its signature. Verification is stateless: final fee and height acceptance
 // remain the responsibility of a synchronized Canopy node.
 func Inspect(transaction *lib.Transaction) (*Details, error) {
+	// validate the transaction reference
 	if transaction == nil {
 		return nil, fmt.Errorf("transaction is nil")
 	}
+	// execute the stateless transaction validation
 	if err := transaction.CheckBasic(); err != nil {
 		return nil, err
 	}
+	// ensure the transaction declares a native send
 	if transaction.MessageType != fsm.MessageSendName {
 		return nil, fmt.Errorf("transaction type must be %q", fsm.MessageSendName)
 	}
+	// decode the wrapped transaction message
 	message, messageErr := lib.FromAny(transaction.Msg)
 	if messageErr != nil {
 		return nil, messageErr
 	}
+	// ensure the decoded payload is a native send
 	send, ok := message.(*fsm.MessageSend)
 	if !ok {
 		return nil, fmt.Errorf("transaction payload is not a native send")
 	}
+	// validate the native send message
 	if checkErr := send.Check(); checkErr != nil {
 		return nil, checkErr
 	}
+	// decode the signing public key
 	publicKey, err := crypto.NewPublicKeyFromBytes(transaction.Signature.PublicKey)
 	if err != nil {
 		return nil, fmt.Errorf("decode public key: %w", err)
 	}
+	// ensure the message sender matches the signing key
 	if !bytes.Equal(send.FromAddress, publicKey.Address().Bytes()) {
 		return nil, fmt.Errorf("sender does not match signing public key")
 	}
+	// recreate the canonical transaction sign bytes
 	signBytes, signErr := transaction.GetSignBytes()
 	if signErr != nil {
 		return nil, signErr
 	}
+	// verify the transaction signature
 	if !publicKey.VerifyBytes(signBytes, transaction.Signature.Signature) {
 		return nil, fmt.Errorf("invalid transaction signature")
 	}
+	// calculate the verified transaction hash
 	hash, hashErr := transaction.GetHash()
 	if hashErr != nil {
 		return nil, hashErr
 	}
+	// return the human-readable signed fields
 	return &Details{
 		TransactionHash: hex.EncodeToString(hash),
 		Sender:          publicKey.Address().String(),

--- a/lib/crypto/signer/signer.go
+++ b/lib/crypto/signer/signer.go
@@ -1,0 +1,188 @@
+// Package signer builds, signs, and verifies native Canopy send transactions.
+//
+// The package performs no network or filesystem access. Callers are responsible
+// for obtaining a recent height and the current send fee before moving a request
+// into an offline signing environment.
+package signer
+
+import (
+	"bytes"
+	"encoding/hex"
+	"fmt"
+
+	"github.com/canopy-network/canopy/fsm"
+	"github.com/canopy-network/canopy/lib"
+	"github.com/canopy-network/canopy/lib/crypto"
+)
+
+// SendRequest contains every operator-controlled field of a native send.
+// AmountUCNPY and FeeUCNPY are integer micro-CNPY values. Time is a required
+// Unix-microsecond value that must remain stable for every retry.
+//
+// Integer fields are JSON strings so values retain full uint64 precision in
+// every language that invokes the command-line signer.
+type SendRequest struct {
+	Recipient     string `json:"recipient"`
+	AmountUCNPY   uint64 `json:"amountUCNPY,string"`
+	FeeUCNPY      uint64 `json:"feeUCNPY,string"`
+	CreatedHeight uint64 `json:"createdHeight,string"`
+	NetworkID     uint64 `json:"networkID,string"`
+	ChainID       uint64 `json:"chainID,string"`
+	Memo          string `json:"memo,omitempty"`
+	Time          uint64 `json:"time,string"`
+}
+
+// Details is an auditable summary derived from a verified signed transaction.
+type Details struct {
+	TransactionHash string `json:"transactionHash"`
+	Sender          string `json:"sender"`
+	Recipient       string `json:"recipient"`
+	AmountUCNPY     uint64 `json:"amountUCNPY,string"`
+	FeeUCNPY        uint64 `json:"feeUCNPY,string"`
+	CreatedHeight   uint64 `json:"createdHeight,string"`
+	NetworkID       uint64 `json:"networkID,string"`
+	ChainID         uint64 `json:"chainID,string"`
+	Memo            string `json:"memo,omitempty"`
+	Time            uint64 `json:"time,string"`
+}
+
+// BuildSend constructs an unsigned native send using Canopy's canonical
+// protobuf types. It does not check the governance-controlled minimum fee or
+// whether CreatedHeight is recent; those checks require current chain state.
+func BuildSend(request SendRequest, publicKey crypto.PublicKeyI) (*lib.Transaction, error) {
+	if publicKey == nil {
+		return nil, fmt.Errorf("public key is nil")
+	}
+	if request.CreatedHeight == 0 {
+		return nil, fmt.Errorf("createdHeight must be greater than zero")
+	}
+	if request.NetworkID == 0 {
+		return nil, fmt.Errorf("networkID must be greater than zero")
+	}
+	if request.ChainID == 0 {
+		return nil, fmt.Errorf("chainID must be greater than zero")
+	}
+	if request.Time == 0 {
+		return nil, fmt.Errorf("time must be greater than zero")
+	}
+	if len(request.Memo) > 200 {
+		return nil, fmt.Errorf("memo exceeds 200 bytes")
+	}
+	if lib.IsRLPMemo(request.Memo) {
+		return nil, fmt.Errorf("memo %q is reserved for Ethereum transactions", request.Memo)
+	}
+	recipient, err := crypto.NewAddressFromString(request.Recipient)
+	if err != nil || len(recipient.Bytes()) != crypto.AddressSize {
+		return nil, fmt.Errorf("recipient must be exactly 40 hexadecimal characters")
+	}
+	message := &fsm.MessageSend{
+		FromAddress: publicKey.Address().Bytes(),
+		ToAddress:   recipient.Bytes(),
+		Amount:      request.AmountUCNPY,
+	}
+	if checkErr := message.Check(); checkErr != nil {
+		return nil, checkErr
+	}
+	anyMessage, anyErr := lib.NewAny(message)
+	if anyErr != nil {
+		return nil, anyErr
+	}
+	return &lib.Transaction{
+		MessageType:   fsm.MessageSendName,
+		Msg:           anyMessage,
+		CreatedHeight: request.CreatedHeight,
+		Time:          request.Time,
+		Fee:           request.FeeUCNPY,
+		Memo:          request.Memo,
+		NetworkId:     request.NetworkID,
+		ChainId:       request.ChainID,
+	}, nil
+}
+
+// SignSend builds and signs a native send, then verifies the resulting
+// signature and signed fields before returning it.
+func SignSend(request SendRequest, privateKey crypto.PrivateKeyI) (*lib.Transaction, error) {
+	if privateKey == nil {
+		return nil, fmt.Errorf("private key is nil")
+	}
+	publicKey := privateKey.PublicKey()
+	if publicKey == nil {
+		return nil, fmt.Errorf("private key public key is nil")
+	}
+	transaction, err := BuildSend(request, publicKey)
+	if err != nil {
+		return nil, err
+	}
+	signBytes, signErr := transaction.GetSignBytes()
+	if signErr != nil {
+		return nil, signErr
+	}
+	signature := privateKey.Sign(signBytes)
+	if len(signature) == 0 {
+		return nil, fmt.Errorf("signer returned an empty signature")
+	}
+	transaction.Signature = &lib.Signature{
+		PublicKey: publicKey.Bytes(),
+		Signature: signature,
+	}
+	if _, err = Inspect(transaction); err != nil {
+		return nil, fmt.Errorf("verify signed transaction: %w", err)
+	}
+	return transaction, nil
+}
+
+// Inspect verifies a signed native send and returns the exact fields covered by
+// its signature. Verification is stateless: final fee and height acceptance
+// remain the responsibility of a synchronized Canopy node.
+func Inspect(transaction *lib.Transaction) (*Details, error) {
+	if transaction == nil {
+		return nil, fmt.Errorf("transaction is nil")
+	}
+	if err := transaction.CheckBasic(); err != nil {
+		return nil, err
+	}
+	if transaction.MessageType != fsm.MessageSendName {
+		return nil, fmt.Errorf("transaction type must be %q", fsm.MessageSendName)
+	}
+	message, messageErr := lib.FromAny(transaction.Msg)
+	if messageErr != nil {
+		return nil, messageErr
+	}
+	send, ok := message.(*fsm.MessageSend)
+	if !ok {
+		return nil, fmt.Errorf("transaction payload is not a native send")
+	}
+	if checkErr := send.Check(); checkErr != nil {
+		return nil, checkErr
+	}
+	publicKey, err := crypto.NewPublicKeyFromBytes(transaction.Signature.PublicKey)
+	if err != nil {
+		return nil, fmt.Errorf("decode public key: %w", err)
+	}
+	if !bytes.Equal(send.FromAddress, publicKey.Address().Bytes()) {
+		return nil, fmt.Errorf("sender does not match signing public key")
+	}
+	signBytes, signErr := transaction.GetSignBytes()
+	if signErr != nil {
+		return nil, signErr
+	}
+	if !publicKey.VerifyBytes(signBytes, transaction.Signature.Signature) {
+		return nil, fmt.Errorf("invalid transaction signature")
+	}
+	hash, hashErr := transaction.GetHash()
+	if hashErr != nil {
+		return nil, hashErr
+	}
+	return &Details{
+		TransactionHash: hex.EncodeToString(hash),
+		Sender:          publicKey.Address().String(),
+		Recipient:       hex.EncodeToString(send.ToAddress),
+		AmountUCNPY:     send.Amount,
+		FeeUCNPY:        transaction.Fee,
+		CreatedHeight:   transaction.CreatedHeight,
+		NetworkID:       transaction.NetworkId,
+		ChainID:         transaction.ChainId,
+		Memo:            transaction.Memo,
+		Time:            transaction.Time,
+	}, nil
+}

--- a/lib/crypto/signer/signer_test.go
+++ b/lib/crypto/signer/signer_test.go
@@ -1,0 +1,105 @@
+package signer_test
+
+import (
+	"bytes"
+	"crypto/ed25519"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/canopy-network/canopy/lib"
+	"github.com/canopy-network/canopy/lib/crypto"
+	"github.com/canopy-network/canopy/lib/crypto/signer"
+)
+
+func TestSignSendGoldenVector(t *testing.T) {
+	transaction, err := signer.SignSend(goldenRequest(), goldenKey())
+	if err != nil {
+		t.Fatal(err)
+	}
+	details, err := signer.Inspect(transaction)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if details.TransactionHash != "3c12e6f105125934803f39291dc649dcc3488efdf55ea9d04107956cd45a90fe" {
+		t.Fatalf("golden transaction hash changed: %s", details.TransactionHash)
+	}
+	encoded, err := json.Marshal(transaction)
+	if err != nil {
+		t.Fatal(err)
+	}
+	const goldenJSON = `{"type":"send","msg":{"fromAddress":"3097e2dee2cb4a34b53840cdb705aed71067c36f","toAddress":"502c0b3d6ccd1c6f164aa5536b2ba2cb9e80c711","amount":1234567},"signature":{"publicKey":"2152f8d19b791d24453242e15f2eab6cb7cffa7b6a5ed30097960e069881db12","signature":"02dc03269c709ba3485d38a70f6e433e66b76fc7f21c886d5fb617be7b7b19907d7b9119d5bcb59f424ed44e1e785c9562d3320c87f62cecab863a901d342a06"},"time":1786569463230678,"createdHeight":2044370,"fee":10000,"memo":"withdrawal-123","networkID":1,"chainID":1}`
+	if string(encoded) != goldenJSON {
+		t.Fatalf("golden transaction JSON changed:\n%s", encoded)
+	}
+
+	decoded := new(lib.Transaction)
+	if err = json.Unmarshal(encoded, decoded); err != nil {
+		t.Fatal(err)
+	}
+	if _, err = signer.Inspect(decoded); err != nil {
+		t.Fatalf("verify JSON round trip: %v", err)
+	}
+}
+
+func TestInspectRejectsTampering(t *testing.T) {
+	transaction, err := signer.SignSend(goldenRequest(), goldenKey())
+	if err != nil {
+		t.Fatal(err)
+	}
+	transaction.Fee++
+	if _, err = signer.Inspect(transaction); err == nil || !strings.Contains(err.Error(), "invalid transaction signature") {
+		t.Fatalf("expected invalid signature, got %v", err)
+	}
+}
+
+func TestBuildSendRejectsInvalidRequests(t *testing.T) {
+	valid := goldenRequest()
+	tests := []struct {
+		name   string
+		mutate func(*signer.SendRequest)
+	}{
+		{"recipient", func(r *signer.SendRequest) { r.Recipient = "abcd" }},
+		{"amount", func(r *signer.SendRequest) { r.AmountUCNPY = 0 }},
+		{"height", func(r *signer.SendRequest) { r.CreatedHeight = 0 }},
+		{"network", func(r *signer.SendRequest) { r.NetworkID = 0 }},
+		{"chain", func(r *signer.SendRequest) { r.ChainID = 0 }},
+		{"time", func(r *signer.SendRequest) { r.Time = 0 }},
+		{"memo bytes", func(r *signer.SendRequest) { r.Memo = strings.Repeat("é", 101) }},
+		{"RLP memo", func(r *signer.SendRequest) { r.Memo = lib.RLPIndicator }},
+		{"RLP.V2 memo", func(r *signer.SendRequest) { r.Memo = lib.RLPV2Indicator }},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			request := valid
+			test.mutate(&request)
+			if _, err := signer.BuildSend(request, goldenKey().PublicKey()); err == nil {
+				t.Fatal("expected validation error")
+			}
+		})
+	}
+}
+
+func TestSignSendRejectsNilPrivateKey(t *testing.T) {
+	if _, err := signer.SignSend(goldenRequest(), nil); err == nil {
+		t.Fatal("expected private key error")
+	}
+}
+
+func goldenRequest() signer.SendRequest {
+	return signer.SendRequest{
+		Recipient:     "502c0b3d6ccd1c6f164aa5536b2ba2cb9e80c711",
+		AmountUCNPY:   1_234_567,
+		FeeUCNPY:      10_000,
+		CreatedHeight: 2_044_370,
+		NetworkID:     1,
+		ChainID:       1,
+		Memo:          "withdrawal-123",
+		Time:          1_786_569_463_230_678,
+	}
+}
+
+func goldenKey() crypto.PrivateKeyI {
+	seed := bytes.Repeat([]byte{0x42}, ed25519.SeedSize)
+	return crypto.BytesToED25519Private(ed25519.NewKeyFromSeed(seed))
+}

--- a/lib/crypto/signer/signer_test.go
+++ b/lib/crypto/signer/signer_test.go
@@ -13,26 +13,32 @@ import (
 )
 
 func TestSignSendGoldenVector(t *testing.T) {
+	// sign the deterministic golden request
 	transaction, err := signer.SignSend(goldenRequest(), goldenKey())
 	if err != nil {
 		t.Fatal(err)
 	}
+	// inspect the signed transaction
 	details, err := signer.Inspect(transaction)
 	if err != nil {
 		t.Fatal(err)
 	}
+	// validate the deterministic transaction hash
 	if details.TransactionHash != "3c12e6f105125934803f39291dc649dcc3488efdf55ea9d04107956cd45a90fe" {
 		t.Fatalf("golden transaction hash changed: %s", details.TransactionHash)
 	}
+	// encode the signed transaction
 	encoded, err := json.Marshal(transaction)
 	if err != nil {
 		t.Fatal(err)
 	}
+	// validate the canonical signed transaction JSON
 	const goldenJSON = `{"type":"send","msg":{"fromAddress":"3097e2dee2cb4a34b53840cdb705aed71067c36f","toAddress":"502c0b3d6ccd1c6f164aa5536b2ba2cb9e80c711","amount":1234567},"signature":{"publicKey":"2152f8d19b791d24453242e15f2eab6cb7cffa7b6a5ed30097960e069881db12","signature":"02dc03269c709ba3485d38a70f6e433e66b76fc7f21c886d5fb617be7b7b19907d7b9119d5bcb59f424ed44e1e785c9562d3320c87f62cecab863a901d342a06"},"time":1786569463230678,"createdHeight":2044370,"fee":10000,"memo":"withdrawal-123","networkID":1,"chainID":1}`
 	if string(encoded) != goldenJSON {
 		t.Fatalf("golden transaction JSON changed:\n%s", encoded)
 	}
 
+	// decode and verify the JSON round trip
 	decoded := new(lib.Transaction)
 	if err = json.Unmarshal(encoded, decoded); err != nil {
 		t.Fatal(err)
@@ -43,18 +49,23 @@ func TestSignSendGoldenVector(t *testing.T) {
 }
 
 func TestInspectRejectsTampering(t *testing.T) {
+	// create a valid signed transaction
 	transaction, err := signer.SignSend(goldenRequest(), goldenKey())
 	if err != nil {
 		t.Fatal(err)
 	}
+	// tamper with a signed field
 	transaction.Fee++
+	// ensure signature verification detects the change
 	if _, err = signer.Inspect(transaction); err == nil || !strings.Contains(err.Error(), "invalid transaction signature") {
 		t.Fatalf("expected invalid signature, got %v", err)
 	}
 }
 
 func TestBuildSendRejectsInvalidRequests(t *testing.T) {
+	// create a valid base request
 	valid := goldenRequest()
+	// define each invalid request mutation
 	tests := []struct {
 		name   string
 		mutate func(*signer.SendRequest)
@@ -69,10 +80,13 @@ func TestBuildSendRejectsInvalidRequests(t *testing.T) {
 		{"RLP memo", func(r *signer.SendRequest) { r.Memo = lib.RLPIndicator }},
 		{"RLP.V2 memo", func(r *signer.SendRequest) { r.Memo = lib.RLPV2Indicator }},
 	}
+	// execute the validation cases
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
+			// mutate a copy of the valid request
 			request := valid
 			test.mutate(&request)
+			// ensure the invalid request is rejected
 			if _, err := signer.BuildSend(request, goldenKey().PublicKey()); err == nil {
 				t.Fatal("expected validation error")
 			}
@@ -81,11 +95,13 @@ func TestBuildSendRejectsInvalidRequests(t *testing.T) {
 }
 
 func TestSignSendRejectsNilPrivateKey(t *testing.T) {
+	// ensure a nil private key is rejected
 	if _, err := signer.SignSend(goldenRequest(), nil); err == nil {
 		t.Fatal("expected private key error")
 	}
 }
 
+// goldenRequest() returns the deterministic send request used by signer tests
 func goldenRequest() signer.SendRequest {
 	return signer.SendRequest{
 		Recipient:     "502c0b3d6ccd1c6f164aa5536b2ba2cb9e80c711",
@@ -99,7 +115,9 @@ func goldenRequest() signer.SendRequest {
 	}
 }
 
+// goldenKey() returns the deterministic private key used by signer tests
 func goldenKey() crypto.PrivateKeyI {
+	// create a fixed Ed25519 key from a repeated-byte seed
 	seed := bytes.Repeat([]byte{0x42}, ed25519.SeedSize)
 	return crypto.BytesToED25519Private(ed25519.NewKeyFromSeed(seed))
 }


### PR DESCRIPTION
Pretty small on purpose. This adds a native Canopy send signer that can be imported as a Go package or used as a standalone binary.

It uses the existing encrypted keystore, requires an explicit timestamp so retries stay deterministic, rejects the reserved RLP memos, and can inspect signed transactions before they are broadcast. The release workflow also publishes signer binaries and checksums.

Checked with:
- focused unit tests
- race detector
- go vet
- FSM tests
- Linux static build