### PR TITLE
fix(fsm): return LoadCommittee errors in ApplyBlock

### DIFF
--- a/fsm/state.go
+++ b/fsm/state.go
@@ -187,14 +187,20 @@ func (s *StateMachine) ApplyBlock(ctx context.Context, b *lib.Block, allowOversi
 	// add the events from end block
 	r.AddEvent(events...)
 	// load the validator set for the previous height
-	lastValidatorSet, _ := s.LoadCommittee(s.Config.ChainId, s.Height()-1)
+	lastValidatorSet, err := s.LoadCommittee(s.Config.ChainId, s.Height()-1)
+	if err != nil {
+		return nil, nil, err
+	}
 	// calculate the merkle root of the last validators to maintain validator continuity between blocks (if root)
 	lastValidatorRoot, err := lastValidatorSet.ValidatorSet.Root()
 	if err != nil {
 		return nil, nil, err
 	}
 	// load the 'next validator set' from the state
-	nextValidatorSet, _ := s.LoadCommittee(s.Config.ChainId, s.Height())
+	nextValidatorSet, err := s.LoadCommittee(s.Config.ChainId, s.Height())
+	if err != nil {
+		return nil, nil, err
+	}
 	// calculate the merkle root of the next validators to maintain validator continuity between blocks (if root)
 	nextValidatorRoot, err := nextValidatorSet.ValidatorSet.Root()
 	if err != nil {

--- a/fsm/state_test.go
+++ b/fsm/state_test.go
@@ -286,6 +286,28 @@ func TestApplyBlock(t *testing.T) {
 	}
 }
 
+type failNewReadOnlyStore struct {
+	lib.StoreI
+}
+
+func (s failNewReadOnlyStore) NewReadOnly(uint64) (lib.StoreI, lib.ErrorI) {
+	return nil, ErrWrongStoreType()
+}
+
+func TestApplyBlockReturnsLoadCommitteeError(t *testing.T) {
+	sm := newTestStateMachine(t)
+	sm.height = 1
+	sm.ProtocolVersion = 1
+	sm.store = failNewReadOnlyStore{StoreI: sm.store.(lib.StoreI)}
+	_, _, err := sm.ApplyBlock(context.Background(), &lib.Block{
+		BlockHeader: &lib.BlockHeader{
+			Time:            uint64(time.Date(2024, 2, 1, 0, 0, 0, 0, time.UTC).UnixMicro()),
+			ProposerAddress: newTestAddressBytes(t),
+		},
+	}, false)
+	require.ErrorContains(t, err, "wrong store type")
+}
+
 func TestApplyTransactions_DoesNotReturnCheckErrors(t *testing.T) {
 	sm := newTestStateMachine(t)
 	kg := newTestKeyGroup(t)


### PR DESCRIPTION
## Summary
- `ApplyBlock` called `LoadCommittee` twice and discarded the error with `_`. A store / `TimeMachine` failure then continued with an empty `ValidatorSet`.
- `ConsensusValidators.Root()` treats an empty set as success (`nil, nil`), and `nonEmptyHash` substitutes a dummy `FFFF…` root. A real read error could therefore be written into the block header as if the committee were empty.
- Return the error, matching `BeginBlock` which already checks `LoadCommittee`.
- Do not change dummy-root behavior for a genuinely empty committee.

## Test plan
- [x] `go test ./fsm/ -run TestApplyBlock`
- [x] `TestApplyBlock` happy path
- [x] `TestApplyBlockReturnsLoadCommitteeError`