### PR TITLE
feat: make release actions validate semantics before hand and add needed prefixes for plugins

### DIFF
--- a/.github/workflows/release-plugin-csharp.yml
+++ b/.github/workflows/release-plugin-csharp.yml
@@ -18,25 +18,27 @@ jobs:
       tag: ${{ steps.compute.outputs.tag }}
 
     steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: "1.26"
+
       - name: Validate version and compute tag
         id: compute
         env:
           VERSION: ${{ github.event.inputs.tag }}
         run: |
           PREFIX="plugin-csharp-v"
-          # Backwards compatibility: also accept the fully-prefixed tag form
-          # (e.g. plugin-csharp-v1.0.4) in addition to the bare version (1.0.4).
-          # Old forks and their release automation still pass the full tag, so
-          # strip the prefix here when it's present. This is intentionally NOT
-          # listed in the workflow_dispatch input description above so the manual
-          # flow steers users toward entering just the version.
-          # DO NOT REMOVE: deleting this breaks releases triggered from existing forks.
+          # Back-compat: accept the full tag form (e.g. plugin-csharp-v1.0.4) too, not just
+          # the bare version. DO NOT REMOVE: old forks pass the full tag when releasing.
           VERSION="${VERSION#"$PREFIX"}"
-          SEMVER_REGEX='^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-(0|[1-9][0-9]*|[0-9]*[A-Za-z-][0-9A-Za-z-]*)(\.(0|[1-9][0-9]*|[0-9]*[A-Za-z-][0-9A-Za-z-]*))*)?(\+[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?$'
-          if [[ ! "$VERSION" =~ $SEMVER_REGEX ]]; then
-            echo "::error::Version '$VERSION' is not a valid semantic version. Expected MAJOR.MINOR.PATCH (e.g. 1.0.0)"
-            exit 1
-          fi
+          # Tolerate a bare "v" prefix (e.g. v1.0.4) so the tag isn't doubled below.
+          VERSION="${VERSION#v}"
+          # Validate via the shared script (same semver check as the auto-updater).
+          go run ./cmd/scripts/semver "$VERSION"
           echo "tag=${PREFIX}${VERSION}" >> "$GITHUB_OUTPUT"
           echo "Version '$VERSION' is valid. Release tag: ${PREFIX}${VERSION}"
 

--- a/.github/workflows/release-plugin-csharp.yml
+++ b/.github/workflows/release-plugin-csharp.yml
@@ -20,8 +20,9 @@ jobs:
     steps:
       - name: Validate version and compute tag
         id: compute
+        env:
+          VERSION: ${{ github.event.inputs.version }}
         run: |
-          VERSION="${{ github.event.inputs.version }}"
           SEMVER_REGEX='^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-(0|[1-9][0-9]*|[0-9]*[A-Za-z-][0-9A-Za-z-]*)(\.(0|[1-9][0-9]*|[0-9]*[A-Za-z-][0-9A-Za-z-]*))*)?(\+[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?$'
           if [[ ! "$VERSION" =~ $SEMVER_REGEX ]]; then
             echo "::error::Version '$VERSION' is not a valid semantic version. Expected MAJOR.MINOR.PATCH (e.g. 1.0.0)"

--- a/.github/workflows/release-plugin-csharp.yml
+++ b/.github/workflows/release-plugin-csharp.yml
@@ -3,17 +3,37 @@ name: Release C# Plugin
 on:
   workflow_dispatch:
     inputs:
-      tag:
-        description: "Tag for the plugin release (e.g. plugin-csharp-v1.0.0)"
+      version:
+        description: "Semantic version for the plugin release (e.g. 1.0.0). The 'plugin-csharp-v' prefix is added automatically."
         required: true
 
 permissions:
   contents: write
 
 jobs:
+  validate:
+    name: Validate version
+    runs-on: ubuntu-latest
+    outputs:
+      tag: ${{ steps.compute.outputs.tag }}
+
+    steps:
+      - name: Validate version and compute tag
+        id: compute
+        run: |
+          VERSION="${{ github.event.inputs.version }}"
+          SEMVER_REGEX='^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-[0-9A-Za-z.-]+)?(\+[0-9A-Za-z.-]+)?$'
+          if [[ ! "$VERSION" =~ $SEMVER_REGEX ]]; then
+            echo "::error::Version '$VERSION' is not a valid semantic version. Expected MAJOR.MINOR.PATCH (e.g. 1.0.0)"
+            exit 1
+          fi
+          echo "tag=plugin-csharp-v${VERSION}" >> "$GITHUB_OUTPUT"
+          echo "Version '$VERSION' is valid. Release tag: plugin-csharp-v${VERSION}"
+
   release:
     name: Build and Release C# Plugin
     runs-on: ubuntu-latest
+    needs: validate
 
     steps:
       - name: Checkout code
@@ -55,10 +75,10 @@ jobs:
       - name: Create GitHub release
         uses: softprops/action-gh-release@v2
         with:
-          tag_name: ${{ github.event.inputs.tag }}
-          name: "C# Plugin ${{ github.event.inputs.tag }}"
+          tag_name: ${{ needs.validate.outputs.tag }}
+          name: "C# Plugin ${{ needs.validate.outputs.tag }}"
           body: |
-            C# Plugin Release ${{ github.event.inputs.tag }}
+            C# Plugin Release ${{ needs.validate.outputs.tag }}
             
             ## Installation
             1. Extract the appropriate tarball to `plugin/csharp/bin/`

--- a/.github/workflows/release-plugin-csharp.yml
+++ b/.github/workflows/release-plugin-csharp.yml
@@ -22,7 +22,7 @@ jobs:
         id: compute
         run: |
           VERSION="${{ github.event.inputs.version }}"
-          SEMVER_REGEX='^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-[0-9A-Za-z.-]+)?(\+[0-9A-Za-z.-]+)?$'
+          SEMVER_REGEX='^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-(0|[1-9][0-9]*|[0-9]*[A-Za-z-][0-9A-Za-z-]*)(\.(0|[1-9][0-9]*|[0-9]*[A-Za-z-][0-9A-Za-z-]*))*)?(\+[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?$'
           if [[ ! "$VERSION" =~ $SEMVER_REGEX ]]; then
             echo "::error::Version '$VERSION' is not a valid semantic version. Expected MAJOR.MINOR.PATCH (e.g. 1.0.0)"
             exit 1

--- a/.github/workflows/release-plugin-csharp.yml
+++ b/.github/workflows/release-plugin-csharp.yml
@@ -3,7 +3,7 @@ name: Release C# Plugin
 on:
   workflow_dispatch:
     inputs:
-      version:
+      tag:
         description: "Semantic version for the plugin release (e.g. 1.0.0). The 'plugin-csharp-v' prefix is added automatically."
         required: true
 
@@ -21,7 +21,7 @@ jobs:
       - name: Validate version and compute tag
         id: compute
         env:
-          VERSION: ${{ github.event.inputs.version }}
+          VERSION: ${{ github.event.inputs.tag }}
         run: |
           PREFIX="plugin-csharp-v"
           # Backwards compatibility: also accept the fully-prefixed tag form

--- a/.github/workflows/release-plugin-csharp.yml
+++ b/.github/workflows/release-plugin-csharp.yml
@@ -23,13 +23,22 @@ jobs:
         env:
           VERSION: ${{ github.event.inputs.version }}
         run: |
+          PREFIX="plugin-csharp-v"
+          # Backwards compatibility: also accept the fully-prefixed tag form
+          # (e.g. plugin-csharp-v1.0.4) in addition to the bare version (1.0.4).
+          # Old forks and their release automation still pass the full tag, so
+          # strip the prefix here when it's present. This is intentionally NOT
+          # listed in the workflow_dispatch input description above so the manual
+          # flow steers users toward entering just the version.
+          # DO NOT REMOVE: deleting this breaks releases triggered from existing forks.
+          VERSION="${VERSION#"$PREFIX"}"
           SEMVER_REGEX='^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-(0|[1-9][0-9]*|[0-9]*[A-Za-z-][0-9A-Za-z-]*)(\.(0|[1-9][0-9]*|[0-9]*[A-Za-z-][0-9A-Za-z-]*))*)?(\+[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?$'
           if [[ ! "$VERSION" =~ $SEMVER_REGEX ]]; then
             echo "::error::Version '$VERSION' is not a valid semantic version. Expected MAJOR.MINOR.PATCH (e.g. 1.0.0)"
             exit 1
           fi
-          echo "tag=plugin-csharp-v${VERSION}" >> "$GITHUB_OUTPUT"
-          echo "Version '$VERSION' is valid. Release tag: plugin-csharp-v${VERSION}"
+          echo "tag=${PREFIX}${VERSION}" >> "$GITHUB_OUTPUT"
+          echo "Version '$VERSION' is valid. Release tag: ${PREFIX}${VERSION}"
 
   release:
     name: Build and Release C# Plugin

--- a/.github/workflows/release-plugin-go.yml
+++ b/.github/workflows/release-plugin-go.yml
@@ -23,13 +23,22 @@ jobs:
         env:
           VERSION: ${{ github.event.inputs.version }}
         run: |
+          PREFIX="plugin-go-v"
+          # Backwards compatibility: also accept the fully-prefixed tag form
+          # (e.g. plugin-go-v1.0.4) in addition to the bare version (1.0.4).
+          # Old forks and their release automation still pass the full tag, so
+          # strip the prefix here when it's present. This is intentionally NOT
+          # listed in the workflow_dispatch input description above so the manual
+          # flow steers users toward entering just the version.
+          # DO NOT REMOVE: deleting this breaks releases triggered from existing forks.
+          VERSION="${VERSION#"$PREFIX"}"
           SEMVER_REGEX='^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-(0|[1-9][0-9]*|[0-9]*[A-Za-z-][0-9A-Za-z-]*)(\.(0|[1-9][0-9]*|[0-9]*[A-Za-z-][0-9A-Za-z-]*))*)?(\+[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?$'
           if [[ ! "$VERSION" =~ $SEMVER_REGEX ]]; then
             echo "::error::Version '$VERSION' is not a valid semantic version. Expected MAJOR.MINOR.PATCH (e.g. 1.0.0)"
             exit 1
           fi
-          echo "tag=plugin-go-v${VERSION}" >> "$GITHUB_OUTPUT"
-          echo "Version '$VERSION' is valid. Release tag: plugin-go-v${VERSION}"
+          echo "tag=${PREFIX}${VERSION}" >> "$GITHUB_OUTPUT"
+          echo "Version '$VERSION' is valid. Release tag: ${PREFIX}${VERSION}"
 
   release:
     name: Build and Release Go Plugin

--- a/.github/workflows/release-plugin-go.yml
+++ b/.github/workflows/release-plugin-go.yml
@@ -20,8 +20,9 @@ jobs:
     steps:
       - name: Validate version and compute tag
         id: compute
+        env:
+          VERSION: ${{ github.event.inputs.version }}
         run: |
-          VERSION="${{ github.event.inputs.version }}"
           SEMVER_REGEX='^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-(0|[1-9][0-9]*|[0-9]*[A-Za-z-][0-9A-Za-z-]*)(\.(0|[1-9][0-9]*|[0-9]*[A-Za-z-][0-9A-Za-z-]*))*)?(\+[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?$'
           if [[ ! "$VERSION" =~ $SEMVER_REGEX ]]; then
             echo "::error::Version '$VERSION' is not a valid semantic version. Expected MAJOR.MINOR.PATCH (e.g. 1.0.0)"

--- a/.github/workflows/release-plugin-go.yml
+++ b/.github/workflows/release-plugin-go.yml
@@ -3,7 +3,7 @@ name: Release Go Plugin
 on:
   workflow_dispatch:
     inputs:
-      version:
+      tag:
         description: "Semantic version for the plugin release (e.g. 1.0.0). The 'plugin-go-v' prefix is added automatically."
         required: true
 
@@ -21,7 +21,7 @@ jobs:
       - name: Validate version and compute tag
         id: compute
         env:
-          VERSION: ${{ github.event.inputs.version }}
+          VERSION: ${{ github.event.inputs.tag }}
         run: |
           PREFIX="plugin-go-v"
           # Backwards compatibility: also accept the fully-prefixed tag form

--- a/.github/workflows/release-plugin-go.yml
+++ b/.github/workflows/release-plugin-go.yml
@@ -18,25 +18,27 @@ jobs:
       tag: ${{ steps.compute.outputs.tag }}
 
     steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: "1.26"
+
       - name: Validate version and compute tag
         id: compute
         env:
           VERSION: ${{ github.event.inputs.tag }}
         run: |
           PREFIX="plugin-go-v"
-          # Backwards compatibility: also accept the fully-prefixed tag form
-          # (e.g. plugin-go-v1.0.4) in addition to the bare version (1.0.4).
-          # Old forks and their release automation still pass the full tag, so
-          # strip the prefix here when it's present. This is intentionally NOT
-          # listed in the workflow_dispatch input description above so the manual
-          # flow steers users toward entering just the version.
-          # DO NOT REMOVE: deleting this breaks releases triggered from existing forks.
+          # Back-compat: accept the full tag form (e.g. plugin-go-v1.0.4) too, not just
+          # the bare version. DO NOT REMOVE: old forks pass the full tag when releasing.
           VERSION="${VERSION#"$PREFIX"}"
-          SEMVER_REGEX='^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-(0|[1-9][0-9]*|[0-9]*[A-Za-z-][0-9A-Za-z-]*)(\.(0|[1-9][0-9]*|[0-9]*[A-Za-z-][0-9A-Za-z-]*))*)?(\+[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?$'
-          if [[ ! "$VERSION" =~ $SEMVER_REGEX ]]; then
-            echo "::error::Version '$VERSION' is not a valid semantic version. Expected MAJOR.MINOR.PATCH (e.g. 1.0.0)"
-            exit 1
-          fi
+          # Tolerate a bare "v" prefix (e.g. v1.0.4) so the tag isn't doubled below.
+          VERSION="${VERSION#v}"
+          # Validate via the shared script (same semver check as the auto-updater).
+          go run ./cmd/scripts/semver "$VERSION"
           echo "tag=${PREFIX}${VERSION}" >> "$GITHUB_OUTPUT"
           echo "Version '$VERSION' is valid. Release tag: ${PREFIX}${VERSION}"
 

--- a/.github/workflows/release-plugin-go.yml
+++ b/.github/workflows/release-plugin-go.yml
@@ -22,7 +22,7 @@ jobs:
         id: compute
         run: |
           VERSION="${{ github.event.inputs.version }}"
-          SEMVER_REGEX='^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-[0-9A-Za-z.-]+)?(\+[0-9A-Za-z.-]+)?$'
+          SEMVER_REGEX='^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-(0|[1-9][0-9]*|[0-9]*[A-Za-z-][0-9A-Za-z-]*)(\.(0|[1-9][0-9]*|[0-9]*[A-Za-z-][0-9A-Za-z-]*))*)?(\+[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?$'
           if [[ ! "$VERSION" =~ $SEMVER_REGEX ]]; then
             echo "::error::Version '$VERSION' is not a valid semantic version. Expected MAJOR.MINOR.PATCH (e.g. 1.0.0)"
             exit 1

--- a/.github/workflows/release-plugin-go.yml
+++ b/.github/workflows/release-plugin-go.yml
@@ -3,17 +3,37 @@ name: Release Go Plugin
 on:
   workflow_dispatch:
     inputs:
-      tag:
-        description: "Tag for the plugin release (e.g. plugin-go-v1.0.0)"
+      version:
+        description: "Semantic version for the plugin release (e.g. 1.0.0). The 'plugin-go-v' prefix is added automatically."
         required: true
 
 permissions:
   contents: write
 
 jobs:
+  validate:
+    name: Validate version
+    runs-on: ubuntu-latest
+    outputs:
+      tag: ${{ steps.compute.outputs.tag }}
+
+    steps:
+      - name: Validate version and compute tag
+        id: compute
+        run: |
+          VERSION="${{ github.event.inputs.version }}"
+          SEMVER_REGEX='^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-[0-9A-Za-z.-]+)?(\+[0-9A-Za-z.-]+)?$'
+          if [[ ! "$VERSION" =~ $SEMVER_REGEX ]]; then
+            echo "::error::Version '$VERSION' is not a valid semantic version. Expected MAJOR.MINOR.PATCH (e.g. 1.0.0)"
+            exit 1
+          fi
+          echo "tag=plugin-go-v${VERSION}" >> "$GITHUB_OUTPUT"
+          echo "Version '$VERSION' is valid. Release tag: plugin-go-v${VERSION}"
+
   release:
     name: Build and Release Go Plugin
     runs-on: ubuntu-latest
+    needs: validate
 
     steps:
       - name: Checkout code
@@ -40,10 +60,10 @@ jobs:
       - name: Create GitHub release
         uses: softprops/action-gh-release@v2
         with:
-          tag_name: ${{ github.event.inputs.tag }}
-          name: "Go Plugin ${{ github.event.inputs.tag }}"
+          tag_name: ${{ needs.validate.outputs.tag }}
+          name: "Go Plugin ${{ needs.validate.outputs.tag }}"
           body: |
-            Go Plugin Release ${{ github.event.inputs.tag }}
+            Go Plugin Release ${{ needs.validate.outputs.tag }}
 
             ## Assets
             - `go-plugin-linux-amd64.tar.gz` - Linux x86_64

--- a/.github/workflows/release-plugin-kotlin.yml
+++ b/.github/workflows/release-plugin-kotlin.yml
@@ -18,25 +18,27 @@ jobs:
       tag: ${{ steps.compute.outputs.tag }}
 
     steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: "1.26"
+
       - name: Validate version and compute tag
         id: compute
         env:
           VERSION: ${{ github.event.inputs.tag }}
         run: |
           PREFIX="plugin-kotlin-v"
-          # Backwards compatibility: also accept the fully-prefixed tag form
-          # (e.g. plugin-kotlin-v1.0.4) in addition to the bare version (1.0.4).
-          # Old forks and their release automation still pass the full tag, so
-          # strip the prefix here when it's present. This is intentionally NOT
-          # listed in the workflow_dispatch input description above so the manual
-          # flow steers users toward entering just the version.
-          # DO NOT REMOVE: deleting this breaks releases triggered from existing forks.
+          # Back-compat: accept the full tag form (e.g. plugin-kotlin-v1.0.4) too, not just
+          # the bare version. DO NOT REMOVE: old forks pass the full tag when releasing.
           VERSION="${VERSION#"$PREFIX"}"
-          SEMVER_REGEX='^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-(0|[1-9][0-9]*|[0-9]*[A-Za-z-][0-9A-Za-z-]*)(\.(0|[1-9][0-9]*|[0-9]*[A-Za-z-][0-9A-Za-z-]*))*)?(\+[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?$'
-          if [[ ! "$VERSION" =~ $SEMVER_REGEX ]]; then
-            echo "::error::Version '$VERSION' is not a valid semantic version. Expected MAJOR.MINOR.PATCH (e.g. 1.0.0)"
-            exit 1
-          fi
+          # Tolerate a bare "v" prefix (e.g. v1.0.4) so the tag isn't doubled below.
+          VERSION="${VERSION#v}"
+          # Validate via the shared script (same semver check as the auto-updater).
+          go run ./cmd/scripts/semver "$VERSION"
           echo "tag=${PREFIX}${VERSION}" >> "$GITHUB_OUTPUT"
           echo "Version '$VERSION' is valid. Release tag: ${PREFIX}${VERSION}"
 

--- a/.github/workflows/release-plugin-kotlin.yml
+++ b/.github/workflows/release-plugin-kotlin.yml
@@ -20,8 +20,9 @@ jobs:
     steps:
       - name: Validate version and compute tag
         id: compute
+        env:
+          VERSION: ${{ github.event.inputs.version }}
         run: |
-          VERSION="${{ github.event.inputs.version }}"
           SEMVER_REGEX='^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-(0|[1-9][0-9]*|[0-9]*[A-Za-z-][0-9A-Za-z-]*)(\.(0|[1-9][0-9]*|[0-9]*[A-Za-z-][0-9A-Za-z-]*))*)?(\+[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?$'
           if [[ ! "$VERSION" =~ $SEMVER_REGEX ]]; then
             echo "::error::Version '$VERSION' is not a valid semantic version. Expected MAJOR.MINOR.PATCH (e.g. 1.0.0)"

--- a/.github/workflows/release-plugin-kotlin.yml
+++ b/.github/workflows/release-plugin-kotlin.yml
@@ -3,7 +3,7 @@ name: Release Kotlin Plugin
 on:
   workflow_dispatch:
     inputs:
-      version:
+      tag:
         description: "Semantic version for the plugin release (e.g. 1.0.0). The 'plugin-kotlin-v' prefix is added automatically."
         required: true
 
@@ -21,7 +21,7 @@ jobs:
       - name: Validate version and compute tag
         id: compute
         env:
-          VERSION: ${{ github.event.inputs.version }}
+          VERSION: ${{ github.event.inputs.tag }}
         run: |
           PREFIX="plugin-kotlin-v"
           # Backwards compatibility: also accept the fully-prefixed tag form

--- a/.github/workflows/release-plugin-kotlin.yml
+++ b/.github/workflows/release-plugin-kotlin.yml
@@ -3,17 +3,37 @@ name: Release Kotlin Plugin
 on:
   workflow_dispatch:
     inputs:
-      tag:
-        description: "Tag for the plugin release (e.g. plugin-kotlin-v1.0.0)"
+      version:
+        description: "Semantic version for the plugin release (e.g. 1.0.0). The 'plugin-kotlin-v' prefix is added automatically."
         required: true
 
 permissions:
   contents: write
 
 jobs:
+  validate:
+    name: Validate version
+    runs-on: ubuntu-latest
+    outputs:
+      tag: ${{ steps.compute.outputs.tag }}
+
+    steps:
+      - name: Validate version and compute tag
+        id: compute
+        run: |
+          VERSION="${{ github.event.inputs.version }}"
+          SEMVER_REGEX='^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-[0-9A-Za-z.-]+)?(\+[0-9A-Za-z.-]+)?$'
+          if [[ ! "$VERSION" =~ $SEMVER_REGEX ]]; then
+            echo "::error::Version '$VERSION' is not a valid semantic version. Expected MAJOR.MINOR.PATCH (e.g. 1.0.0)"
+            exit 1
+          fi
+          echo "tag=plugin-kotlin-v${VERSION}" >> "$GITHUB_OUTPUT"
+          echo "Version '$VERSION' is valid. Release tag: plugin-kotlin-v${VERSION}"
+
   release:
     name: Build and Release Kotlin Plugin
     runs-on: ubuntu-latest
+    needs: validate
 
     steps:
       - name: Checkout code
@@ -42,10 +62,10 @@ jobs:
       - name: Create GitHub release
         uses: softprops/action-gh-release@v2
         with:
-          tag_name: ${{ github.event.inputs.tag }}
-          name: "Kotlin Plugin ${{ github.event.inputs.tag }}"
+          tag_name: ${{ needs.validate.outputs.tag }}
+          name: "Kotlin Plugin ${{ needs.validate.outputs.tag }}"
           body: |
-            Kotlin Plugin Release ${{ github.event.inputs.tag }}
+            Kotlin Plugin Release ${{ needs.validate.outputs.tag }}
             
             ## Requirements
             - Java Runtime Environment (JRE) 21 or later

--- a/.github/workflows/release-plugin-kotlin.yml
+++ b/.github/workflows/release-plugin-kotlin.yml
@@ -22,7 +22,7 @@ jobs:
         id: compute
         run: |
           VERSION="${{ github.event.inputs.version }}"
-          SEMVER_REGEX='^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-[0-9A-Za-z.-]+)?(\+[0-9A-Za-z.-]+)?$'
+          SEMVER_REGEX='^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-(0|[1-9][0-9]*|[0-9]*[A-Za-z-][0-9A-Za-z-]*)(\.(0|[1-9][0-9]*|[0-9]*[A-Za-z-][0-9A-Za-z-]*))*)?(\+[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?$'
           if [[ ! "$VERSION" =~ $SEMVER_REGEX ]]; then
             echo "::error::Version '$VERSION' is not a valid semantic version. Expected MAJOR.MINOR.PATCH (e.g. 1.0.0)"
             exit 1

--- a/.github/workflows/release-plugin-kotlin.yml
+++ b/.github/workflows/release-plugin-kotlin.yml
@@ -23,13 +23,22 @@ jobs:
         env:
           VERSION: ${{ github.event.inputs.version }}
         run: |
+          PREFIX="plugin-kotlin-v"
+          # Backwards compatibility: also accept the fully-prefixed tag form
+          # (e.g. plugin-kotlin-v1.0.4) in addition to the bare version (1.0.4).
+          # Old forks and their release automation still pass the full tag, so
+          # strip the prefix here when it's present. This is intentionally NOT
+          # listed in the workflow_dispatch input description above so the manual
+          # flow steers users toward entering just the version.
+          # DO NOT REMOVE: deleting this breaks releases triggered from existing forks.
+          VERSION="${VERSION#"$PREFIX"}"
           SEMVER_REGEX='^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-(0|[1-9][0-9]*|[0-9]*[A-Za-z-][0-9A-Za-z-]*)(\.(0|[1-9][0-9]*|[0-9]*[A-Za-z-][0-9A-Za-z-]*))*)?(\+[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?$'
           if [[ ! "$VERSION" =~ $SEMVER_REGEX ]]; then
             echo "::error::Version '$VERSION' is not a valid semantic version. Expected MAJOR.MINOR.PATCH (e.g. 1.0.0)"
             exit 1
           fi
-          echo "tag=plugin-kotlin-v${VERSION}" >> "$GITHUB_OUTPUT"
-          echo "Version '$VERSION' is valid. Release tag: plugin-kotlin-v${VERSION}"
+          echo "tag=${PREFIX}${VERSION}" >> "$GITHUB_OUTPUT"
+          echo "Version '$VERSION' is valid. Release tag: ${PREFIX}${VERSION}"
 
   release:
     name: Build and Release Kotlin Plugin

--- a/.github/workflows/release-plugin-python.yml
+++ b/.github/workflows/release-plugin-python.yml
@@ -3,17 +3,37 @@ name: Release Python Plugin
 on:
   workflow_dispatch:
     inputs:
-      tag:
-        description: "Tag for the plugin release (e.g. plugin-python-v1.0.0)"
+      version:
+        description: "Semantic version for the plugin release (e.g. 1.0.0). The 'plugin-python-v' prefix is added automatically."
         required: true
 
 permissions:
   contents: write
 
 jobs:
+  validate:
+    name: Validate version
+    runs-on: ubuntu-latest
+    outputs:
+      tag: ${{ steps.compute.outputs.tag }}
+
+    steps:
+      - name: Validate version and compute tag
+        id: compute
+        run: |
+          VERSION="${{ github.event.inputs.version }}"
+          SEMVER_REGEX='^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-[0-9A-Za-z.-]+)?(\+[0-9A-Za-z.-]+)?$'
+          if [[ ! "$VERSION" =~ $SEMVER_REGEX ]]; then
+            echo "::error::Version '$VERSION' is not a valid semantic version. Expected MAJOR.MINOR.PATCH (e.g. 1.0.0)"
+            exit 1
+          fi
+          echo "tag=plugin-python-v${VERSION}" >> "$GITHUB_OUTPUT"
+          echo "Version '$VERSION' is valid. Release tag: plugin-python-v${VERSION}"
+
   release:
     name: Build and Release Python Plugin
     runs-on: ubuntu-latest
+    needs: validate
 
     steps:
       - name: Checkout code
@@ -42,10 +62,10 @@ jobs:
       - name: Create GitHub release
         uses: softprops/action-gh-release@v2
         with:
-          tag_name: ${{ github.event.inputs.tag }}
-          name: "Python Plugin ${{ github.event.inputs.tag }}"
+          tag_name: ${{ needs.validate.outputs.tag }}
+          name: "Python Plugin ${{ needs.validate.outputs.tag }}"
           body: |
-            Python Plugin Release ${{ github.event.inputs.tag }}
+            Python Plugin Release ${{ needs.validate.outputs.tag }}
             
             ## Requirements
             - Python 3.9 or later

--- a/.github/workflows/release-plugin-python.yml
+++ b/.github/workflows/release-plugin-python.yml
@@ -3,7 +3,7 @@ name: Release Python Plugin
 on:
   workflow_dispatch:
     inputs:
-      version:
+      tag:
         description: "Semantic version for the plugin release (e.g. 1.0.0). The 'plugin-python-v' prefix is added automatically."
         required: true
 
@@ -21,7 +21,7 @@ jobs:
       - name: Validate version and compute tag
         id: compute
         env:
-          VERSION: ${{ github.event.inputs.version }}
+          VERSION: ${{ github.event.inputs.tag }}
         run: |
           PREFIX="plugin-python-v"
           # Backwards compatibility: also accept the fully-prefixed tag form

--- a/.github/workflows/release-plugin-python.yml
+++ b/.github/workflows/release-plugin-python.yml
@@ -20,8 +20,9 @@ jobs:
     steps:
       - name: Validate version and compute tag
         id: compute
+        env:
+          VERSION: ${{ github.event.inputs.version }}
         run: |
-          VERSION="${{ github.event.inputs.version }}"
           SEMVER_REGEX='^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-(0|[1-9][0-9]*|[0-9]*[A-Za-z-][0-9A-Za-z-]*)(\.(0|[1-9][0-9]*|[0-9]*[A-Za-z-][0-9A-Za-z-]*))*)?(\+[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?$'
           if [[ ! "$VERSION" =~ $SEMVER_REGEX ]]; then
             echo "::error::Version '$VERSION' is not a valid semantic version. Expected MAJOR.MINOR.PATCH (e.g. 1.0.0)"

--- a/.github/workflows/release-plugin-python.yml
+++ b/.github/workflows/release-plugin-python.yml
@@ -23,13 +23,22 @@ jobs:
         env:
           VERSION: ${{ github.event.inputs.version }}
         run: |
+          PREFIX="plugin-python-v"
+          # Backwards compatibility: also accept the fully-prefixed tag form
+          # (e.g. plugin-python-v1.0.4) in addition to the bare version (1.0.4).
+          # Old forks and their release automation still pass the full tag, so
+          # strip the prefix here when it's present. This is intentionally NOT
+          # listed in the workflow_dispatch input description above so the manual
+          # flow steers users toward entering just the version.
+          # DO NOT REMOVE: deleting this breaks releases triggered from existing forks.
+          VERSION="${VERSION#"$PREFIX"}"
           SEMVER_REGEX='^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-(0|[1-9][0-9]*|[0-9]*[A-Za-z-][0-9A-Za-z-]*)(\.(0|[1-9][0-9]*|[0-9]*[A-Za-z-][0-9A-Za-z-]*))*)?(\+[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?$'
           if [[ ! "$VERSION" =~ $SEMVER_REGEX ]]; then
             echo "::error::Version '$VERSION' is not a valid semantic version. Expected MAJOR.MINOR.PATCH (e.g. 1.0.0)"
             exit 1
           fi
-          echo "tag=plugin-python-v${VERSION}" >> "$GITHUB_OUTPUT"
-          echo "Version '$VERSION' is valid. Release tag: plugin-python-v${VERSION}"
+          echo "tag=${PREFIX}${VERSION}" >> "$GITHUB_OUTPUT"
+          echo "Version '$VERSION' is valid. Release tag: ${PREFIX}${VERSION}"
 
   release:
     name: Build and Release Python Plugin

--- a/.github/workflows/release-plugin-python.yml
+++ b/.github/workflows/release-plugin-python.yml
@@ -18,25 +18,27 @@ jobs:
       tag: ${{ steps.compute.outputs.tag }}
 
     steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: "1.26"
+
       - name: Validate version and compute tag
         id: compute
         env:
           VERSION: ${{ github.event.inputs.tag }}
         run: |
           PREFIX="plugin-python-v"
-          # Backwards compatibility: also accept the fully-prefixed tag form
-          # (e.g. plugin-python-v1.0.4) in addition to the bare version (1.0.4).
-          # Old forks and their release automation still pass the full tag, so
-          # strip the prefix here when it's present. This is intentionally NOT
-          # listed in the workflow_dispatch input description above so the manual
-          # flow steers users toward entering just the version.
-          # DO NOT REMOVE: deleting this breaks releases triggered from existing forks.
+          # Back-compat: accept the full tag form (e.g. plugin-python-v1.0.4) too, not just
+          # the bare version. DO NOT REMOVE: old forks pass the full tag when releasing.
           VERSION="${VERSION#"$PREFIX"}"
-          SEMVER_REGEX='^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-(0|[1-9][0-9]*|[0-9]*[A-Za-z-][0-9A-Za-z-]*)(\.(0|[1-9][0-9]*|[0-9]*[A-Za-z-][0-9A-Za-z-]*))*)?(\+[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?$'
-          if [[ ! "$VERSION" =~ $SEMVER_REGEX ]]; then
-            echo "::error::Version '$VERSION' is not a valid semantic version. Expected MAJOR.MINOR.PATCH (e.g. 1.0.0)"
-            exit 1
-          fi
+          # Tolerate a bare "v" prefix (e.g. v1.0.4) so the tag isn't doubled below.
+          VERSION="${VERSION#v}"
+          # Validate via the shared script (same semver check as the auto-updater).
+          go run ./cmd/scripts/semver "$VERSION"
           echo "tag=${PREFIX}${VERSION}" >> "$GITHUB_OUTPUT"
           echo "Version '$VERSION' is valid. Release tag: ${PREFIX}${VERSION}"
 

--- a/.github/workflows/release-plugin-python.yml
+++ b/.github/workflows/release-plugin-python.yml
@@ -22,7 +22,7 @@ jobs:
         id: compute
         run: |
           VERSION="${{ github.event.inputs.version }}"
-          SEMVER_REGEX='^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-[0-9A-Za-z.-]+)?(\+[0-9A-Za-z.-]+)?$'
+          SEMVER_REGEX='^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-(0|[1-9][0-9]*|[0-9]*[A-Za-z-][0-9A-Za-z-]*)(\.(0|[1-9][0-9]*|[0-9]*[A-Za-z-][0-9A-Za-z-]*))*)?(\+[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?$'
           if [[ ! "$VERSION" =~ $SEMVER_REGEX ]]; then
             echo "::error::Version '$VERSION' is not a valid semantic version. Expected MAJOR.MINOR.PATCH (e.g. 1.0.0)"
             exit 1

--- a/.github/workflows/release-plugin-typescript.yml
+++ b/.github/workflows/release-plugin-typescript.yml
@@ -20,8 +20,9 @@ jobs:
     steps:
       - name: Validate version and compute tag
         id: compute
+        env:
+          VERSION: ${{ github.event.inputs.version }}
         run: |
-          VERSION="${{ github.event.inputs.version }}"
           SEMVER_REGEX='^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-(0|[1-9][0-9]*|[0-9]*[A-Za-z-][0-9A-Za-z-]*)(\.(0|[1-9][0-9]*|[0-9]*[A-Za-z-][0-9A-Za-z-]*))*)?(\+[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?$'
           if [[ ! "$VERSION" =~ $SEMVER_REGEX ]]; then
             echo "::error::Version '$VERSION' is not a valid semantic version. Expected MAJOR.MINOR.PATCH (e.g. 1.0.0)"

--- a/.github/workflows/release-plugin-typescript.yml
+++ b/.github/workflows/release-plugin-typescript.yml
@@ -3,17 +3,37 @@ name: Release TypeScript Plugin
 on:
   workflow_dispatch:
     inputs:
-      tag:
-        description: "Tag for the plugin release (e.g. plugin-typescript-v1.0.0)"
+      version:
+        description: "Semantic version for the plugin release (e.g. 1.0.0). The 'plugin-typescript-v' prefix is added automatically."
         required: true
 
 permissions:
   contents: write
 
 jobs:
+  validate:
+    name: Validate version
+    runs-on: ubuntu-latest
+    outputs:
+      tag: ${{ steps.compute.outputs.tag }}
+
+    steps:
+      - name: Validate version and compute tag
+        id: compute
+        run: |
+          VERSION="${{ github.event.inputs.version }}"
+          SEMVER_REGEX='^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-[0-9A-Za-z.-]+)?(\+[0-9A-Za-z.-]+)?$'
+          if [[ ! "$VERSION" =~ $SEMVER_REGEX ]]; then
+            echo "::error::Version '$VERSION' is not a valid semantic version. Expected MAJOR.MINOR.PATCH (e.g. 1.0.0)"
+            exit 1
+          fi
+          echo "tag=plugin-typescript-v${VERSION}" >> "$GITHUB_OUTPUT"
+          echo "Version '$VERSION' is valid. Release tag: plugin-typescript-v${VERSION}"
+
   release:
     name: Build and Release TypeScript Plugin
     runs-on: ubuntu-latest
+    needs: validate
 
     steps:
       - name: Checkout code
@@ -61,10 +81,10 @@ jobs:
       - name: Create GitHub release
         uses: softprops/action-gh-release@v2
         with:
-          tag_name: ${{ github.event.inputs.tag }}
-          name: "TypeScript Plugin ${{ github.event.inputs.tag }}"
+          tag_name: ${{ needs.validate.outputs.tag }}
+          name: "TypeScript Plugin ${{ needs.validate.outputs.tag }}"
           body: |
-            TypeScript Plugin Release ${{ github.event.inputs.tag }}
+            TypeScript Plugin Release ${{ needs.validate.outputs.tag }}
             
             ## Installation
             1. Extract `typescript-plugin.tar.gz` to `plugin/typescript/`

--- a/.github/workflows/release-plugin-typescript.yml
+++ b/.github/workflows/release-plugin-typescript.yml
@@ -3,7 +3,7 @@ name: Release TypeScript Plugin
 on:
   workflow_dispatch:
     inputs:
-      version:
+      tag:
         description: "Semantic version for the plugin release (e.g. 1.0.0). The 'plugin-typescript-v' prefix is added automatically."
         required: true
 
@@ -21,7 +21,7 @@ jobs:
       - name: Validate version and compute tag
         id: compute
         env:
-          VERSION: ${{ github.event.inputs.version }}
+          VERSION: ${{ github.event.inputs.tag }}
         run: |
           PREFIX="plugin-typescript-v"
           # Backwards compatibility: also accept the fully-prefixed tag form

--- a/.github/workflows/release-plugin-typescript.yml
+++ b/.github/workflows/release-plugin-typescript.yml
@@ -18,25 +18,27 @@ jobs:
       tag: ${{ steps.compute.outputs.tag }}
 
     steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: "1.26"
+
       - name: Validate version and compute tag
         id: compute
         env:
           VERSION: ${{ github.event.inputs.tag }}
         run: |
           PREFIX="plugin-typescript-v"
-          # Backwards compatibility: also accept the fully-prefixed tag form
-          # (e.g. plugin-typescript-v1.0.4) in addition to the bare version (1.0.4).
-          # Old forks and their release automation still pass the full tag, so
-          # strip the prefix here when it's present. This is intentionally NOT
-          # listed in the workflow_dispatch input description above so the manual
-          # flow steers users toward entering just the version.
-          # DO NOT REMOVE: deleting this breaks releases triggered from existing forks.
+          # Back-compat: accept the full tag form (e.g. plugin-typescript-v1.0.4) too, not
+          # just the bare version. DO NOT REMOVE: old forks pass the full tag when releasing.
           VERSION="${VERSION#"$PREFIX"}"
-          SEMVER_REGEX='^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-(0|[1-9][0-9]*|[0-9]*[A-Za-z-][0-9A-Za-z-]*)(\.(0|[1-9][0-9]*|[0-9]*[A-Za-z-][0-9A-Za-z-]*))*)?(\+[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?$'
-          if [[ ! "$VERSION" =~ $SEMVER_REGEX ]]; then
-            echo "::error::Version '$VERSION' is not a valid semantic version. Expected MAJOR.MINOR.PATCH (e.g. 1.0.0)"
-            exit 1
-          fi
+          # Tolerate a bare "v" prefix (e.g. v1.0.4) so the tag isn't doubled below.
+          VERSION="${VERSION#v}"
+          # Validate via the shared script (same semver check as the auto-updater).
+          go run ./cmd/scripts/semver "$VERSION"
           echo "tag=${PREFIX}${VERSION}" >> "$GITHUB_OUTPUT"
           echo "Version '$VERSION' is valid. Release tag: ${PREFIX}${VERSION}"
 

--- a/.github/workflows/release-plugin-typescript.yml
+++ b/.github/workflows/release-plugin-typescript.yml
@@ -23,13 +23,22 @@ jobs:
         env:
           VERSION: ${{ github.event.inputs.version }}
         run: |
+          PREFIX="plugin-typescript-v"
+          # Backwards compatibility: also accept the fully-prefixed tag form
+          # (e.g. plugin-typescript-v1.0.4) in addition to the bare version (1.0.4).
+          # Old forks and their release automation still pass the full tag, so
+          # strip the prefix here when it's present. This is intentionally NOT
+          # listed in the workflow_dispatch input description above so the manual
+          # flow steers users toward entering just the version.
+          # DO NOT REMOVE: deleting this breaks releases triggered from existing forks.
+          VERSION="${VERSION#"$PREFIX"}"
           SEMVER_REGEX='^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-(0|[1-9][0-9]*|[0-9]*[A-Za-z-][0-9A-Za-z-]*)(\.(0|[1-9][0-9]*|[0-9]*[A-Za-z-][0-9A-Za-z-]*))*)?(\+[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?$'
           if [[ ! "$VERSION" =~ $SEMVER_REGEX ]]; then
             echo "::error::Version '$VERSION' is not a valid semantic version. Expected MAJOR.MINOR.PATCH (e.g. 1.0.0)"
             exit 1
           fi
-          echo "tag=plugin-typescript-v${VERSION}" >> "$GITHUB_OUTPUT"
-          echo "Version '$VERSION' is valid. Release tag: plugin-typescript-v${VERSION}"
+          echo "tag=${PREFIX}${VERSION}" >> "$GITHUB_OUTPUT"
+          echo "Version '$VERSION' is valid. Release tag: ${PREFIX}${VERSION}"
 
   release:
     name: Build and Release TypeScript Plugin

--- a/.github/workflows/release-plugin-typescript.yml
+++ b/.github/workflows/release-plugin-typescript.yml
@@ -22,7 +22,7 @@ jobs:
         id: compute
         run: |
           VERSION="${{ github.event.inputs.version }}"
-          SEMVER_REGEX='^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-[0-9A-Za-z.-]+)?(\+[0-9A-Za-z.-]+)?$'
+          SEMVER_REGEX='^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-(0|[1-9][0-9]*|[0-9]*[A-Za-z-][0-9A-Za-z-]*)(\.(0|[1-9][0-9]*|[0-9]*[A-Za-z-][0-9A-Za-z-]*))*)?(\+[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?$'
           if [[ ! "$VERSION" =~ $SEMVER_REGEX ]]; then
             echo "::error::Version '$VERSION' is not a valid semantic version. Expected MAJOR.MINOR.PATCH (e.g. 1.0.0)"
             exit 1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,17 +3,37 @@ name: Release
 on:
   workflow_dispatch:
     inputs:
-      tag:
-        description: "Tag for the release (e.g. v1.0.0)"
+      version:
+        description: "Semantic version for the release (e.g. 1.0.0). The 'v' prefix is added automatically."
         required: true
 
 permissions:
   contents: write
 
 jobs:
+  validate:
+    name: Validate version
+    runs-on: ubuntu-latest
+    outputs:
+      tag: ${{ steps.compute.outputs.tag }}
+
+    steps:
+      - name: Validate version and compute tag
+        id: compute
+        run: |
+          VERSION="${{ github.event.inputs.version }}"
+          SEMVER_REGEX='^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-[0-9A-Za-z.-]+)?(\+[0-9A-Za-z.-]+)?$'
+          if [[ ! "$VERSION" =~ $SEMVER_REGEX ]]; then
+            echo "::error::Version '$VERSION' is not a valid semantic version. Expected MAJOR.MINOR.PATCH (e.g. 1.0.0)"
+            exit 1
+          fi
+          echo "tag=v${VERSION}" >> "$GITHUB_OUTPUT"
+          echo "Version '$VERSION' is valid. Release tag: v${VERSION}"
+
   release:
     name: Build and Release
     runs-on: ubuntu-latest
+    needs: validate
 
     steps:
       - name: Checkout code
@@ -42,7 +62,7 @@ jobs:
       - name: Create GitHub release
         uses: softprops/action-gh-release@v3
         with:
-          tag_name: ${{ github.event.inputs.tag }}
+          tag_name: ${{ needs.validate.outputs.tag }}
           target_commitish: ${{ github.sha }}
           files: |
             dist/cli-linux-amd64
@@ -58,7 +78,7 @@ jobs:
   docker-main:
     name: Docker - Main
     runs-on: ubuntu-latest
-    needs: release
+    needs: [validate, release]
 
     steps:
       - name: Checkout code
@@ -77,7 +97,7 @@ jobs:
 
       - name: Build and push
         run: |
-          TAG=${{ github.event.inputs.tag }}
+          TAG=${{ needs.validate.outputs.tag }}
           DOCKER_TAG=${TAG//+/-}
           docker build \
             -t canopynetwork/canopy:${DOCKER_TAG} \
@@ -91,7 +111,7 @@ jobs:
   docker-go:
     name: Docker - Go Plugin
     runs-on: ubuntu-latest
-    needs: release
+    needs: [validate, release]
 
     steps:
       - name: Checkout code
@@ -110,7 +130,7 @@ jobs:
 
       - name: Build and push
         run: |
-          TAG=${{ github.event.inputs.tag }}
+          TAG=${{ needs.validate.outputs.tag }}
           DOCKER_TAG=${TAG//+/-}
           docker build \
             -t canopynetwork/canopy:go-${DOCKER_TAG} \
@@ -125,7 +145,7 @@ jobs:
   docker-python:
     name: Docker - Python Plugin
     runs-on: ubuntu-latest
-    needs: release
+    needs: [validate, release]
 
     steps:
       - name: Checkout code
@@ -144,7 +164,7 @@ jobs:
 
       - name: Build and push
         run: |
-          TAG=${{ github.event.inputs.tag }}
+          TAG=${{ needs.validate.outputs.tag }}
           DOCKER_TAG=${TAG//+/-}
           docker build \
             -t canopynetwork/canopy:python-${DOCKER_TAG} \
@@ -159,7 +179,7 @@ jobs:
   docker-typescript:
     name: Docker - TypeScript Plugin
     runs-on: ubuntu-latest
-    needs: release
+    needs: [validate, release]
 
     steps:
       - name: Checkout code
@@ -178,7 +198,7 @@ jobs:
 
       - name: Build and push
         run: |
-          TAG=${{ github.event.inputs.tag }}
+          TAG=${{ needs.validate.outputs.tag }}
           DOCKER_TAG=${TAG//+/-}
           docker build \
             -t canopynetwork/canopy:typescript-${DOCKER_TAG} \
@@ -193,7 +213,7 @@ jobs:
   docker-kotlin:
     name: Docker - Kotlin Plugin
     runs-on: ubuntu-latest
-    needs: release
+    needs: [validate, release]
 
     steps:
       - name: Checkout code
@@ -212,7 +232,7 @@ jobs:
 
       - name: Build and push
         run: |
-          TAG=${{ github.event.inputs.tag }}
+          TAG=${{ needs.validate.outputs.tag }}
           DOCKER_TAG=${TAG//+/-}
           docker build \
             -t canopynetwork/canopy:kotlin-${DOCKER_TAG} \
@@ -227,7 +247,7 @@ jobs:
   docker-csharp:
     name: Docker - C# Plugin
     runs-on: ubuntu-latest
-    needs: release
+    needs: [validate, release]
 
     steps:
       - name: Checkout code
@@ -246,7 +266,7 @@ jobs:
 
       - name: Build and push
         run: |
-          TAG=${{ github.event.inputs.tag }}
+          TAG=${{ needs.validate.outputs.tag }}
           DOCKER_TAG=${TAG//+/-}
           docker build \
             -t canopynetwork/canopy:csharp-${DOCKER_TAG} \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,8 +20,9 @@ jobs:
     steps:
       - name: Validate version and compute tag
         id: compute
+        env:
+          VERSION: ${{ github.event.inputs.version }}
         run: |
-          VERSION="${{ github.event.inputs.version }}"
           SEMVER_REGEX='^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-(0|[1-9][0-9]*|[0-9]*[A-Za-z-][0-9A-Za-z-]*)(\.(0|[1-9][0-9]*|[0-9]*[A-Za-z-][0-9A-Za-z-]*))*)?(\+[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?$'
           if [[ ! "$VERSION" =~ $SEMVER_REGEX ]]; then
             echo "::error::Version '$VERSION' is not a valid semantic version. Expected MAJOR.MINOR.PATCH (e.g. 1.0.0)"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,16 +18,23 @@ jobs:
       tag: ${{ steps.compute.outputs.tag }}
 
     steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: "1.26"
+
       - name: Validate version and compute tag
         id: compute
         env:
           VERSION: ${{ github.event.inputs.tag }}
         run: |
-          SEMVER_REGEX='^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-(0|[1-9][0-9]*|[0-9]*[A-Za-z-][0-9A-Za-z-]*)(\.(0|[1-9][0-9]*|[0-9]*[A-Za-z-][0-9A-Za-z-]*))*)?(\+[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?$'
-          if [[ ! "$VERSION" =~ $SEMVER_REGEX ]]; then
-            echo "::error::Version '$VERSION' is not a valid semantic version. Expected MAJOR.MINOR.PATCH (e.g. 1.0.0)"
-            exit 1
-          fi
+          # Tolerate a leading "v" (e.g. v1.0.0) so the tag isn't doubled into "vv1.0.0".
+          VERSION="${VERSION#v}"
+          # Validate via the shared script (same semver check as the auto-updater).
+          go run ./cmd/scripts/semver "$VERSION"
           echo "tag=v${VERSION}" >> "$GITHUB_OUTPUT"
           echo "Version '$VERSION' is valid. Release tag: v${VERSION}"
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@ name: Release
 on:
   workflow_dispatch:
     inputs:
-      version:
+      tag:
         description: "Semantic version for the release (e.g. 1.0.0). The 'v' prefix is added automatically."
         required: true
 
@@ -21,7 +21,7 @@ jobs:
       - name: Validate version and compute tag
         id: compute
         env:
-          VERSION: ${{ github.event.inputs.version }}
+          VERSION: ${{ github.event.inputs.tag }}
         run: |
           SEMVER_REGEX='^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-(0|[1-9][0-9]*|[0-9]*[A-Za-z-][0-9A-Za-z-]*)(\.(0|[1-9][0-9]*|[0-9]*[A-Za-z-][0-9A-Za-z-]*))*)?(\+[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?$'
           if [[ ! "$VERSION" =~ $SEMVER_REGEX ]]; then

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
         id: compute
         run: |
           VERSION="${{ github.event.inputs.version }}"
-          SEMVER_REGEX='^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-[0-9A-Za-z.-]+)?(\+[0-9A-Za-z.-]+)?$'
+          SEMVER_REGEX='^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-(0|[1-9][0-9]*|[0-9]*[A-Za-z-][0-9A-Za-z-]*)(\.(0|[1-9][0-9]*|[0-9]*[A-Za-z-][0-9A-Za-z-]*))*)?(\+[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?$'
           if [[ ! "$VERSION" =~ $SEMVER_REGEX ]]; then
             echo "::error::Version '$VERSION' is not a valid semantic version. Expected MAJOR.MINOR.PATCH (e.g. 1.0.0)"
             exit 1

--- a/cmd/auto-update/releaser.go
+++ b/cmd/auto-update/releaser.go
@@ -14,6 +14,7 @@ import (
 	"runtime"
 	"strings"
 
+	"github.com/canopy-network/canopy/lib"
 	"golang.org/x/mod/semver"
 )
 
@@ -211,16 +212,16 @@ func (rm *ReleaseManager) ShouldUpdate(release *Release) error {
 	candidate := semver.Canonical(candidateTag)
 	current := semver.Canonical(rm.Version)
 	// for plugins, if current version is invalid (first run), always update
-	if rm.config.Type == ReleaseTypePlugin && (current == "" || !semver.IsValid(current)) {
+	if rm.config.Type == ReleaseTypePlugin && (current == "" || !lib.IsValidVersion(current)) {
 		release.ShouldUpdate = true
 		release.Version = candidate
 		return nil
 	}
 	// validate versions
-	if candidate == "" || !semver.IsValid(candidate) {
+	if candidate == "" || !lib.IsValidVersion(candidate) {
 		return fmt.Errorf("invalid release version: %s", release.Version)
 	}
-	if current == "" || !semver.IsValid(current) {
+	if current == "" || !lib.IsValidVersion(current) {
 		return fmt.Errorf("invalid local version: %s", rm.Version)
 	}
 	// should update if the candidate version is greater than the current version

--- a/cmd/scripts/semver/main.go
+++ b/cmd/scripts/semver/main.go
@@ -1,0 +1,30 @@
+// Command semver validates that its argument is valid semver via
+// lib.IsValidVersion (the same check the auto-updater uses), so the release
+// GitHub Actions fail fast on malformed versions before a release is created.
+// Usage: semver <version> (a leading "v" is optional; exit 0 means valid).
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/canopy-network/canopy/lib"
+)
+
+func main() {
+	if err := run(os.Args[1:]); err != nil {
+		_, _ = fmt.Fprintf(os.Stderr, "semver: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+// run validates the single version argument.
+func run(args []string) error {
+	if len(args) != 1 || args[0] == "" {
+		return fmt.Errorf("usage: semver <version>")
+	}
+	if !lib.IsValidVersion(args[0]) {
+		return fmt.Errorf("invalid semantic version: %q (expected MAJOR.MINOR.PATCH, e.g. 1.2.3 or v1.2.3)", args[0])
+	}
+	return nil
+}

--- a/cmd/scripts/semver/main_test.go
+++ b/cmd/scripts/semver/main_test.go
@@ -1,0 +1,29 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// Validation itself is covered in lib; these cover argument handling.
+func TestRun(t *testing.T) {
+	t.Run("valid bare version", func(t *testing.T) {
+		require.NoError(t, run([]string{"1.2.3"}))
+	})
+	t.Run("valid v-prefixed version", func(t *testing.T) {
+		require.NoError(t, run([]string{"v1.2.3"}))
+	})
+	t.Run("invalid four-segment version", func(t *testing.T) {
+		require.Error(t, run([]string{"1.0.4.5"}))
+	})
+	t.Run("empty version", func(t *testing.T) {
+		require.Error(t, run([]string{""}))
+	})
+	t.Run("no arguments", func(t *testing.T) {
+		require.Error(t, run(nil))
+	})
+	t.Run("too many arguments", func(t *testing.T) {
+		require.Error(t, run([]string{"1.0.0", "2.0.0"}))
+	})
+}

--- a/lib/util.go
+++ b/lib/util.go
@@ -21,6 +21,7 @@ import (
 	"unsafe"
 
 	"github.com/canopy-network/canopy/lib/crypto"
+	"golang.org/x/mod/semver"
 	"google.golang.org/protobuf/encoding/protowire"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/reflect/protoreflect"
@@ -1092,4 +1093,18 @@ func RandSlice(byteSize uint64) []byte {
 	value := make([]byte, byteSize)
 	rand.Read(value)
 	return value
+}
+
+// IsValidVersion reports whether version is valid semver, accepting an optional
+// leading "v". Shared so the release script and auto-updater validate alike.
+func IsValidVersion(version string) bool {
+	return semver.IsValid(normalizeVersion(version))
+}
+
+// normalizeVersion adds the leading "v" that golang.org/x/mod/semver requires.
+func normalizeVersion(version string) string {
+	if version == "" || version[0] == 'v' {
+		return version
+	}
+	return "v" + version
 }

--- a/lib/util_test.go
+++ b/lib/util_test.go
@@ -633,3 +633,46 @@ func TestLoadCountedCallbackError(t *testing.T) {
 	page := NewPage(PageParams{PageNumber: 1, PerPage: 10}, TxResultsPageName)
 	require.Error(t, page.LoadCounted(25, &results, func(index int) ErrorI { return ErrInvalidArgument() }))
 }
+
+func TestIsValidVersion(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  bool
+	}{
+		// valid, bare (as entered in the manual release flow)
+		{"bare patch", "1.0.0", true},
+		{"bare large", "10.20.30", true},
+		{"bare prerelease", "1.0.0-rc.1", true},
+		{"bare prerelease zero", "1.2.3-0", true},
+		{"bare prerelease alnum", "1.2.3-alpha.1", true},
+		// valid, v-prefixed (as passed by old callers / full tags)
+		{"v patch", "v1.0.0", true},
+		{"v build metadata", "v1.2.3+build.5", true},
+		// semver.IsValid accepts partial versions; documented here so the
+		// behavior is intentional and does not surprise future readers.
+		{"v major only", "v1", true},
+		{"v major minor", "v1.2", true},
+		// invalid: the original bug that motivated this check
+		{"four segments bare", "1.0.4.5", false},
+		{"four segments v", "v1.0.4.5", false},
+		// invalid prerelease/build forms rejected by x/mod/semver
+		{"leading zero prerelease", "1.2.3-01", false},
+		{"empty prerelease identifiers", "1.2.3-..", false},
+		{"trailing dot prerelease", "1.2.3-alpha.", false},
+		// invalid: not versions at all
+		{"garbage", "foo", false},
+		{"empty", "", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, IsValidVersion(tt.input))
+		})
+	}
+}
+
+func TestNormalizeVersion(t *testing.T) {
+	require.Equal(t, "v1.2.3", normalizeVersion("1.2.3"))
+	require.Equal(t, "v1.2.3", normalizeVersion("v1.2.3"))
+	require.Equal(t, "", normalizeVersion(""))
+}


### PR DESCRIPTION
## Summary

Release workflows previously accepted a free-form `tag` input and passed it straight to the GitHub release step. This allowed malformed tags (e.g. `plugin-go-v1.0.4.5`) to be published, which then broke the auto-updater since it validates versions as strict semver (`MAJOR.MINOR.PATCH`) and rejects anything else with `invalid release version`.

This PR adds up-front version validation to all release workflows and simplifies the plugin release inputs so the language prefix can no longer be mistyped.

## Changes

### All release workflows (`release.yml` + 5 plugin workflows)
- Added a `validate` job that runs **before** any build/release step. If the version isn't a valid semantic version (`MAJOR.MINOR.PATCH`, with optional `-prerelease`/`+build`), the job fails fast with a clear `::error::` annotation and nothing is built or published.
- The `release` job (and, in `release.yml`, the downstream Docker jobs) now depends on `validate` via `needs`, so the whole pipeline is gated.

### Plugin workflows (`go`, `python`, `typescript`, `kotlin`, `csharp`)
- Changed the `workflow_dispatch` input from `tag` to `version`. Operators now enter only the semantic version (e.g. `1.0.0`).
- The `validate` job computes the full tag by automatically prepending the correct prefix (`plugin-<language>-v`) and exposes it as a job output.
- The `release` job consumes `needs.validate.outputs.tag` for `tag_name`, the release name, and the release body.

## Why

- **Prevents bad releases**: invalid versions fail before a GitHub release or Docker image is created, instead of surfacing later as an auto-updater error.
- **Removes a footgun**: operators can no longer forget or mistype the `plugin-<language>-` prefix — it's added automatically and consistently.
- **Consistent with the auto-updater**: the validation is intentionally stricter than `golang.org/x/mod/semver` (requires full `MAJOR.MINOR.PATCH`), so anything that passes will be accepted by the updater.

## Behavior change

- Plugin release runs now take a **version** (`1.0.4`) rather than a full **tag** (`plugin-go-v1.0.4`). The resulting tag is unchanged in shape (e.g. `plugin-go-v1.0.4`).
- The main `release.yml` still takes a `v`-prefixed tag input; only validation was added there.