### PR TITLE
fix(bft): handle empty proposal slices

### DIFF
--- a/bft/prop.go
+++ b/bft/prop.go
@@ -74,7 +74,7 @@ func (b *BFT) GetProposal() *Message { return b.getProposal(b.Round, b.Phase) }
 // getProposal() retrieves a proposal from the leader at the Round.Phase
 func (b *BFT) getProposal(round uint64, phase Phase) *Message {
 	proposal, found := b.Proposals[round][phaseToString(phase-1)]
-	if !found {
+	if !found || len(proposal) == 0 {
 		return nil
 	}
 	return proposal[0]

--- a/bft/prop_test.go
+++ b/bft/prop_test.go
@@ -88,3 +88,13 @@ func TestAddProposal(t *testing.T) {
 		})
 	}
 }
+
+func TestGetProposalAfterNewCommitteeResetWithoutElectionCandidate(t *testing.T) {
+	b := &BFT{
+		Proposals: make(ProposalsForHeight),
+	}
+
+	b.ProposalsResetForNewCommittee()
+
+	require.Nil(t, b.getProposal(0, ElectionVote))
+}


### PR DESCRIPTION
getProposal could panic when the proposal key exists but the slice is empty.

This can happen after a new committee reset when there isn't a round 0 election candidate yet.

Added a length check and a regression test.

Tested with go test ./bft -count=1.﻿
