### PR TITLE
fix: nil-safe QC payloads, serialize plugin writes, clone indexer delete keys

### DIFF
--- a/lib/certificate.go
+++ b/lib/certificate.go
@@ -248,9 +248,12 @@ func (x *QuorumCertificate) SignBytes() (signBytes []byte) {
 
 // EqualPayloads() compares the payloads only of two certs (can have different signatures)
 func (x *QuorumCertificate) EqualPayloads(compare *QuorumCertificate) bool {
+	// a missing certificate or header is not a matching payload
+	if x == nil || x.Header == nil || compare == nil || compare.Header == nil {
+		return false
+	}
 	// returns if both certificates have the same height, proposer key, block hash and result hash
-	return x != nil && x.Header != nil &&
-		bytes.Equal(x.ProposerKey, compare.ProposerKey) &&
+	return bytes.Equal(x.ProposerKey, compare.ProposerKey) &&
 		x.Header.Height == compare.Header.Height &&
 		bytes.Equal(x.BlockHash, compare.BlockHash) &&
 		bytes.Equal(x.ResultsHash, compare.ResultsHash)

--- a/lib/certificate_test.go
+++ b/lib/certificate_test.go
@@ -280,6 +280,76 @@ func TestCertificateCheckBasicAllowsNilResults(t *testing.T) {
 	require.NoError(t, qc.CheckBasic())
 }
 
+func TestEqualPayloads(t *testing.T) {
+	base := &QuorumCertificate{
+		Header:      &View{Height: 7},
+		ProposerKey: []byte("proposer"),
+		BlockHash:   crypto.Hash([]byte("block")),
+		ResultsHash: crypto.Hash([]byte("results")),
+		Signature:   &AggregateSignature{Signature: []byte("sig-a"), Bitmap: []byte("bm-a")},
+	}
+	samePayloadDifferentSig := &QuorumCertificate{
+		Header:      &View{Height: 7},
+		ProposerKey: []byte("proposer"),
+		BlockHash:   crypto.Hash([]byte("block")),
+		ResultsHash: crypto.Hash([]byte("results")),
+		Signature:   &AggregateSignature{Signature: []byte("sig-b"), Bitmap: []byte("bm-b")},
+	}
+	tests := []struct {
+		name    string
+		qc      *QuorumCertificate
+		compare *QuorumCertificate
+		equal   bool
+	}{
+		{
+			name:    "matching payloads ignore signatures",
+			qc:      base,
+			compare: samePayloadDifferentSig,
+			equal:   true,
+		},
+		{
+			name:    "nil compare",
+			qc:      base,
+			compare: nil,
+			equal:   false,
+		},
+		{
+			name:    "nil compare header",
+			qc:      base,
+			compare: &QuorumCertificate{Header: nil, ProposerKey: base.ProposerKey, BlockHash: base.BlockHash, ResultsHash: base.ResultsHash},
+			equal:   false,
+		},
+		{
+			name:    "nil receiver",
+			qc:      nil,
+			compare: base,
+			equal:   false,
+		},
+		{
+			name:    "nil receiver header",
+			qc:      &QuorumCertificate{Header: nil},
+			compare: base,
+			equal:   false,
+		},
+		{
+			name: "different height",
+			qc:   base,
+			compare: &QuorumCertificate{
+				Header:      &View{Height: 8},
+				ProposerKey: base.ProposerKey,
+				BlockHash:   base.BlockHash,
+				ResultsHash: base.ResultsHash,
+			},
+			equal: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.equal, tt.qc.EqualPayloads(tt.compare))
+		})
+	}
+}
+
 func TestCertificateResultsCheckBasic(t *testing.T) {
 	tests := []struct {
 		name   string

--- a/lib/plugin.go
+++ b/lib/plugin.go
@@ -40,7 +40,8 @@ type Plugin struct {
 	pending       map[uint64]chan isPluginToFSM_Payload // the outstanding requests from the FSM
 	requestFSMs   map[uint64]PluginCompatibleFSM        // maps request IDs to their FSM context for concurrent operations
 	queryProvider PluginQueryProvider                   // serves detached, read-only state queries from the plugin
-	l             sync.Mutex                            // thread safety
+	l             sync.Mutex                            // thread safety for pending maps
+	writeMu       sync.Mutex                            // serializes length-prefixed socket writes
 	log           LoggerI                               // the logger associated with the plugin
 	timeout       time.Duration                         // plugin request timeout
 }
@@ -667,6 +668,9 @@ func (p *Plugin) receiveProtoMsg(ptr proto.Message) ErrorI {
 
 // sendLengthPrefixed() sends a message that is prefix by length through a tcp connection
 func (p *Plugin) sendLengthPrefixed(bz []byte) ErrorI {
+	// serialize writes: handlers send concurrently after unlocking p.l
+	p.writeMu.Lock()
+	defer p.writeMu.Unlock()
 	// debug log length prefixed send start
 	p.log.Debugf("sendLengthPrefixed() sending %d bytes", len(bz))
 	// create the length prefix (4 bytes, big endian)

--- a/lib/plugin_test.go
+++ b/lib/plugin_test.go
@@ -1,0 +1,82 @@
+package lib
+
+import (
+	"encoding/binary"
+	"io"
+	"net"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// byteWriterConn forwards Write one byte at a time so concurrent writers
+// interleave unless the caller serializes them.
+type byteWriterConn struct {
+	net.Conn
+}
+
+func (c byteWriterConn) Write(b []byte) (int, error) {
+	total := 0
+	for len(b) > 0 {
+		n, err := c.Conn.Write(b[:1])
+		total += n
+		if n > 0 {
+			b = b[n:]
+		}
+		if err != nil {
+			return total, err
+		}
+	}
+	return total, nil
+}
+
+func TestSendLengthPrefixedSerializesWrites(t *testing.T) {
+	client, server := net.Pipe()
+	defer client.Close()
+	defer server.Close()
+
+	p := &Plugin{conn: byteWriterConn{client}, log: NewNullLogger()}
+	const n = 50
+	const payloadLen = 64
+	payloads := make([][]byte, n)
+	for i := 0; i < n; i++ {
+		payloads[i] = make([]byte, payloadLen)
+		for j := 0; j < payloadLen; j++ {
+			payloads[i][j] = byte(i + 1)
+		}
+	}
+
+	errCh := make(chan error, n)
+	var wg sync.WaitGroup
+	wg.Add(n)
+	for i := 0; i < n; i++ {
+		go func(i int) {
+			defer wg.Done()
+			errCh <- p.sendLengthPrefixed(payloads[i])
+		}(i)
+	}
+
+	got := make(map[byte]int, n)
+	for i := 0; i < n; i++ {
+		lenBuf := make([]byte, 4)
+		_, err := io.ReadFull(server, lenBuf)
+		require.NoError(t, err)
+		length := binary.BigEndian.Uint32(lenBuf)
+		require.Equal(t, uint32(payloadLen), length)
+		body := make([]byte, length)
+		_, err = io.ReadFull(server, body)
+		require.NoError(t, err)
+		first := body[0]
+		for _, b := range body {
+			require.Equal(t, first, b)
+		}
+		got[first]++
+	}
+	wg.Wait()
+	close(errCh)
+	for err := range errCh {
+		require.NoError(t, err)
+	}
+	require.Len(t, got, n)
+}

--- a/plugin/go/contract/plugin.go
+++ b/plugin/go/contract/plugin.go
@@ -26,7 +26,8 @@ type Plugin struct {
 	conn            net.Conn                              // the underlying unix sock file connection
 	pending         map[uint64]chan isFSMToPlugin_Payload // the outstanding requests from the contract
 	requestContract map[uint64]*Contract                  // maps request IDs to their contract context for concurrent operations
-	l               sync.Mutex                            // thread safety
+	l               sync.Mutex                            // thread safety for pending maps
+	writeMu         sync.Mutex                            // serializes length-prefixed socket writes
 	config          Config                                // general app config
 }
 
@@ -329,6 +330,9 @@ func (p *Plugin) receiveProtoMsg(ptr proto.Message) *PluginError {
 
 // sendLengthPrefixed() sends a message that is prefix by length through a tcp connection
 func (p *Plugin) sendLengthPrefixed(bz []byte) *PluginError {
+	// serialize writes: inbound handlers send concurrently after unlocking p.l
+	p.writeMu.Lock()
+	defer p.writeMu.Unlock()
 	// create the length prefix (4 bytes, big endian)
 	lengthPrefix := make([]byte, 4)
 	binary.BigEndian.PutUint32(lengthPrefix, uint32(len(bz)))

--- a/plugin/go/contract/plugin_write_test.go
+++ b/plugin/go/contract/plugin_write_test.go
@@ -1,0 +1,94 @@
+package contract
+
+import (
+	"encoding/binary"
+	"io"
+	"net"
+	"sync"
+	"testing"
+)
+
+// byteWriterConn forwards Write one byte at a time so concurrent writers
+// interleave unless the caller serializes them.
+type byteWriterConn struct {
+	net.Conn
+}
+
+func (c byteWriterConn) Write(b []byte) (int, error) {
+	total := 0
+	for len(b) > 0 {
+		n, err := c.Conn.Write(b[:1])
+		total += n
+		if n > 0 {
+			b = b[n:]
+		}
+		if err != nil {
+			return total, err
+		}
+	}
+	return total, nil
+}
+
+func TestSendLengthPrefixedSerializesWrites(t *testing.T) {
+	client, server := net.Pipe()
+	defer client.Close()
+	defer server.Close()
+
+	p := &Plugin{conn: byteWriterConn{client}}
+	const n = 50
+	const payloadLen = 64
+	payloads := make([][]byte, n)
+	for i := 0; i < n; i++ {
+		payloads[i] = make([]byte, payloadLen)
+		for j := 0; j < payloadLen; j++ {
+			payloads[i][j] = byte(i + 1)
+		}
+	}
+
+	errCh := make(chan error, n)
+	var wg sync.WaitGroup
+	wg.Add(n)
+	for i := 0; i < n; i++ {
+		go func(i int) {
+			defer wg.Done()
+			if err := p.sendLengthPrefixed(payloads[i]); err != nil {
+				errCh <- err
+				return
+			}
+			errCh <- nil
+		}(i)
+	}
+
+	got := make(map[byte]int, n)
+	for i := 0; i < n; i++ {
+		lenBuf := make([]byte, 4)
+		if _, err := io.ReadFull(server, lenBuf); err != nil {
+			t.Fatal(err)
+		}
+		length := binary.BigEndian.Uint32(lenBuf)
+		if length != uint32(payloadLen) {
+			t.Fatalf("garbled length prefix: got %d", length)
+		}
+		body := make([]byte, length)
+		if _, err := io.ReadFull(server, body); err != nil {
+			t.Fatal(err)
+		}
+		first := body[0]
+		for _, b := range body {
+			if b != first {
+				t.Fatalf("interleaved payload bytes")
+			}
+		}
+		got[first]++
+	}
+	wg.Wait()
+	close(errCh)
+	for err := range errCh {
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+	if len(got) != n {
+		t.Fatalf("expected %d distinct frames, got %d", n, len(got))
+	}
+}

--- a/store/indexer.go
+++ b/store/indexer.go
@@ -956,7 +956,8 @@ func (t *Indexer) deleteAll(prefix []byte) lib.ErrorI {
 	defer it.Close()
 	var keysToDelete [][]byte
 	for ; it.Valid(); it.Next() {
-		keysToDelete = append(keysToDelete, it.Key())
+		// clone: iterator Key() is only valid until Next()
+		keysToDelete = append(keysToDelete, bytes.Clone(it.Key()))
 	}
 	for _, k := range keysToDelete {
 		if err = t.db.Delete(k); err != nil {

--- a/store/indexer_test.go
+++ b/store/indexer_test.go
@@ -81,6 +81,38 @@ func TestDeleteTxsForHeightRemovesEthereumHashAlias(t *testing.T) {
 	require.True(t, got == nil || got.TxHash == "")
 }
 
+func TestDeleteAllClonesIteratorKeys(t *testing.T) {
+	store, _, cleanup := testStore(t)
+	defer cleanup()
+
+	const n = 64
+	for i := 0; i < n; i++ {
+		txRes, _, _, _, _ := newTestTxResult(t)
+		txRes.Height = testHeight
+		txRes.Index = uint64(i)
+		require.NoError(t, store.IndexTx(txRes))
+	}
+	other, _, _, _, _ := newTestTxResult(t)
+	other.Height = testHeight + 1
+	other.Index = 0
+	require.NoError(t, store.IndexTx(other))
+
+	_, err := store.Commit()
+	require.NoError(t, err)
+
+	require.NoError(t, store.DeleteTxsForHeight(testHeight))
+	_, err = store.Commit()
+	require.NoError(t, err)
+
+	got, err := store.GetTxsByHeightNonPaginated(testHeight, false)
+	require.NoError(t, err)
+	require.Len(t, got, 0)
+
+	remaining, err := store.GetTxsByHeightNonPaginated(testHeight+1, false)
+	require.NoError(t, err)
+	require.Len(t, remaining, 1)
+}
+
 const ethGasPriceTestValue = 10_000_000_000
 
 func ptrAddress(address common.Address) *common.Address { return &address }


### PR DESCRIPTION
## Summary
- Guard `QuorumCertificate.EqualPayloads` against a nil compare cert/header so last-certificate checks cannot panic.
- Serialize length-prefixed plugin socket writes with a dedicated `writeMu` on both the FSM plugin and the Go plugin SDK (do not reuse `p.l`).
- Clone iterator keys in indexer `deleteAll` before `Next()`, matching `DeleteCheckpointsForChain`, so prefix deletes cannot skip keys.

## Test plan
- [x] `go test ./lib/ ./store/`
- [x] `go test ./contract/` in `plugin/go`
- [x] `TestEqualPayloads` — same payload, different signatures still equal
- [x] `TestSendLengthPrefixedSerializesWrites` — concurrent length-prefixed writes stay framed
- [ ] Optional: `plugin/go` tutorial `TestPluginTransactions` against a running node with `"plugin": "go"`