### PR TITLE
fix(crypto): remove data race and stale sieve state in NewDiscriminant

### DIFF
--- a/lib/crypto/classgroup.go
+++ b/lib/crypto/classgroup.go
@@ -385,35 +385,29 @@ func NewDiscriminant(seed []byte) *big.Int {
 	// initialize a sieve to mark non-prime candidates within the range
 	sieveLen := 65536
 	sieve := make([]bool, sieveLen)
+	// reuse a single scratch integer for the sieve arithmetic
+	tmp := bip.New()
+	defer bip.Recycle(tmp)
 	for {
-		// reset the slice
-		sieve = sieve[:]
-		var wg sync.WaitGroup
-		// parallelize the marking of multiples
+		// clear the sieve so marks from the previous range do not leak into this one
+		clear(sieve)
+		// mark the multiples of each prime divisor as non-prime candidates
 		for _, v := range SieveInfo {
-			wg.Add(1)
-			go func(v Pair) {
-				tmp := bip.New().Set(temp)
-				defer wg.Done()
-				// `v.p` is a prime divisor, and `v.q` is the modular inverse of m mod v.p
-				// `i` calculates the starting index for marking multiples of v.p
-				// it represents the smallest integer such that:
-				//     m * i ≡ -n (mod v.p)
-				// simplified as:
-				//     i = ((-n % v.p) * v.q) % v.p
-				i := (tmp.Mod(negN, tmp.SetInt64(v.p)).Int64() * v.q) % v.p
-
-				// adjust `i` to ensure it's within the bounds of the sieve
-				for i < int64(sieveLen) {
-					// mark the sieve index as non-prime
-					sieve[i] = true
-					// move to the next multiple of v.p within the sieve range
-					i += v.p
-				}
-			}(v)
+			// `v.p` is a prime divisor, and `v.q` is the modular inverse of m mod v.p
+			// `i` calculates the starting index for marking multiples of v.p
+			// it represents the smallest integer such that:
+			//     m * i ≡ -n (mod v.p)
+			// simplified as:
+			//     i = ((-n % v.p) * v.q) % v.p
+			i := (tmp.Mod(negN, tmp.SetInt64(v.p)).Int64() * v.q) % v.p
+			// adjust `i` to ensure it's within the bounds of the sieve
+			for i < int64(sieveLen) {
+				// mark the sieve index as non-prime
+				sieve[i] = true
+				// move to the next multiple of v.p within the sieve range
+				i += v.p
+			}
 		}
-		// wait for all marking goroutines to finish
-		wg.Wait()
 		// check each number in the sieve range for primality.
 		for i, marked := range sieve {
 			// skip if pre-marked as non prime


### PR DESCRIPTION

## Problem

`NewDiscriminant` spawns one goroutine per entry in `SieveInfo`, and every

goroutine writes into the same shared `sieve` slice. Multiples of different

prime divisors can land on the same index, so the writes to `sieve[i]` are

unsynchronized. The race detector reports this as a write/write race in

`lib/crypto/classgroup.go`, and it takes down two tests:

```

WARNING: DATA RACE

Write at 0x00c006d00054 by goroutine 365:

  github.com/canopy-network/canopy/lib/crypto.NewDiscriminant.func1()

      lib/crypto/classgroup.go:409

Previous write at 0x00c006d00054 by goroutine 362:

  github.com/canopy-network/canopy/lib/crypto.NewDiscriminant.func1()

      lib/crypto/classgroup.go:409

--- FAIL: TestVDF (3.68s)
testing.go:1712: race detected during execution of test
--- FAIL: TestProofAndVerify/50_iterations (0.77s)
testing.go:1712: race detected during execution of test



There is a second, quieter bug in the same loop. The comment says the sieve is

reset on each pass, but `sieve = sieve[:]` only reslices, it does not zero the

backing array. When no prime is found in a range and the outer loop advances to

`n + m*2^16`, the sieve still carries every mark from the previous range, so

valid prime candidates get skipped as pre-marked.

## Change

- Mark the multiples sequentially instead of concurrently, which removes the race.

- Replace the no-op reset with `clear(sieve)` so each range starts clean.

- Reuse one scratch `big.Int` instead of allocating one per goroutine.

Comments were kept and extended in the existing style.

## Performance

Dropping the parallelism does not cost anything. The goroutine setup and the

per-goroutine `big.Int` allocation outweighed the work being parallelized, so

the sequential version is marginally faster.

Apple M2, `-benchtime=30x -count=3`, cache cleared between iterations:

| | ns/op |

|---|---|

| before | 164741051, 165282814, 164110875 |

| after | 164621854, 162343600, 163312792 |

## Verification

$ go test -race -run "TestProofAndVerify" ./lib/crypto/
ok github.com/canopy-network/canopy/lib/crypto 6.512s

$ go test -race ./lib/crypto/
ok github.com/canopy-network/canopy/lib/crypto 2.122s



`gofmt` clean, `go build ./lib/...` passes.

## Note on branch target

`CONTRIBUTING.md` asks for PRs against `development`, but no such branch exists

on the remote and every recently merged PR targets `main`, so this one targets

`main`. Happy to retarget if that is wrong.

## Out of scope

`TestVDFPrematureExit` still fails under `-race`, but that is an unrelated race

between `lib/vdf.go` and its test. Keeping this PR to a single fix per the

contributing guidelines.

