### PR TITLE
fix(lib): ContainsByteSlice never reports a match

### DIFF
--- a/lib/util.go
+++ b/lib/util.go
@@ -1062,11 +1062,15 @@ func IntSqrt(n uint64) uint64 {
 
 // ContainsByteSlice() checks to see if the byte slice is within the list
 func ContainsByteSlice(list [][]byte, target []byte) (found bool) {
+	// for each item in the list
 	for _, item := range list {
+		// if the item matches the target
 		if bytes.Equal(item, target) {
-			return
+			// found the target; signal true and exit
+			return true
 		}
 	}
+	// target not present in the list
 	return
 }
 

--- a/lib/util_test.go
+++ b/lib/util_test.go
@@ -551,6 +551,57 @@ func TestAddUint64(t *testing.T) {
 	require.True(t, overflow)
 }
 
+func TestContainsByteSlice(t *testing.T) {
+	tests := []struct {
+		name     string
+		detail   string
+		list     [][]byte
+		target   []byte
+		expected bool
+	}{
+		{
+			name:     "empty list",
+			detail:   "a nil list never contains the target",
+			list:     nil,
+			target:   []byte("a"),
+			expected: false,
+		},
+		{
+			name:     "present at head",
+			detail:   "the target is the first element of the list",
+			list:     [][]byte{[]byte("a"), []byte("b"), []byte("c")},
+			target:   []byte("a"),
+			expected: true,
+		},
+		{
+			name:     "present in middle",
+			detail:   "the target is somewhere within the list",
+			list:     [][]byte{[]byte("a"), []byte("b"), []byte("c")},
+			target:   []byte("b"),
+			expected: true,
+		},
+		{
+			name:     "present at tail",
+			detail:   "the target is the last element of the list",
+			list:     [][]byte{[]byte("a"), []byte("b"), []byte("c")},
+			target:   []byte("c"),
+			expected: true,
+		},
+		{
+			name:     "absent",
+			detail:   "the target is not a member of the list",
+			list:     [][]byte{[]byte("a"), []byte("b"), []byte("c")},
+			target:   []byte("z"),
+			expected: false,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			require.Equal(t, test.expected, ContainsByteSlice(test.list, test.target))
+		})
+	}
+}
+
 func TestLoadCounted(t *testing.T) {
 	tests := []struct {
 		name           string


### PR DESCRIPTION
## Problem

`lib.ContainsByteSlice` uses a naked `return` inside the match branch, so the named return value `found` is never set to `true`. The function therefore returns `false` even when `target` is present in `list`:

```go
func ContainsByteSlice(list [][]byte, target []byte) (found bool) {
    for _, item := range list {
        if bytes.Equal(item, target) {
            return // found is still false here
        }
    }
    return
}
```

This helper fills a real gap because `slices.Contains` cannot operate on `[][]byte` (`[]byte` is not comparable), so any current or future caller relying on it would silently get the wrong answer.

## Fix

Return `true` on a match.

## Tests

Added `TestContainsByteSlice` (table-driven, matching the existing style in `util_test.go`) covering the target present at the head, middle, and tail, plus the empty-list and absent cases. The presence cases fail against the previous implementation and pass with the fix.