### PR TITLE
fix: zero drops on fail get wallet

### DIFF
--- a/cmd/rpc/web/wallet/src/hooks/useBalanceChart.ts
+++ b/cmd/rpc/web/wallet/src/hooks/useBalanceChart.ts
@@ -66,27 +66,32 @@ export function useBalanceChart({ points = 7, type = 'balance' }: BalanceChartOp
 
             const sortedHeights = Array.from(heights).sort((a, b) => a - b)
 
-            const dataPoints = await Promise.all(
-                sortedHeights.map(async (height): Promise<ChartDataPoint> => {
+            // Each point carries an `ok` flag so we can distinguish a genuine zero
+            // balance from a failed/partial fetch. Failed points are back-filled
+            // with the previous good value so the chart never shows a false drop.
+            const rawPoints = await Promise.all(
+                sortedHeights.map(async (height): Promise<ChartDataPoint & { ok: boolean }> => {
                     const secondsAgo = Math.max(0, (currentHeight - height) * secondsPerBlock)
+                    const label = formatAgoLabel(secondsAgo)
 
                     try {
                         let totalValue = 0
 
+                        // Note: individual fetches are intentionally NOT caught here so a
+                        // rejection propagates and marks the whole point as failed (ok=false),
+                        // rather than silently contributing 0 and skewing the total.
                         if (type === 'balance' || type === 'liquid') {
                             const [balances, stakes] = await Promise.all([
                                 Promise.all(
                                     addresses.map(address =>
                                         dsFetch<number>('accountByHeight', { address, height })
                                             .then(v => v || 0)
-                                            .catch(() => 0)
                                     )
                                 ),
                                 Promise.all(
                                     addresses.map(address =>
                                         dsFetch<Record<string, unknown>>('validatorByHeight', { address, height })
                                             .then(v => Number((v as Record<string, unknown>)?.stakedAmount ?? 0) || 0)
-                                            .catch(() => 0)
                                     )
                                 ),
                             ])
@@ -96,38 +101,57 @@ export function useBalanceChart({ points = 7, type = 'balance' }: BalanceChartOp
                         } else if (type === 'staked') {
                             const stakes = await Promise.all(
                                 addresses.map(address =>
-                                    dsFetch<any>('validatorByHeight', { address, height })
-                                        .then(v => v?.stakedAmount || 0)
-                                        .catch(() => 0)
+                                    dsFetch<Record<string, unknown>>('validatorByHeight', { address, height })
+                                        .then(v => Number((v as Record<string, unknown>)?.stakedAmount ?? 0) || 0)
                                 )
                             )
                             totalValue = stakes.reduce((sum, v) => sum + v, 0)
                         }
 
-                        return {
-                            timestamp: height,
-                            value: totalValue,
-                            label: formatAgoLabel(secondsAgo),
-                        }
+                        return { timestamp: height, value: totalValue, label, ok: true }
                     } catch (error) {
                         console.warn(`Error fetching data for height ${height}:`, error)
-                        return {
-                            timestamp: height,
-                            value: 0,
-                            label: formatAgoLabel(secondsAgo),
-                        }
+                        return { timestamp: height, value: 0, label, ok: false }
                     }
                 })
             )
 
-            const hasNonZero = dataPoints.some(p => p.value > 0)
-            if (hasNonZero) {
-                lastGoodDataRef.current = dataPoints
-                return dataPoints
+            const hasGoodPoint = rawPoints.some(p => p.ok)
+
+            // Every point failed: keep showing the last good series instead of a flat-zero graph.
+            if (!hasGoodPoint && lastGoodDataRef.current.length > 0) {
+                return lastGoodDataRef.current
             }
 
-            if (lastGoodDataRef.current.length > 0) {
-                return lastGoodDataRef.current
+            const filled = rawPoints.map(p => ({ ...p, resolved: p.ok }))
+
+            // Carry the previous good value forward across failed points (oldest -> newest).
+            let prevGoodValue: number | null = null
+            for (const point of filled) {
+                if (point.ok) {
+                    prevGoodValue = point.value
+                } else if (prevGoodValue != null) {
+                    point.value = prevGoodValue
+                    point.resolved = true
+                }
+            }
+
+            // Back-fill any remaining (leading) failed points with the next good value (newest -> oldest).
+            let nextGoodValue: number | null = null
+            for (let i = filled.length - 1; i >= 0; i--) {
+                const point = filled[i]
+                if (point.ok) {
+                    nextGoodValue = point.value
+                } else if (!point.resolved && nextGoodValue != null) {
+                    point.value = nextGoodValue
+                    point.resolved = true
+                }
+            }
+
+            const dataPoints: ChartDataPoint[] = filled.map(({ timestamp, value, label }) => ({ timestamp, value, label }))
+
+            if (hasGoodPoint) {
+                lastGoodDataRef.current = dataPoints
             }
 
             return dataPoints


### PR DESCRIPTION
## Summary

Fixes a bug in the wallet dashboard where the balance graphs (Total Liquid Balance / Total Staked Balance) would momentarily drop to `0` and then recover. The drop was caused by transient data-fetch failures on individual chart points, and this change makes the graph carry forward the last known good value instead — matching how the non-graphic scalar values already behave.

## Problem

In `useBalanceChart`, each point in the sparkline is fetched independently per height. Any fetch failure fell back to `value: 0`:

- Per-address fetches used `.catch(() => 0)`, and
- the per-point `try/catch` returned `value: 0`.

So when a transient RPC error hit a height (most often the current/"Now" height), that point collapsed to zero and then recovered on the next successful refetch, producing a visible dip in the graph. The existing `lastGoodDataRef` fallback only helped when *every* point was zero, so a single failed point still showed the drop.

## Fix

Per-point failures now carry forward the previous good value, exactly like the scalar cards keep their prior value:

1. Each point tracks an `ok` flag. Individual fetches are no longer swallowed into `0` — a rejection now propagates and marks the whole point as failed, instead of silently skewing the total toward zero.
2. Failed points are **forward-filled** with the most recent good value (oldest → newest).
3. Any leading failed points (before the first good value) are **back-filled** with the next good value.
4. If *all* points fail, it keeps rendering the last good series (previous behavior, preserved).
5. `lastGoodDataRef` is updated only when at least one point actually succeeded.

A genuine zero balance still renders as zero (only `ok === false` points get filled), so real data isn't masked — only failed refreshes are smoothed over.

Also removed a stray `any` type on the `staked` branch's `dsFetch` call, replacing it with `Record<string, unknown>` to match the other branch.

## Files changed

- `cmd/rpc/web/wallet/src/hooks/useBalanceChart.ts`