### PR TITLE
Feat/auto update binary persistence

### DIFF
--- a/.docker/auto-update/Dockerfile.csharp
+++ b/.docker/auto-update/Dockerfile.csharp
@@ -63,8 +63,9 @@ COPY --from=builder /go/src/github.com/canopy-network/canopy/bin ./canopy
 COPY --from=builder ${BIN_PATH} ${BIN_PATH}
 
 # Create plugin directory and copy only pluginctl.sh
-# Self-contained plugin binary will be downloaded from upstream release and extracted on first start
-RUN mkdir -p /app/plugin/csharp/bin
+# Self-contained plugin binary will be downloaded from upstream release and
+# extracted into the persistent data dir (CANOPY_PLUGIN_HOME) on first start
+RUN mkdir -p /app/plugin/csharp
 COPY --from=builder /go/src/github.com/canopy-network/canopy/plugin/csharp/pluginctl.sh /app/plugin/csharp/pluginctl.sh
 
 # Copy entrypoint

--- a/.docker/auto-update/Dockerfile.kotlin
+++ b/.docker/auto-update/Dockerfile.kotlin
@@ -62,8 +62,9 @@ COPY --from=builder /go/src/github.com/canopy-network/canopy/bin ./canopy
 COPY --from=builder ${BIN_PATH} ${BIN_PATH}
 
 # Create plugin directory and copy only pluginctl.sh
-# Plugin JAR will be downloaded from upstream release and extracted on first start
-RUN mkdir -p /app/plugin/kotlin/build/libs
+# Plugin JAR will be downloaded from upstream release and extracted into the
+# persistent data dir (CANOPY_PLUGIN_HOME) on first start
+RUN mkdir -p /app/plugin/kotlin
 COPY --from=builder /go/src/github.com/canopy-network/canopy/plugin/kotlin/pluginctl.sh /app/plugin/kotlin/pluginctl.sh
 
 # Copy entrypoint

--- a/.docker/auto-update/entrypoint.sh
+++ b/.docker/auto-update/entrypoint.sh
@@ -27,6 +27,7 @@ DATA_DIR=$(cd "$DATA_DIR" && pwd) || { echo "failed to resolve data dir: $DATA_D
 echo "using data directory $DATA_DIR"
 
 # Persisting current version
+# TODO: remove this block as the auto-updater persists updates on its own
 # Check if it exist
 if [ -f "$DATA_DIR/cli" ]; then
   echo "Found existing persistent cli version"

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,8 @@ FROM golang:1.26-alpine AS builder
 
 RUN apk update && apk add --no-cache make bash nodejs npm
 
-ARG BIN_PATH
+# default value for BIN_PATH, can be overridden at build time
+ARG BIN_PATH=./cli
 
 WORKDIR /go/src/github.com/canopy-network/canopy
 COPY . /go/src/github.com/canopy-network/canopy
@@ -23,10 +24,10 @@ FROM alpine:3.19
 
 RUN apk add --no-cache pigz ca-certificates
 
-ARG BIN_PATH
+ARG BIN_PATH=./cli
 
 WORKDIR /app
 COPY --from=builder /go/src/github.com/canopy-network/canopy/bin ./
 COPY --from=builder /go/src/github.com/canopy-network/canopy/${BIN_PATH} ${BIN_PATH}
-RUN chmod +x ${BIN_PATH}
+RUN chmod +x "${BIN_PATH}"
 ENTRYPOINT ["/app/bin"]

--- a/cmd/auto-update/README.md
+++ b/cmd/auto-update/README.md
@@ -92,6 +92,18 @@ The auto-update mechanism can be enabled/disabled through the Canopy configurati
 
 - `BIN_PATH`: Specifies the path to the CLI binary (defaults to "./cli")
 
+### Binary persistence
+
+`BIN_PATH` is only ever read, never written to. It points at the binary shipped with the
+build, which in a container lives on the ephemeral filesystem and is discarded whenever
+the container is recreated.
+
+Updates are downloaded to `<data-dir>/canopy_updated` instead, since the data directory
+is the volume that persists across restarts. On every start, and on every restart after
+an update, the coordinator runs `<data-dir>/canopy_updated` when it exists and is
+executable, and falls back to `BIN_PATH` when it does not. Removing that file rolls the
+node back to the version shipped with the image.
+
 ## Dependencies
 
 - Go standard library

--- a/cmd/auto-update/README.md
+++ b/cmd/auto-update/README.md
@@ -104,6 +104,15 @@ an update, the coordinator runs `<data-dir>/canopy_updated` when it exists and i
 executable, and falls back to `BIN_PATH` when it does not. Removing that file rolls the
 node back to the version shipped with the image.
 
+### Plugin persistence
+
+For the same reason, plugin artifacts are stored under the data directory rather than in
+the image. The coordinator downloads (and `pluginctl.sh` extracts and runs) the plugin
+from `<data-dir>/plugin/<lang>`, which is exported to the launcher as `CANOPY_PLUGIN_HOME`.
+Only `pluginctl.sh` ships in the image; the downloaded binary/tarball live on the
+persistent volume, so a restart reuses the already-downloaded plugin instead of
+re-fetching it from GitHub. Removing that directory forces a fresh download on next start.
+
 ## Dependencies
 
 - Go standard library

--- a/cmd/auto-update/coordinator.go
+++ b/cmd/auto-update/coordinator.go
@@ -286,7 +286,7 @@ func (c *Coordinator) UpdateLoop(cancelSignal chan os.Signal) error {
 			return err
 		// periodic check for updates
 		case <-timer.C:
-			if !c.updater.Enabled {
+			if !c.config.Canopy.AutoUpdate {
 				continue
 			}
 			// wrap it on a goroutine so it doesn't block the main loop

--- a/cmd/auto-update/coordinator.go
+++ b/cmd/auto-update/coordinator.go
@@ -157,11 +157,12 @@ func (s *Supervisor) KillPlugin() {
 
 // CoordinatorConfig holds the configuration for the Coordinator
 type CoordinatorConfig struct {
-	Canopy       lib.Config    // Configuration for the canopy service
-	BinPath      string        // Path to the binary file
-	MaxDelayTime int           // Max time for delaying the update process (minutes)
-	CheckPeriod  time.Duration // Period for checking updates
-	GracePeriod  time.Duration // Grace period for tasks completion during shutdown
+	Canopy         lib.Config    // Configuration for the canopy service
+	BinPath        string        // Path to the binary file shipped with the build
+	UpdatedBinPath string        // Path to the downloaded binary on the data directory
+	MaxDelayTime   int           // Max time for delaying the update process (minutes)
+	CheckPeriod    time.Duration // Period for checking updates
+	GracePeriod    time.Duration // Grace period for tasks completion during shutdown
 }
 
 // Coordinator orchestrates the process of updating while managing CLI lifecycle
@@ -189,6 +190,11 @@ func NewCoordinator(config *CoordinatorConfig, updater, pluginUpdater *ReleaseMa
 		updateInProgress: atomic.Bool{},
 		log:              logger,
 	}
+}
+
+// binPath returns the preferred binary to run
+func (c *Coordinator) binPath() string {
+	return effectiveBinPath(c.config.UpdatedBinPath, c.config.BinPath)
 }
 
 // EnsurePluginReady checks if the plugin binary or tarball exists, and downloads if needed.
@@ -245,7 +251,7 @@ func (c *Coordinator) UpdateLoop(cancelSignal chan os.Signal) error {
 		// continue anyway - CLI might work without plugin or plugin might exist
 	}
 	// start the process
-	if err := c.supervisor.Start(c.config.BinPath); err != nil {
+	if err := c.supervisor.Start(c.binPath()); err != nil {
 		return err
 	}
 	// create a cancellable context
@@ -451,7 +457,7 @@ func (c *Coordinator) ApplyUpdate(ctx context.Context, release, pluginRelease *R
 	}
 
 	// restart the process (pluginctl.sh will extract the new tarball on start)
-	if err := c.supervisor.Start(c.config.BinPath); err != nil {
+	if err := c.supervisor.Start(c.binPath()); err != nil {
 		return fmt.Errorf("failed to start updated process: %w", err)
 	}
 

--- a/cmd/auto-update/main.go
+++ b/cmd/auto-update/main.go
@@ -26,6 +26,7 @@ const (
 	defaultRepoName     = "canopy"
 	defaultRepoOwner    = "canopy-network"
 	defaultBinPath      = "./cli"
+	defaultNewBinName   = "canopy_updated" // name of the downloaded binary, kept on the data directory
 	defaultCheckPeriod  = time.Minute * 30 // default check period for updates
 	defaultGracePeriod  = time.Second * 2  // default grace period for graceful shutdown
 	defaultMaxDelayTime = 30               // default max delay time for staggered updates (minutes)
@@ -99,22 +100,24 @@ func main() {
 		return
 	}
 	autoUpdaterEnabled := configs.Coordinator.Canopy.AutoUpdate
-	binPath := configs.Coordinator.BinPath
+	// run a previously downloaded update if there is one, the shipped binary otherwise
+	binPath := effectiveBinPath(configs.Coordinator.UpdatedBinPath, configs.Coordinator.BinPath)
 	// ensure the binary exists before proceeding
-	if !isExecutable(binPath) {
+	if binPath == "" {
 		logger.Fatalf("canopy binary not found or not executable: %s", binPath)
 	}
+	binaryVersion := getSoftwareVersion(autoUpdaterEnabled, binPath)
 	if autoUpdaterEnabled {
-		logger.Infof("auto-update enabled, starting coordinator on version %s", rpc.SoftwareVersion)
+		logger.Infof("auto-update enabled (updater version: %s, canopy version: %s)",
+			rpc.SoftwareVersion, binaryVersion)
 	} else {
-		logger.Infof("auto-update disabled, starting binary: %s", binPath)
+		logger.Infof("auto-update disabled (canopy version: %s)", binPath)
 	}
 	// handle external shutdown signals
 	sigChan := make(chan os.Signal, 1)
 	signal.Notify(sigChan, syscall.SIGINT, syscall.SIGTERM, syscall.SIGQUIT)
 	// setup the dependencies
-	updater := NewReleaseManager(configs.Updater,
-		getSoftwareVersion(autoUpdaterEnabled, binPath), autoUpdaterEnabled)
+	updater := NewReleaseManager(configs.Updater, binaryVersion, autoUpdaterEnabled)
 	snapshot := NewSnapshotManager(configs.Snapshot)
 	// setup plugin updater and config if configured
 	var pluginUpdater *ReleaseManager
@@ -163,7 +166,13 @@ func getConfigs() (*Configs, lib.LoggerI) {
 		JSON:       canopyConfig.JSON,
 	}, canopyConfig.DataDirPath)
 
+	// resolve to an absolute path so of the binary
 	binPath := envOrDefault("BIN_PATH", defaultBinPath)
+	if abs, err := filepath.Abs(binPath); err == nil {
+		binPath = abs
+	}
+	// updates are downloaded on the data directory
+	updatedBinPath := filepath.Join(canopyConfig.DataDirPath, defaultNewBinName)
 	githubToken := envOrDefault("CANOPY_GITHUB_API_TOKEN", "")
 
 	// core auto-update repo: config.json or defaults
@@ -181,7 +190,7 @@ func getConfigs() (*Configs, lib.LoggerI) {
 		RepoName:       repoName,
 		RepoOwner:      repoOwner,
 		GithubApiToken: githubToken,
-		BinPath:        binPath,
+		BinPath:        updatedBinPath,
 		SnapshotKey:    snapshotMetadataKey,
 	}
 	snapshot := &SnapshotConfig{
@@ -189,11 +198,12 @@ func getConfigs() (*Configs, lib.LoggerI) {
 		Name: snapshotFileName,
 	}
 	coordinator := &CoordinatorConfig{
-		Canopy:       canopyConfig,
-		BinPath:      binPath,
-		MaxDelayTime: envOrDefaultInt("AUTO_UPDATE_MAX_DELAY_MINUTES", defaultMaxDelayTime),
-		CheckPeriod:  envOrDefaultDuration("AUTO_UPDATE_CHECK_PERIOD", defaultCheckPeriod),
-		GracePeriod:  defaultGracePeriod,
+		Canopy:         canopyConfig,
+		BinPath:        binPath,
+		UpdatedBinPath: updatedBinPath,
+		MaxDelayTime:   envOrDefaultInt("AUTO_UPDATE_MAX_DELAY_MINUTES", defaultMaxDelayTime),
+		CheckPeriod:    envOrDefaultDuration("AUTO_UPDATE_CHECK_PERIOD", defaultCheckPeriod),
+		GracePeriod:    defaultGracePeriod,
 	}
 
 	// setup plugin updater config if plugin auto-update is enabled
@@ -252,6 +262,16 @@ func isExecutable(path string) bool {
 	}
 	// check for any execute bit (owner, group, or other)
 	return info.Mode()&0111 != 0
+}
+
+// effectiveBinPath returns the first valid binary to run, or an empty string if neither is valid
+func effectiveBinPath(paths ...string) string {
+	for _, path := range paths {
+		if isExecutable(path) {
+			return path
+		}
+	}
+	return ""
 }
 
 func getSoftwareVersion(autoUpdate bool, binPath string) string {

--- a/cmd/auto-update/main.go
+++ b/cmd/auto-update/main.go
@@ -227,7 +227,7 @@ func getConfigs() (*Configs, lib.LoggerI) {
 				Type:           ReleaseTypePlugin,
 				RepoOwner:      repoOwner,
 				RepoName:       repoName,
-				PluginDir:      filepath.Join(canopyConfig.DataDirPath, "plugin", canopyConfig.Plugin),
+				PluginDir:      canopyConfig.PluginHome(canopyConfig.Plugin),
 				PluginConfig:   pluginReleaseCfg,
 				GithubApiToken: githubToken,
 			}

--- a/cmd/auto-update/main.go
+++ b/cmd/auto-update/main.go
@@ -165,7 +165,7 @@ func getConfigs() (*Configs, lib.LoggerI) {
 		Structured: canopyConfig.Structured,
 		JSON:       canopyConfig.JSON,
 	}, canopyConfig.DataDirPath)
-	// resolve to an absolute path so of the binary
+	// resolve to an absolute path of the binary
 	binPath := envOrDefault("BIN_PATH", defaultBinPath)
 	if abs, err := filepath.Abs(binPath); err == nil {
 		binPath = abs

--- a/cmd/auto-update/main.go
+++ b/cmd/auto-update/main.go
@@ -111,19 +111,19 @@ func main() {
 		logger.Infof("auto-update enabled (updater version: %s, canopy version: %s)",
 			rpc.SoftwareVersion, binaryVersion)
 	} else {
-		logger.Infof("auto-update disabled (canopy version: %s)", binPath)
+		logger.Infof("auto-update disabled (canopy version: %s)", rpc.SoftwareVersion)
 	}
 	// handle external shutdown signals
 	sigChan := make(chan os.Signal, 1)
 	signal.Notify(sigChan, syscall.SIGINT, syscall.SIGTERM, syscall.SIGQUIT)
 	// setup the dependencies
-	updater := NewReleaseManager(configs.Updater, binaryVersion, autoUpdaterEnabled)
+	updater := NewReleaseManager(configs.Updater, binaryVersion)
 	snapshot := NewSnapshotManager(configs.Snapshot)
 	// setup plugin updater and config if configured
 	var pluginUpdater *ReleaseManager
 	var pluginConfig *PluginReleaseConfig
 	if configs.PluginUpdater != nil {
-		pluginUpdater = NewReleaseManager(configs.PluginUpdater, "v0.0.0", true)
+		pluginUpdater = NewReleaseManager(configs.PluginUpdater, "v0.0.0")
 		pluginConfig = configs.PluginUpdater.PluginConfig
 		logger.Infof("plugin auto-update enabled from %s/%s",
 			configs.PluginUpdater.RepoOwner,
@@ -165,7 +165,6 @@ func getConfigs() (*Configs, lib.LoggerI) {
 		Structured: canopyConfig.Structured,
 		JSON:       canopyConfig.JSON,
 	}, canopyConfig.DataDirPath)
-
 	// resolve to an absolute path so of the binary
 	binPath := envOrDefault("BIN_PATH", defaultBinPath)
 	if abs, err := filepath.Abs(binPath); err == nil {
@@ -278,9 +277,7 @@ func getSoftwareVersion(autoUpdate bool, binPath string) string {
 	if !autoUpdate {
 		return rpc.SoftwareVersion
 	}
-	// forward the global flags so 'version' targets the same data directory
-	versionArgs := append([]string{"version"}, cli.GlobalFlagArgs()...)
-	out, err := exec.Command(binPath, versionArgs...).Output()
+	out, err := exec.Command(binPath, "version").Output()
 	if err != nil {
 		panic(fmt.Sprintf("failed to get software version from binary: %v", err))
 	}

--- a/cmd/auto-update/main.go
+++ b/cmd/auto-update/main.go
@@ -227,7 +227,7 @@ func getConfigs() (*Configs, lib.LoggerI) {
 				Type:           ReleaseTypePlugin,
 				RepoOwner:      repoOwner,
 				RepoName:       repoName,
-				PluginDir:      fmt.Sprintf("plugin/%s", canopyConfig.Plugin),
+				PluginDir:      filepath.Join(canopyConfig.DataDirPath, "plugin", canopyConfig.Plugin),
 				PluginConfig:   pluginReleaseCfg,
 				GithubApiToken: githubToken,
 			}

--- a/cmd/auto-update/releaser.go
+++ b/cmd/auto-update/releaser.go
@@ -79,16 +79,14 @@ type ReleaseManager struct {
 	config     *ReleaseManagerConfig
 	httpClient *http.Client
 	Version    string // current version
-	Enabled    bool   // whether this updater should actively check for updates
 }
 
 // NewReleaseManager creates a new ReleaseManager instance
-func NewReleaseManager(config *ReleaseManagerConfig, version string, enabled bool) *ReleaseManager {
+func NewReleaseManager(config *ReleaseManagerConfig, version string) *ReleaseManager {
 	return &ReleaseManager{
 		config:     config,
 		httpClient: &http.Client{Timeout: httpReleaseClientTimeout},
 		Version:    version,
-		Enabled:    enabled,
 	}
 }
 

--- a/cmd/auto-update/releaser_stream_test.go
+++ b/cmd/auto-update/releaser_stream_test.go
@@ -54,7 +54,7 @@ func TestGetLatestPluginReleaseFiltersByPluginAssetStream(t *testing.T) {
 			AssetName:    "go-plugin-%s-%s.tar.gz",
 			ArchSpecific: true,
 		},
-	}, "v0.0.0", true)
+	}, "v0.0.0")
 
 	release, err := rm.GetLatestRelease()
 	require.NoError(t, err)
@@ -93,7 +93,7 @@ func TestGetLatestCLIReleaseIgnoresPluginOnlyReleases(t *testing.T) {
 		Type:      ReleaseTypeCLI,
 		RepoOwner: "canopy-network",
 		RepoName:  "canopy",
-	}, "v0.1.17", true)
+	}, "v0.1.17")
 
 	release, err := rm.GetLatestRelease()
 	require.NoError(t, err)

--- a/cmd/auto-update/releaser_test.go
+++ b/cmd/auto-update/releaser_test.go
@@ -60,7 +60,7 @@ func TestGetLatestPluginReleaseFiltersByPluginStream(t *testing.T) {
 			AssetName:    "go-plugin-%s-%s.tar.gz",
 			ArchSpecific: true,
 		},
-	}, "v0.0.0", true)
+	}, "v0.0.0")
 
 	release, err := rm.GetLatestRelease()
 	require.NoError(t, err)
@@ -72,7 +72,7 @@ func TestShouldUpdateAcceptsPluginPrefixedSemver(t *testing.T) {
 	rm := NewReleaseManager(&ReleaseManagerConfig{
 		Type:      ReleaseTypePlugin,
 		PluginDir: "plugin/go",
-	}, "v2026.78.100", true)
+	}, "v2026.78.100")
 
 	release := &Release{Version: "plugin-go-v2026.79.200"}
 	err := rm.ShouldUpdate(release)

--- a/cmd/rpc/server.go
+++ b/cmd/rpc/server.go
@@ -33,7 +33,7 @@ const (
 
 	// uses golang's semver naming convention
 	// https://pkg.go.dev/golang.org/x/mod/semver
-	SoftwareVersion = "v0.1.21+beta"
+	SoftwareVersion = "v0.1.20+beta"
 	ContentType     = "Content-MessageType"
 	ApplicationJSON = "application/json; charset=utf-8"
 

--- a/cmd/rpc/server.go
+++ b/cmd/rpc/server.go
@@ -33,7 +33,7 @@ const (
 
 	// uses golang's semver naming convention
 	// https://pkg.go.dev/golang.org/x/mod/semver
-	SoftwareVersion = "v0.1.20+beta"
+	SoftwareVersion = "v0.1.21+beta"
 	ContentType     = "Content-MessageType"
 	ApplicationJSON = "application/json; charset=utf-8"
 

--- a/controller/controller.go
+++ b/controller/controller.go
@@ -279,9 +279,8 @@ func (c *Controller) runPluginCtl(plugin, action string) ([]byte, lib.ErrorI) {
 	// create the command using the requested action
 	cmd := exec.Command(cmdPath, action)
 	// point the launcher at the persistent plugin home under the data dir so
-	// artifacts survive restarts (must match the coordinator's PluginDir)
-	pluginHome := filepath.Join(c.Config.DataDirPath, "plugin", plugin)
-	cmd.Env = append(os.Environ(), "CANOPY_PLUGIN_HOME="+pluginHome)
+	// downloaded artifacts survive restarts
+	cmd.Env = append(os.Environ(), "CANOPY_PLUGIN_HOME="+c.Config.PluginHome(plugin))
 	// execute the command and capture output
 	output, err := cmd.CombinedOutput()
 	if err != nil {

--- a/controller/controller.go
+++ b/controller/controller.go
@@ -278,6 +278,10 @@ func (c *Controller) runPluginCtl(plugin, action string) ([]byte, lib.ErrorI) {
 	}
 	// create the command using the requested action
 	cmd := exec.Command(cmdPath, action)
+	// point the launcher at the persistent plugin home under the data dir so
+	// artifacts survive restarts (must match the coordinator's PluginDir)
+	pluginHome := filepath.Join(c.Config.DataDirPath, "plugin", plugin)
+	cmd.Env = append(os.Environ(), "CANOPY_PLUGIN_HOME="+pluginHome)
 	// execute the command and capture output
 	output, err := cmd.CombinedOutput()
 	if err != nil {

--- a/lib/config.go
+++ b/lib/config.go
@@ -58,6 +58,12 @@ func DefaultConfig() Config {
 	}
 }
 
+// PluginHome() returns the persistent plugin directory under the data dir; the
+// single source of truth shared by the node launcher and the auto-updater
+func (c Config) PluginHome(plugin string) string {
+	return filepath.Join(c.DataDirPath, "plugin", plugin)
+}
+
 // MAIN CONFIG BELOW
 
 type MainConfig struct {

--- a/plugin/csharp/pluginctl.sh
+++ b/plugin/csharp/pluginctl.sh
@@ -3,19 +3,10 @@
 # Usage: ./pluginctl.sh {start|stop|status|restart}
 # Configuration variables for paths and files
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-# Downloaded plugin updates (binary + tarball) are persisted under the canopy
-# data directory so they survive restarts. CANOPY_PLUGIN_HOME is exported by
-# canopy; fall back to the default data dir location when running standalone.
+# Persistent plugin home under the data dir (set by canopy, else default location).
 PLUGIN_HOME="${CANOPY_PLUGIN_HOME:-${CANOPY_DATA_DIR:-$HOME/.canopy}/plugin/$(basename "$SCRIPT_DIR")}"
 mkdir -p "$PLUGIN_HOME"
-# Resolve where the artifact lives: prefer the data dir (a downloaded/extracted
-# update, or a tarball to extract), else the binary baked next to this script in
-# the image (plain plugin images ship it there; auto-update images download it).
-# This mirrors the CLI's "prefer updated, else shipped" resolution. The baked
-# binary is never copied into the data dir: the auto-updater treats a present
-# data-dir artifact as "already downloaded", so seeding it there would suppress
-# future updates (stale-version bug).
-# Self-contained executable (not DLL)
+# Prefer a downloaded update in the data dir, else the binary baked in the image.
 if [ -f "$PLUGIN_HOME/bin/CanopyPlugin" ] || ls "$PLUGIN_HOME"/csharp-plugin-linux-*.tar.gz >/dev/null 2>&1; then
     RUN_HOME="$PLUGIN_HOME"
 elif [ -f "$SCRIPT_DIR/bin/CanopyPlugin" ]; then

--- a/plugin/csharp/pluginctl.sh
+++ b/plugin/csharp/pluginctl.sh
@@ -3,13 +3,27 @@
 # Usage: ./pluginctl.sh {start|stop|status|restart}
 # Configuration variables for paths and files
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-# Plugin artifacts (binary + tarball) live under the canopy data directory so
-# they persist across restarts. CANOPY_PLUGIN_HOME is exported by canopy; fall
-# back to the default data dir location when running this script standalone.
+# Downloaded plugin updates (binary + tarball) are persisted under the canopy
+# data directory so they survive restarts. CANOPY_PLUGIN_HOME is exported by
+# canopy; fall back to the default data dir location when running standalone.
 PLUGIN_HOME="${CANOPY_PLUGIN_HOME:-${CANOPY_DATA_DIR:-$HOME/.canopy}/plugin/$(basename "$SCRIPT_DIR")}"
 mkdir -p "$PLUGIN_HOME"
+# Resolve where the artifact lives: prefer the data dir (a downloaded/extracted
+# update, or a tarball to extract), else the binary baked next to this script in
+# the image (plain plugin images ship it there; auto-update images download it).
+# This mirrors the CLI's "prefer updated, else shipped" resolution. The baked
+# binary is never copied into the data dir: the auto-updater treats a present
+# data-dir artifact as "already downloaded", so seeding it there would suppress
+# future updates (stale-version bug).
 # Self-contained executable (not DLL)
-BINARY_PATH="$PLUGIN_HOME/bin/CanopyPlugin"
+if [ -f "$PLUGIN_HOME/bin/CanopyPlugin" ] || ls "$PLUGIN_HOME"/csharp-plugin-linux-*.tar.gz >/dev/null 2>&1; then
+    RUN_HOME="$PLUGIN_HOME"
+elif [ -f "$SCRIPT_DIR/bin/CanopyPlugin" ]; then
+    RUN_HOME="$SCRIPT_DIR"
+else
+    RUN_HOME="$PLUGIN_HOME"
+fi
+BINARY_PATH="$RUN_HOME/bin/CanopyPlugin"
 PID_FILE="/tmp/plugin/csharp-plugin.pid"
 LOG_FILE="/tmp/plugin/csharp-plugin.log"
 PLUGIN_DIR="/tmp/plugin"
@@ -51,20 +65,20 @@ extract_if_needed() {
     
     # Try musl tarball first on Alpine, then glibc
     if is_musl; then
-        tarball="$PLUGIN_HOME/csharp-plugin-linux-musl-${arch}.tar.gz"
+        tarball="$RUN_HOME/csharp-plugin-linux-musl-${arch}.tar.gz"
     fi
     
     # Fall back to glibc tarball if musl not found or not on Alpine
     if [ -z "$tarball" ] || [ ! -f "$tarball" ]; then
-        tarball="$PLUGIN_HOME/csharp-plugin-linux-${arch}.tar.gz"
+        tarball="$RUN_HOME/csharp-plugin-linux-${arch}.tar.gz"
     fi
     
     if [ -f "$tarball" ]; then
         echo "Extracting $tarball..."
         # Clear old bin directory to avoid leftover files from previous builds
-        rm -rf "$PLUGIN_HOME/bin"
-        mkdir -p "$PLUGIN_HOME/bin"
-        tar -xzf "$tarball" -C "$PLUGIN_HOME/bin"
+        rm -rf "$RUN_HOME/bin"
+        mkdir -p "$RUN_HOME/bin"
+        tar -xzf "$tarball" -C "$RUN_HOME/bin"
         if [ $? -eq 0 ] && [ -f "$BINARY_PATH" ]; then
             echo "Extraction complete"
             return 0

--- a/plugin/csharp/pluginctl.sh
+++ b/plugin/csharp/pluginctl.sh
@@ -3,8 +3,13 @@
 # Usage: ./pluginctl.sh {start|stop|status|restart}
 # Configuration variables for paths and files
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# Plugin artifacts (binary + tarball) live under the canopy data directory so
+# they persist across restarts. CANOPY_PLUGIN_HOME is exported by canopy; fall
+# back to the default data dir location when running this script standalone.
+PLUGIN_HOME="${CANOPY_PLUGIN_HOME:-${CANOPY_DATA_DIR:-$HOME/.canopy}/plugin/$(basename "$SCRIPT_DIR")}"
+mkdir -p "$PLUGIN_HOME"
 # Self-contained executable (not DLL)
-BINARY_PATH="$SCRIPT_DIR/bin/CanopyPlugin"
+BINARY_PATH="$PLUGIN_HOME/bin/CanopyPlugin"
 PID_FILE="/tmp/plugin/csharp-plugin.pid"
 LOG_FILE="/tmp/plugin/csharp-plugin.log"
 PLUGIN_DIR="/tmp/plugin"
@@ -46,20 +51,20 @@ extract_if_needed() {
     
     # Try musl tarball first on Alpine, then glibc
     if is_musl; then
-        tarball="$SCRIPT_DIR/csharp-plugin-linux-musl-${arch}.tar.gz"
+        tarball="$PLUGIN_HOME/csharp-plugin-linux-musl-${arch}.tar.gz"
     fi
     
     # Fall back to glibc tarball if musl not found or not on Alpine
     if [ -z "$tarball" ] || [ ! -f "$tarball" ]; then
-        tarball="$SCRIPT_DIR/csharp-plugin-linux-${arch}.tar.gz"
+        tarball="$PLUGIN_HOME/csharp-plugin-linux-${arch}.tar.gz"
     fi
     
     if [ -f "$tarball" ]; then
         echo "Extracting $tarball..."
         # Clear old bin directory to avoid leftover files from previous builds
-        rm -rf "$SCRIPT_DIR/bin"
-        mkdir -p "$SCRIPT_DIR/bin"
-        tar -xzf "$tarball" -C "$SCRIPT_DIR/bin"
+        rm -rf "$PLUGIN_HOME/bin"
+        mkdir -p "$PLUGIN_HOME/bin"
+        tar -xzf "$tarball" -C "$PLUGIN_HOME/bin"
         if [ $? -eq 0 ] && [ -f "$BINARY_PATH" ]; then
             echo "Extraction complete"
             return 0

--- a/plugin/go/Dockerfile
+++ b/plugin/go/Dockerfile
@@ -18,7 +18,7 @@ RUN go build -o /plugin .
 # Stage 3: Runtime
 FROM alpine:latest
 WORKDIR /app
-RUN apk add --no-cache bash && mkdir -p /tmp/plugin /root/.canopy plugin/go
+RUN apk add --no-cache bash procps && mkdir -p /tmp/plugin /root/.canopy plugin/go
 
 COPY --from=canopy-builder /canopy .
 COPY --from=plugin-builder /plugin plugin/go/go-plugin

--- a/plugin/go/pluginctl.sh
+++ b/plugin/go/pluginctl.sh
@@ -3,7 +3,12 @@
 # Usage: ./pluginctl.sh {start|stop|status|restart}
 # Configuration variables for paths and files
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-BINARY_PATH="$SCRIPT_DIR/go-plugin"
+# Plugin artifacts (binary + tarball) live under the canopy data directory so
+# they persist across restarts. CANOPY_PLUGIN_HOME is exported by canopy; fall
+# back to the default data dir location when running this script standalone.
+PLUGIN_HOME="${CANOPY_PLUGIN_HOME:-${CANOPY_DATA_DIR:-$HOME/.canopy}/plugin/$(basename "$SCRIPT_DIR")}"
+mkdir -p "$PLUGIN_HOME"
+BINARY_PATH="$PLUGIN_HOME/go-plugin"
 PID_FILE="/tmp/plugin/go-plugin.pid"
 LOG_FILE="/tmp/plugin/go-plugin.log"
 PLUGIN_DIR="/tmp/plugin"
@@ -35,11 +40,11 @@ extract_if_needed() {
     
     # Check for architecture-specific tarball
     local arch=$(get_arch)
-    local tarball="$SCRIPT_DIR/go-plugin-linux-${arch}.tar.gz"
+    local tarball="$PLUGIN_HOME/go-plugin-linux-${arch}.tar.gz"
     
     if [ -f "$tarball" ]; then
         echo "Extracting $tarball..."
-        tar -xzf "$tarball" -C "$SCRIPT_DIR"
+        tar -xzf "$tarball" -C "$PLUGIN_HOME"
         if [ $? -eq 0 ] && [ -f "$BINARY_PATH" ]; then
             chmod +x "$BINARY_PATH"
             echo "Extraction complete"

--- a/plugin/go/pluginctl.sh
+++ b/plugin/go/pluginctl.sh
@@ -3,18 +3,10 @@
 # Usage: ./pluginctl.sh {start|stop|status|restart}
 # Configuration variables for paths and files
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-# Downloaded plugin updates are persisted under the canopy data directory so
-# they survive restarts. CANOPY_PLUGIN_HOME is exported by canopy; fall back to
-# the default data dir location when running this script standalone.
+# Persistent plugin home under the data dir (set by canopy, else default location).
 PLUGIN_HOME="${CANOPY_PLUGIN_HOME:-${CANOPY_DATA_DIR:-$HOME/.canopy}/plugin/$(basename "$SCRIPT_DIR")}"
 mkdir -p "$PLUGIN_HOME"
-# Resolve where the artifact lives: prefer the data dir (a downloaded/extracted
-# update, or a tarball to extract), else the artifact baked next to this script
-# in the image (plain plugin images ship it there; auto-update images download
-# it). This mirrors the CLI's "prefer updated, else shipped" resolution. The
-# baked artifact is never copied into the data dir: the auto-updater treats a
-# present data-dir artifact as "already downloaded", so seeding it there would
-# suppress future updates (stale-version bug).
+# Prefer a downloaded update in the data dir, else the artifact baked in the image.
 if [ -x "$PLUGIN_HOME/go-plugin" ] || ls "$PLUGIN_HOME"/go-plugin-linux-*.tar.gz >/dev/null 2>&1; then
     RUN_HOME="$PLUGIN_HOME"
 elif [ -x "$SCRIPT_DIR/go-plugin" ]; then

--- a/plugin/go/pluginctl.sh
+++ b/plugin/go/pluginctl.sh
@@ -3,12 +3,26 @@
 # Usage: ./pluginctl.sh {start|stop|status|restart}
 # Configuration variables for paths and files
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-# Plugin artifacts (binary + tarball) live under the canopy data directory so
-# they persist across restarts. CANOPY_PLUGIN_HOME is exported by canopy; fall
-# back to the default data dir location when running this script standalone.
+# Downloaded plugin updates are persisted under the canopy data directory so
+# they survive restarts. CANOPY_PLUGIN_HOME is exported by canopy; fall back to
+# the default data dir location when running this script standalone.
 PLUGIN_HOME="${CANOPY_PLUGIN_HOME:-${CANOPY_DATA_DIR:-$HOME/.canopy}/plugin/$(basename "$SCRIPT_DIR")}"
 mkdir -p "$PLUGIN_HOME"
-BINARY_PATH="$PLUGIN_HOME/go-plugin"
+# Resolve where the artifact lives: prefer the data dir (a downloaded/extracted
+# update, or a tarball to extract), else the artifact baked next to this script
+# in the image (plain plugin images ship it there; auto-update images download
+# it). This mirrors the CLI's "prefer updated, else shipped" resolution. The
+# baked artifact is never copied into the data dir: the auto-updater treats a
+# present data-dir artifact as "already downloaded", so seeding it there would
+# suppress future updates (stale-version bug).
+if [ -x "$PLUGIN_HOME/go-plugin" ] || ls "$PLUGIN_HOME"/go-plugin-linux-*.tar.gz >/dev/null 2>&1; then
+    RUN_HOME="$PLUGIN_HOME"
+elif [ -x "$SCRIPT_DIR/go-plugin" ]; then
+    RUN_HOME="$SCRIPT_DIR"
+else
+    RUN_HOME="$PLUGIN_HOME"
+fi
+BINARY_PATH="$RUN_HOME/go-plugin"
 PID_FILE="/tmp/plugin/go-plugin.pid"
 LOG_FILE="/tmp/plugin/go-plugin.log"
 PLUGIN_DIR="/tmp/plugin"
@@ -40,11 +54,11 @@ extract_if_needed() {
     
     # Check for architecture-specific tarball
     local arch=$(get_arch)
-    local tarball="$PLUGIN_HOME/go-plugin-linux-${arch}.tar.gz"
+    local tarball="$RUN_HOME/go-plugin-linux-${arch}.tar.gz"
     
     if [ -f "$tarball" ]; then
         echo "Extracting $tarball..."
-        tar -xzf "$tarball" -C "$PLUGIN_HOME"
+        tar -xzf "$tarball" -C "$RUN_HOME"
         if [ $? -eq 0 ] && [ -f "$BINARY_PATH" ]; then
             chmod +x "$BINARY_PATH"
             echo "Extraction complete"

--- a/plugin/kotlin/Dockerfile
+++ b/plugin/kotlin/Dockerfile
@@ -18,7 +18,7 @@ RUN ./gradlew fatJar --no-daemon
 # Stage 3: Runtime
 FROM eclipse-temurin:21-jre-alpine
 WORKDIR /app
-RUN apk add --no-cache bash && mkdir -p /tmp/plugin /root/.canopy plugin/kotlin/build/libs
+RUN apk add --no-cache bash procps && mkdir -p /tmp/plugin /root/.canopy plugin/kotlin/build/libs
 
 COPY --from=canopy-builder /canopy .
 COPY --from=kotlin-builder /app/build/libs/*-all.jar plugin/kotlin/build/libs/canopy-plugin-kotlin-1.0.0-all.jar

--- a/plugin/kotlin/pluginctl.sh
+++ b/plugin/kotlin/pluginctl.sh
@@ -3,18 +3,10 @@
 # Usage: ./pluginctl.sh {start|stop|status|restart}
 # Configuration variables for paths and files
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-# Downloaded plugin updates (jar + tarball) are persisted under the canopy data
-# directory so they survive restarts. CANOPY_PLUGIN_HOME is exported by canopy;
-# fall back to the default data dir location when running this script standalone.
+# Persistent plugin home under the data dir (set by canopy, else default location).
 PLUGIN_HOME="${CANOPY_PLUGIN_HOME:-${CANOPY_DATA_DIR:-$HOME/.canopy}/plugin/$(basename "$SCRIPT_DIR")}"
 mkdir -p "$PLUGIN_HOME"
-# Resolve where the artifact lives: prefer the data dir (a downloaded/extracted
-# update, or a tarball to extract), else the jar baked next to this script in
-# the image (plain plugin images ship it there; auto-update images download it).
-# This mirrors the CLI's "prefer updated, else shipped" resolution. The baked
-# jar is never copied into the data dir: the auto-updater treats a present
-# data-dir artifact as "already downloaded", so seeding it there would suppress
-# future updates (stale-version bug).
+# Prefer a downloaded update in the data dir, else the jar baked in the image.
 if [ -f "$PLUGIN_HOME/build/libs/canopy-plugin-kotlin-1.0.0-all.jar" ] || [ -f "$PLUGIN_HOME/kotlin-plugin.tar.gz" ]; then
     RUN_HOME="$PLUGIN_HOME"
 elif [ -f "$SCRIPT_DIR/build/libs/canopy-plugin-kotlin-1.0.0-all.jar" ]; then

--- a/plugin/kotlin/pluginctl.sh
+++ b/plugin/kotlin/pluginctl.sh
@@ -3,8 +3,13 @@
 # Usage: ./pluginctl.sh {start|stop|status|restart}
 # Configuration variables for paths and files
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-JAR_PATH="$SCRIPT_DIR/build/libs/canopy-plugin-kotlin-1.0.0-all.jar"
-TARBALL="$SCRIPT_DIR/kotlin-plugin.tar.gz"
+# Plugin artifacts (jar + tarball) live under the canopy data directory so they
+# persist across restarts. CANOPY_PLUGIN_HOME is exported by canopy; fall back
+# to the default data dir location when running this script standalone.
+PLUGIN_HOME="${CANOPY_PLUGIN_HOME:-${CANOPY_DATA_DIR:-$HOME/.canopy}/plugin/$(basename "$SCRIPT_DIR")}"
+mkdir -p "$PLUGIN_HOME"
+JAR_PATH="$PLUGIN_HOME/build/libs/canopy-plugin-kotlin-1.0.0-all.jar"
+TARBALL="$PLUGIN_HOME/kotlin-plugin.tar.gz"
 PID_FILE="/tmp/plugin/kotlin-plugin.pid"
 LOG_FILE="/tmp/plugin/kotlin-plugin.log"
 PLUGIN_DIR="/tmp/plugin"
@@ -21,11 +26,11 @@ extract_if_needed() {
     # Check for tarball
     if [ -f "$TARBALL" ]; then
         echo "Extracting $TARBALL..."
-        mkdir -p "$SCRIPT_DIR/build/libs"
-        tar -xzf "$TARBALL" -C "$SCRIPT_DIR/build/libs"
+        mkdir -p "$PLUGIN_HOME/build/libs"
+        tar -xzf "$TARBALL" -C "$PLUGIN_HOME/build/libs"
         # Rename if needed (tarball contains kotlin-plugin.jar)
-        if [ -f "$SCRIPT_DIR/build/libs/kotlin-plugin.jar" ] && [ ! -f "$JAR_PATH" ]; then
-            mv "$SCRIPT_DIR/build/libs/kotlin-plugin.jar" "$JAR_PATH"
+        if [ -f "$PLUGIN_HOME/build/libs/kotlin-plugin.jar" ] && [ ! -f "$JAR_PATH" ]; then
+            mv "$PLUGIN_HOME/build/libs/kotlin-plugin.jar" "$JAR_PATH"
         fi
         if [ $? -eq 0 ] && [ -f "$JAR_PATH" ]; then
             echo "Extraction complete"

--- a/plugin/kotlin/pluginctl.sh
+++ b/plugin/kotlin/pluginctl.sh
@@ -3,13 +3,27 @@
 # Usage: ./pluginctl.sh {start|stop|status|restart}
 # Configuration variables for paths and files
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-# Plugin artifacts (jar + tarball) live under the canopy data directory so they
-# persist across restarts. CANOPY_PLUGIN_HOME is exported by canopy; fall back
-# to the default data dir location when running this script standalone.
+# Downloaded plugin updates (jar + tarball) are persisted under the canopy data
+# directory so they survive restarts. CANOPY_PLUGIN_HOME is exported by canopy;
+# fall back to the default data dir location when running this script standalone.
 PLUGIN_HOME="${CANOPY_PLUGIN_HOME:-${CANOPY_DATA_DIR:-$HOME/.canopy}/plugin/$(basename "$SCRIPT_DIR")}"
 mkdir -p "$PLUGIN_HOME"
-JAR_PATH="$PLUGIN_HOME/build/libs/canopy-plugin-kotlin-1.0.0-all.jar"
-TARBALL="$PLUGIN_HOME/kotlin-plugin.tar.gz"
+# Resolve where the artifact lives: prefer the data dir (a downloaded/extracted
+# update, or a tarball to extract), else the jar baked next to this script in
+# the image (plain plugin images ship it there; auto-update images download it).
+# This mirrors the CLI's "prefer updated, else shipped" resolution. The baked
+# jar is never copied into the data dir: the auto-updater treats a present
+# data-dir artifact as "already downloaded", so seeding it there would suppress
+# future updates (stale-version bug).
+if [ -f "$PLUGIN_HOME/build/libs/canopy-plugin-kotlin-1.0.0-all.jar" ] || [ -f "$PLUGIN_HOME/kotlin-plugin.tar.gz" ]; then
+    RUN_HOME="$PLUGIN_HOME"
+elif [ -f "$SCRIPT_DIR/build/libs/canopy-plugin-kotlin-1.0.0-all.jar" ]; then
+    RUN_HOME="$SCRIPT_DIR"
+else
+    RUN_HOME="$PLUGIN_HOME"
+fi
+JAR_PATH="$RUN_HOME/build/libs/canopy-plugin-kotlin-1.0.0-all.jar"
+TARBALL="$RUN_HOME/kotlin-plugin.tar.gz"
 PID_FILE="/tmp/plugin/kotlin-plugin.pid"
 LOG_FILE="/tmp/plugin/kotlin-plugin.log"
 PLUGIN_DIR="/tmp/plugin"
@@ -26,11 +40,11 @@ extract_if_needed() {
     # Check for tarball
     if [ -f "$TARBALL" ]; then
         echo "Extracting $TARBALL..."
-        mkdir -p "$PLUGIN_HOME/build/libs"
-        tar -xzf "$TARBALL" -C "$PLUGIN_HOME/build/libs"
+        mkdir -p "$RUN_HOME/build/libs"
+        tar -xzf "$TARBALL" -C "$RUN_HOME/build/libs"
         # Rename if needed (tarball contains kotlin-plugin.jar)
-        if [ -f "$PLUGIN_HOME/build/libs/kotlin-plugin.jar" ] && [ ! -f "$JAR_PATH" ]; then
-            mv "$PLUGIN_HOME/build/libs/kotlin-plugin.jar" "$JAR_PATH"
+        if [ -f "$RUN_HOME/build/libs/kotlin-plugin.jar" ] && [ ! -f "$JAR_PATH" ]; then
+            mv "$RUN_HOME/build/libs/kotlin-plugin.jar" "$JAR_PATH"
         fi
         if [ $? -eq 0 ] && [ -f "$JAR_PATH" ]; then
             echo "Extraction complete"

--- a/plugin/python/Dockerfile
+++ b/plugin/python/Dockerfile
@@ -14,7 +14,7 @@ FROM python:3.12-alpine
 WORKDIR /app
 
 # Install bash (required for pluginctl.sh)
-RUN apk add --no-cache bash
+RUN apk add --no-cache bash procps
 
 RUN mkdir -p /tmp/plugin /root/.canopy
 

--- a/plugin/python/pluginctl.sh
+++ b/plugin/python/pluginctl.sh
@@ -3,13 +3,18 @@
 # Usage: ./pluginctl.sh {start|stop|status|restart}
 # Configuration variables for paths and files
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-PYTHON_SCRIPT="$SCRIPT_DIR/main.py"
-VENV_DIR="$SCRIPT_DIR/.venv"
+# Plugin source, venv and tarball live under the canopy data directory so they
+# persist across restarts. CANOPY_PLUGIN_HOME is exported by canopy; fall back
+# to the default data dir location when running this script standalone.
+PLUGIN_HOME="${CANOPY_PLUGIN_HOME:-${CANOPY_DATA_DIR:-$HOME/.canopy}/plugin/$(basename "$SCRIPT_DIR")}"
+mkdir -p "$PLUGIN_HOME"
+PYTHON_SCRIPT="$PLUGIN_HOME/main.py"
+VENV_DIR="$PLUGIN_HOME/.venv"
 PYTHON_CMD="$VENV_DIR/bin/python3"
 PID_FILE="/tmp/plugin/python-plugin.pid"
 LOG_FILE="/tmp/plugin/python-plugin.log"
 PLUGIN_DIR="/tmp/plugin"
-TARBALL="$SCRIPT_DIR/python-plugin.tar.gz"
+TARBALL="$PLUGIN_HOME/python-plugin.tar.gz"
 # Timeout in seconds for graceful shutdown
 STOP_TIMEOUT=10
 
@@ -24,7 +29,7 @@ extract_if_needed() {
     # Check for tarball
     if [ -f "$TARBALL" ]; then
         echo "Extracting $TARBALL..."
-        tar -xzf "$TARBALL" -C "$SCRIPT_DIR"
+        tar -xzf "$TARBALL" -C "$PLUGIN_HOME"
         if [ $? -eq 0 ] && [ -f "$PYTHON_SCRIPT" ]; then
             echo "Extraction complete"
             # Return 2 to indicate extraction happened and deps need reinstall
@@ -59,7 +64,7 @@ install_dependencies() {
     fi
     
     # Install the package in editable mode
-    "$VENV_DIR/bin/pip" install -e "$SCRIPT_DIR"
+    "$VENV_DIR/bin/pip" install -e "$PLUGIN_HOME"
     if [ $? -ne 0 ]; then
         echo "Warning: Editable install failed, trying direct dependency install..."
         # Fallback: install dependencies directly from pyproject.toml

--- a/plugin/python/pluginctl.sh
+++ b/plugin/python/pluginctl.sh
@@ -3,18 +3,10 @@
 # Usage: ./pluginctl.sh {start|stop|status|restart}
 # Configuration variables for paths and files
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-# Downloaded plugin updates (source, venv and tarball) are persisted under the
-# canopy data directory so they survive restarts. CANOPY_PLUGIN_HOME is exported
-# by canopy; fall back to the default data dir location when running standalone.
+# Persistent plugin home under the data dir (set by canopy, else default location).
 PLUGIN_HOME="${CANOPY_PLUGIN_HOME:-${CANOPY_DATA_DIR:-$HOME/.canopy}/plugin/$(basename "$SCRIPT_DIR")}"
 mkdir -p "$PLUGIN_HOME"
-# Resolve where the source lives: prefer the data dir (a downloaded/extracted
-# update, or a tarball to extract), else the source baked next to this script in
-# the image (plain plugin images ship it there; auto-update images download it).
-# This mirrors the CLI's "prefer updated, else shipped" resolution. The baked
-# source is never copied into the data dir: the auto-updater treats a present
-# data-dir artifact as "already downloaded", so seeding it there would suppress
-# future updates (stale-version bug).
+# Prefer a downloaded update in the data dir, else the source baked in the image.
 if [ -f "$PLUGIN_HOME/main.py" ] || [ -f "$PLUGIN_HOME/python-plugin.tar.gz" ]; then
     RUN_HOME="$PLUGIN_HOME"
 elif [ -f "$SCRIPT_DIR/main.py" ]; then

--- a/plugin/python/pluginctl.sh
+++ b/plugin/python/pluginctl.sh
@@ -3,18 +3,32 @@
 # Usage: ./pluginctl.sh {start|stop|status|restart}
 # Configuration variables for paths and files
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-# Plugin source, venv and tarball live under the canopy data directory so they
-# persist across restarts. CANOPY_PLUGIN_HOME is exported by canopy; fall back
-# to the default data dir location when running this script standalone.
+# Downloaded plugin updates (source, venv and tarball) are persisted under the
+# canopy data directory so they survive restarts. CANOPY_PLUGIN_HOME is exported
+# by canopy; fall back to the default data dir location when running standalone.
 PLUGIN_HOME="${CANOPY_PLUGIN_HOME:-${CANOPY_DATA_DIR:-$HOME/.canopy}/plugin/$(basename "$SCRIPT_DIR")}"
 mkdir -p "$PLUGIN_HOME"
-PYTHON_SCRIPT="$PLUGIN_HOME/main.py"
-VENV_DIR="$PLUGIN_HOME/.venv"
+# Resolve where the source lives: prefer the data dir (a downloaded/extracted
+# update, or a tarball to extract), else the source baked next to this script in
+# the image (plain plugin images ship it there; auto-update images download it).
+# This mirrors the CLI's "prefer updated, else shipped" resolution. The baked
+# source is never copied into the data dir: the auto-updater treats a present
+# data-dir artifact as "already downloaded", so seeding it there would suppress
+# future updates (stale-version bug).
+if [ -f "$PLUGIN_HOME/main.py" ] || [ -f "$PLUGIN_HOME/python-plugin.tar.gz" ]; then
+    RUN_HOME="$PLUGIN_HOME"
+elif [ -f "$SCRIPT_DIR/main.py" ]; then
+    RUN_HOME="$SCRIPT_DIR"
+else
+    RUN_HOME="$PLUGIN_HOME"
+fi
+PYTHON_SCRIPT="$RUN_HOME/main.py"
+VENV_DIR="$RUN_HOME/.venv"
 PYTHON_CMD="$VENV_DIR/bin/python3"
 PID_FILE="/tmp/plugin/python-plugin.pid"
 LOG_FILE="/tmp/plugin/python-plugin.log"
 PLUGIN_DIR="/tmp/plugin"
-TARBALL="$PLUGIN_HOME/python-plugin.tar.gz"
+TARBALL="$RUN_HOME/python-plugin.tar.gz"
 # Timeout in seconds for graceful shutdown
 STOP_TIMEOUT=10
 
@@ -29,7 +43,7 @@ extract_if_needed() {
     # Check for tarball
     if [ -f "$TARBALL" ]; then
         echo "Extracting $TARBALL..."
-        tar -xzf "$TARBALL" -C "$PLUGIN_HOME"
+        tar -xzf "$TARBALL" -C "$RUN_HOME"
         if [ $? -eq 0 ] && [ -f "$PYTHON_SCRIPT" ]; then
             echo "Extraction complete"
             # Return 2 to indicate extraction happened and deps need reinstall
@@ -64,7 +78,7 @@ install_dependencies() {
     fi
     
     # Install the package in editable mode
-    "$VENV_DIR/bin/pip" install -e "$PLUGIN_HOME"
+    "$VENV_DIR/bin/pip" install -e "$RUN_HOME"
     if [ $? -ne 0 ]; then
         echo "Warning: Editable install failed, trying direct dependency install..."
         # Fallback: install dependencies directly from pyproject.toml

--- a/plugin/typescript/Dockerfile
+++ b/plugin/typescript/Dockerfile
@@ -18,7 +18,7 @@ RUN npm ci && npm run build:all
 # Stage 3: Runtime
 FROM node:20-alpine
 WORKDIR /app
-RUN apk add --no-cache bash && mkdir -p /tmp/plugin /root/.canopy plugin/typescript
+RUN apk add --no-cache bash procps && mkdir -p /tmp/plugin /root/.canopy plugin/typescript
 
 COPY --from=canopy-builder /canopy .
 COPY --from=typescript-builder /app/dist plugin/typescript/dist/

--- a/plugin/typescript/pluginctl.sh
+++ b/plugin/typescript/pluginctl.sh
@@ -3,18 +3,10 @@
 # Usage: ./pluginctl.sh {start|stop|status|restart}
 # Configuration variables for paths and files
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-# Downloaded plugin updates (dist + node_modules and tarball) are persisted
-# under the canopy data directory so they survive restarts. CANOPY_PLUGIN_HOME
-# is exported by canopy; fall back to the default data dir location standalone.
+# Persistent plugin home under the data dir (set by canopy, else default location).
 PLUGIN_HOME="${CANOPY_PLUGIN_HOME:-${CANOPY_DATA_DIR:-$HOME/.canopy}/plugin/$(basename "$SCRIPT_DIR")}"
 mkdir -p "$PLUGIN_HOME"
-# Resolve where the code lives: prefer the data dir (a downloaded/extracted
-# update, or a tarball to extract), else the code baked next to this script in
-# the image (plain plugin images ship it there; auto-update images download it).
-# This mirrors the CLI's "prefer updated, else shipped" resolution. The baked
-# code is never copied into the data dir: the auto-updater treats a present
-# data-dir artifact as "already downloaded", so seeding it there would suppress
-# future updates (stale-version bug).
+# Prefer a downloaded update in the data dir, else the code baked in the image.
 if [ -f "$PLUGIN_HOME/dist/main.js" ] || [ -f "$PLUGIN_HOME/typescript-plugin.tar.gz" ]; then
     RUN_HOME="$PLUGIN_HOME"
 elif [ -f "$SCRIPT_DIR/dist/main.js" ]; then

--- a/plugin/typescript/pluginctl.sh
+++ b/plugin/typescript/pluginctl.sh
@@ -3,12 +3,17 @@
 # Usage: ./pluginctl.sh {start|stop|status|restart}
 # Configuration variables for paths and files
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-NODE_SCRIPT="$SCRIPT_DIR/dist/main.js"
+# Plugin code (dist + node_modules) and tarball live under the canopy data
+# directory so they persist across restarts. CANOPY_PLUGIN_HOME is exported by
+# canopy; fall back to the default data dir location when running standalone.
+PLUGIN_HOME="${CANOPY_PLUGIN_HOME:-${CANOPY_DATA_DIR:-$HOME/.canopy}/plugin/$(basename "$SCRIPT_DIR")}"
+mkdir -p "$PLUGIN_HOME"
+NODE_SCRIPT="$PLUGIN_HOME/dist/main.js"
 NODE_CMD="node"
 PID_FILE="/tmp/plugin/typescript-plugin.pid"
 LOG_FILE="/tmp/plugin/typescript-plugin.log"
 PLUGIN_DIR="/tmp/plugin"
-TARBALL="$SCRIPT_DIR/typescript-plugin.tar.gz"
+TARBALL="$PLUGIN_HOME/typescript-plugin.tar.gz"
 # Timeout in seconds for graceful shutdown
 STOP_TIMEOUT=10
 
@@ -22,7 +27,7 @@ extract_if_needed() {
     # Check for tarball
     if [ -f "$TARBALL" ]; then
         echo "Extracting $TARBALL..."
-        tar -xzf "$TARBALL" -C "$SCRIPT_DIR"
+        tar -xzf "$TARBALL" -C "$PLUGIN_HOME"
         if [ $? -eq 0 ] && [ -f "$NODE_SCRIPT" ]; then
             echo "Extraction complete"
             return 0

--- a/plugin/typescript/pluginctl.sh
+++ b/plugin/typescript/pluginctl.sh
@@ -3,17 +3,31 @@
 # Usage: ./pluginctl.sh {start|stop|status|restart}
 # Configuration variables for paths and files
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-# Plugin code (dist + node_modules) and tarball live under the canopy data
-# directory so they persist across restarts. CANOPY_PLUGIN_HOME is exported by
-# canopy; fall back to the default data dir location when running standalone.
+# Downloaded plugin updates (dist + node_modules and tarball) are persisted
+# under the canopy data directory so they survive restarts. CANOPY_PLUGIN_HOME
+# is exported by canopy; fall back to the default data dir location standalone.
 PLUGIN_HOME="${CANOPY_PLUGIN_HOME:-${CANOPY_DATA_DIR:-$HOME/.canopy}/plugin/$(basename "$SCRIPT_DIR")}"
 mkdir -p "$PLUGIN_HOME"
-NODE_SCRIPT="$PLUGIN_HOME/dist/main.js"
+# Resolve where the code lives: prefer the data dir (a downloaded/extracted
+# update, or a tarball to extract), else the code baked next to this script in
+# the image (plain plugin images ship it there; auto-update images download it).
+# This mirrors the CLI's "prefer updated, else shipped" resolution. The baked
+# code is never copied into the data dir: the auto-updater treats a present
+# data-dir artifact as "already downloaded", so seeding it there would suppress
+# future updates (stale-version bug).
+if [ -f "$PLUGIN_HOME/dist/main.js" ] || [ -f "$PLUGIN_HOME/typescript-plugin.tar.gz" ]; then
+    RUN_HOME="$PLUGIN_HOME"
+elif [ -f "$SCRIPT_DIR/dist/main.js" ]; then
+    RUN_HOME="$SCRIPT_DIR"
+else
+    RUN_HOME="$PLUGIN_HOME"
+fi
+NODE_SCRIPT="$RUN_HOME/dist/main.js"
 NODE_CMD="node"
 PID_FILE="/tmp/plugin/typescript-plugin.pid"
 LOG_FILE="/tmp/plugin/typescript-plugin.log"
 PLUGIN_DIR="/tmp/plugin"
-TARBALL="$PLUGIN_HOME/typescript-plugin.tar.gz"
+TARBALL="$RUN_HOME/typescript-plugin.tar.gz"
 # Timeout in seconds for graceful shutdown
 STOP_TIMEOUT=10
 
@@ -27,7 +41,7 @@ extract_if_needed() {
     # Check for tarball
     if [ -f "$TARBALL" ]; then
         echo "Extracting $TARBALL..."
-        tar -xzf "$TARBALL" -C "$PLUGIN_HOME"
+        tar -xzf "$TARBALL" -C "$RUN_HOME"
         if [ $? -eq 0 ] && [ -f "$NODE_SCRIPT" ]; then
             echo "Extraction complete"
             return 0


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the changes introduced in this pull request. -->
Currently, when the canopy auto updater downloaded a new binary in a containerized environment such as docker, it was saved in a non-volume path that would be overwritten with the original file on restarts, this meant that everytime the canopy binary was restarted, it would start at an older version, more specifically, the version of the auto updater.

This fix downloads updates to the `data-dir` folder and prefers to execute the canopy binary from there, if not found, it will use the original one from the auto updater.

## Related Issues
<!-- List any issues this pull request closes. -->
Closes: N/A

## Changes Made
<!-- Highlight the key changes made in the code. For example:
- Added a new function to handle X
- Refactored Y for better performance
- Fixed bug Z
-->
- Fix bug where restarting canopy containers would revert the new binary version
- Remove unnecessary `releaser.Enabled` field

## Checklist
- [X] I have tested the changes locally and verified they work as intended.
- [ ] I have appropriately titled my branch `issue-#<issue-number>`.
- [ ] I have run re-built the web-wallet and/or block explorer (if applicable).
- [ ] I have run `npm run prettier` to format the web-wallet and/or block explorer (if applicable)
- [ ] I have updated documentation (if applicable).
- [ ] I have included tests for the changes (if applicable).

## Additional Notes
<!-- Add any additional context, screenshots, or information that reviewers might find helpful. -->
