### PR TITLE
feat: improve blocks call by only fetching the required blocks

### DIFF
--- a/lib/util.go
+++ b/lib/util.go
@@ -130,6 +130,30 @@ func (p *Page) Load(storePrefix []byte, reverse bool, results Pageable, db RStor
 	return
 }
 
+// LoadCounted() fills a page when the total number of items and the position of each item
+// are already known, invoking the callback only for the indices that belong to the requested
+// page. Unlike Load(), no iteration over the skipped items is needed to calculate the params
+func (p *Page) LoadCounted(totalCount int, results Pageable, callback func(index int) ErrorI) (err ErrorI) {
+	// set the page results so that even if it's a zero page, it will have a castable type
+	p.Results, p.TotalCount = results, totalCount
+	// skip to index makes the starting point appropriate based on the page params
+	pageStartIndex := p.skipToIndex()
+	// calculate total pages
+	p.TotalPages = int(math.Ceil(float64(p.TotalCount) / float64(p.PerPage)))
+	// for each index of the requested page that actually exists
+	for i := pageStartIndex; i < pageStartIndex+p.PerPage && i < totalCount; i++ {
+		// execute the callback; passing the index within the complete result set
+		if err = callback(i); err != nil {
+			// exit with error
+			return
+		}
+		// set the results and increment the count
+		p.Results, p.Count = results, p.Count+1
+	}
+	// exit
+	return
+}
+
 // LoadArray() fills a page from a slice
 func (p *Page) LoadArray(slice any, results Pageable, callback func(item any) ErrorI) (err ErrorI) {
 	// if the slice is not type of reflect

--- a/lib/util_test.go
+++ b/lib/util_test.go
@@ -550,3 +550,86 @@ func TestAddUint64(t *testing.T) {
 	require.Equal(t, uint64(0), sum)
 	require.True(t, overflow)
 }
+
+func TestLoadCounted(t *testing.T) {
+	tests := []struct {
+		name           string
+		totalCount     int
+		params         PageParams
+		expectedIdx    []int
+		expectedPages  int
+		expectedPerPag int
+	}{
+		{
+			name:           "first page of many",
+			totalCount:     25,
+			params:         PageParams{PageNumber: 1, PerPage: 10},
+			expectedIdx:    []int{0, 1, 2, 3, 4, 5, 6, 7, 8, 9},
+			expectedPages:  3,
+			expectedPerPag: 10,
+		},
+		{
+			name:           "middle page starts after the previous page",
+			totalCount:     25,
+			params:         PageParams{PageNumber: 2, PerPage: 10},
+			expectedIdx:    []int{10, 11, 12, 13, 14, 15, 16, 17, 18, 19},
+			expectedPages:  3,
+			expectedPerPag: 10,
+		},
+		{
+			name:           "last page is partial",
+			totalCount:     25,
+			params:         PageParams{PageNumber: 3, PerPage: 10},
+			expectedIdx:    []int{20, 21, 22, 23, 24},
+			expectedPages:  3,
+			expectedPerPag: 10,
+		},
+		{
+			name:           "page beyond the total count is empty",
+			totalCount:     25,
+			params:         PageParams{PageNumber: 4, PerPage: 10},
+			expectedIdx:    nil,
+			expectedPages:  3,
+			expectedPerPag: 10,
+		},
+		{
+			name:           "empty result set",
+			totalCount:     0,
+			params:         PageParams{PageNumber: 1, PerPage: 10},
+			expectedIdx:    nil,
+			expectedPages:  0,
+			expectedPerPag: 10,
+		},
+		{
+			name:           "defaults are applied to the params",
+			totalCount:     3,
+			params:         PageParams{},
+			expectedIdx:    []int{0, 1, 2},
+			expectedPages:  1,
+			expectedPerPag: 10,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			var got []int
+			results := make(TxResults, 0)
+			page := NewPage(test.params, TxResultsPageName)
+			require.NoError(t, page.LoadCounted(test.totalCount, &results, func(index int) ErrorI {
+				got = append(got, index)
+				return nil
+			}))
+			require.Equal(t, test.expectedIdx, got)
+			require.Equal(t, len(test.expectedIdx), page.Count)
+			require.Equal(t, test.totalCount, page.TotalCount)
+			require.Equal(t, test.expectedPages, page.TotalPages)
+			require.Equal(t, test.expectedPerPag, page.PerPage)
+			require.Equal(t, &results, page.Results)
+		})
+	}
+}
+
+func TestLoadCountedCallbackError(t *testing.T) {
+	results := make(TxResults, 0)
+	page := NewPage(PageParams{PageNumber: 1, PerPage: 10}, TxResultsPageName)
+	require.Error(t, page.LoadCounted(25, &results, func(index int) ErrorI { return ErrInvalidArgument() }))
+}

--- a/store/indexer.go
+++ b/store/indexer.go
@@ -217,33 +217,143 @@ func (t *Indexer) GetBlockHeaderByHeight(height uint64) (*lib.BlockResult, lib.E
 }
 
 // GetBlocks() returns a page of blocks based on the page parameters
+// blocks are indexed contiguously by height, so the page params are derived from the
+// oldest and newest indexed heights instead of walking the entire block index
 func (t *Indexer) GetBlocks(p lib.PageParams) (page *lib.Page, err lib.ErrorI) {
-	results, count, page := make(lib.BlockResults, 0), 0, lib.NewPage(p, lib.BlockResultsPageName)
-	err = page.Load(lib.JoinLenPrefix(blockHeightPrefix), true, &results, t.db, func(_, b []byte) lib.ErrorI {
-		// get the block from the iterator value
-		block, e := t.getBlock(b, true)
+	results, page := make(lib.BlockResults, 0), lib.NewPage(p, lib.BlockResultsPageName)
+	// get the height boundaries of the index
+	oldest, newest, found, err := t.blockHeightBounds()
+	if err != nil {
+		return
+	}
+	// the total count is the size of the height range (0 when nothing is indexed)
+	totalCount := 0
+	if found {
+		totalCount = int(newest - oldest + 1)
+	}
+	// blocks are ordered newest to oldest, so the item at index i is the block at newest-i
+	err = page.LoadCounted(totalCount, &results, func(index int) lib.ErrorI {
+		block, e := t.getBlockForPage(newest-uint64(index), true)
 		if e != nil {
 			return e
 		}
-		// do not capture the 1 additional block that is needed for the metadata
-		if count < page.PerPage {
-			results = append(results, block)
+		// a cached block result carries the size of the block including its events, so the
+		// size is recalculated to report the same value whether or not the block was cached
+		size, e := blockResultSize(block)
+		if e != nil {
+			return e
 		}
-		// calculate the time took using the N block and the N-1 block (next block aka blockHeight + 1)
-		// this works because we load 1 extra block at the end but don't append it to the results
-		if count != 0 {
-			nextBlock := results[count-1]
-			blockTime := time.UnixMicro(int64(block.BlockHeader.Time))
-			nextBlkTime := time.UnixMicro(int64(nextBlock.BlockHeader.Time))
-			nextBlock.Meta.Took = uint64(nextBlkTime.Sub(blockTime).Milliseconds())
-		} else {
-			page.PerPage += 1 // modify the perPage to get 1 additional block the block meta may be filled in
-		}
-		count++
+		// the block result may be shared with the block cache, so a shallow copy holding its
+		// own metadata is added to the page to keep the 'took' calculation from mutating it
+		results = append(results, &lib.BlockResult{
+			BlockHeader:  block.BlockHeader,
+			Transactions: block.Transactions,
+			Events:       block.Events,
+			Meta:         &lib.BlockResultMeta{Size: size},
+		})
 		return nil
 	})
-	page.PerPage = p.PerPage // reset the perPage
+	if err != nil {
+		return
+	}
+	// fill in the block time metadata now that the page is loaded
+	err = t.setBlocksTook(results, oldest)
 	return
+}
+
+// blockHeightBounds() returns the oldest and newest heights present in the block index
+func (t *Indexer) blockHeightBounds() (oldest, newest uint64, found bool, err lib.ErrorI) {
+	// seek to the highest indexed height
+	newest, found, err = t.seekBlockHeight(true)
+	// exit early if the index is empty or errored
+	if err != nil || !found {
+		return
+	}
+	// seek to the lowest indexed height
+	oldest, found, err = t.seekBlockHeight(false)
+	return
+}
+
+// seekBlockHeight() returns the first height in the block index in the requested direction
+func (t *Indexer) seekBlockHeight(newest bool) (height uint64, found bool, err lib.ErrorI) {
+	var it lib.IteratorI
+	if newest {
+		it, err = t.db.RevIterator(lib.JoinLenPrefix(blockHeightPrefix))
+	} else {
+		it, err = t.db.Iterator(lib.JoinLenPrefix(blockHeightPrefix))
+	}
+	if err != nil {
+		return
+	}
+	defer it.Close()
+	// no blocks are indexed
+	if !it.Valid() {
+		return
+	}
+	// extract the height from the key whose layout is <blockHeightPrefix><height>
+	segments := lib.DecodeLengthPrefixed(it.Key())
+	if len(segments) != 2 {
+		return 0, false, ErrInvalidKey()
+	}
+	return t.decodeBigEndian(segments[1]), true, nil
+}
+
+// setBlocksTook() fills the 'took' metadata of each block using the delta between its time
+// and the time of the block below it; the results are ordered newest to oldest.
+func (t *Indexer) setBlocksTook(results lib.BlockResults, oldest uint64) lib.ErrorI {
+	for i, block := range results {
+		var previousTime uint64
+		if i+1 < len(results) {
+			// the next result is the block directly below this one
+			previousTime = results[i+1].BlockHeader.Time
+		} else {
+			// the last result of the page needs the block below the page
+			height := block.BlockHeader.Height
+			// the oldest indexed block has nothing below it to compare against
+			if oldest >= height {
+				continue
+			}
+			// only the header is needed since the block below the page isn't part of the results
+			previous, err := t.getBlockForPage(height-1, false)
+			if err != nil {
+				return err
+			}
+			previousTime = previous.BlockHeader.Time
+		}
+		// calculate and set block "took" time
+		blockTime := time.UnixMicro(int64(block.BlockHeader.Time))
+		prevBlkTime := time.UnixMicro(int64(previousTime))
+		block.Meta.Took = uint64(blockTime.Sub(prevBlkTime).Milliseconds())
+	}
+	return nil
+}
+
+// blockResultSize() returns the size of the block header and its transactions, matching the
+// size getBlock() reports for a block that wasn't served by the cache
+func blockResultSize(block *lib.BlockResult) (uint64, lib.ErrorI) {
+	bz, err := lib.Marshal(&lib.BlockResult{
+		BlockHeader:  block.BlockHeader,
+		Transactions: block.Transactions,
+	})
+	if err != nil {
+		return 0, err
+	}
+	return uint64(len(bz)), nil
+}
+
+// getBlockForPage() returns the block at the height
+func (t *Indexer) getBlockForPage(height uint64, transactions bool) (*lib.BlockResult, lib.ErrorI) {
+	// use the cached block result if it's already loaded
+	if got, found := blockCache.Get(height); found {
+		return got, nil
+	}
+	// height key points to hash key
+	hashKey, err := t.db.Get(t.blockHeightKey(height))
+	if err != nil {
+		return nil, err
+	}
+	// get the block from the hash key
+	return t.getBlock(hashKey, transactions)
 }
 
 // QUORUM CERTIFICATE CODE BELOW


### PR DESCRIPTION
## Description
`GetBlocks()` walked the entire block index on every call. `page.Load()` derives `totalCount` and `totalPages` as a side effect of iteration, so serving 10 blocks meant stepping over all the blocks and deserializing every block header and its transactions along the way.

Now the `totalCount` and `totalPages` is calculated on the fly by retrieving the current and oldest height (which is always genesis) and only the required blocks are loaded, removing the need to iterate the complete `block` preffix

## Related Issues
Closes: #<issue-number>

## Changes Made
- Revamped `GetBlocks()` to pre-calculate the page's data by using basic arithmetic instead of going through all the blocks
- Added `LoadCounted` to the `Page` structure  so it only loads the required instances assuming the page data has been pre calculated 

## Checklist
- [x] I have tested the changes locally and verified they work as intended.
- [ ] I have appropriately titled my branch `issue-#<issue-number>`.
- [ ] I have run re-built the web-wallet and/or block explorer (if applicable).
- [ ] I have run `npm run prettier` to format the web-wallet and/or block explorer (if applicable)
- [ ] I have updated documentation (if applicable).
- [x] I have included tests for the changes (if applicable).

## Additional Notes
Behavior change for API consumers: a page now returns exactly `perPage` blocks instead of `perPage + 1`, pages no longer overlap, and `count` and `totalPages` are consistent with `perPage`. The block explorer maps `results` directly, so it renders one fewer row per page and no longer shows a duplicate block with an empty `took` which is the expected behavior