### PR TITLE
Tighten transaction encoding validation

### DIFF
--- a/fsm/state.go
+++ b/fsm/state.go
@@ -262,6 +262,9 @@ func (s *StateMachine) ApplyTransactions(ctx context.Context, txs [][]byte, r *l
 	startTime := time.Now()
 	// use a map to check for 'same-block' duplicate transactions
 	deDuplicator := lib.NewDeDuplicator[string]()
+	// threshold-multisig signatures may use different valid signer subsets for the
+	// same intent, so track their stable intent IDs separately from envelope hashes.
+	multisigIntentDeDuplicator := lib.NewDeDuplicator[[crypto.HashSize]byte]()
 	// use a batch verifier for signatures
 	batchVerifier := crypto.NewBatchVerifier()
 	// get the governance parameter for max block size
@@ -271,6 +274,8 @@ func (s *StateMachine) ApplyTransactions(ctx context.Context, txs [][]byte, r *l
 	}
 	// keep a map to track transactions that failed 'check'
 	failedCheckTxs := map[int]error{}
+	// retain stable multisig intent IDs from the successful precheck pass
+	multisigIntentIDs := make([][]byte, len(txs))
 	// map signature batch indices back to original tx indices
 	batchToTxIdx := make([]int, 0, len(txs))
 	// first batch validate signatures over the entire set
@@ -282,8 +287,16 @@ func (s *StateMachine) ApplyTransactions(ctx context.Context, txs [][]byte, r *l
 		if e != nil {
 			return e
 		}
-		if _, checkErr := s.CheckTx(tx, "", batchVerifier); checkErr != nil {
+		checkResult, checkErr := s.CheckTx(tx, "", batchVerifier)
+		if checkErr != nil {
 			failedCheckTxs[i] = checkErr
+		} else {
+			intentID, intentErr := checkResult.tx.GetMultisigIntentID()
+			if intentErr != nil {
+				failedCheckTxs[i] = intentErr
+			} else {
+				multisigIntentIDs[i] = intentID
+			}
 		}
 		checkTxn.Discard()
 		s.SetStore(checkStore)
@@ -330,6 +343,19 @@ func (s *StateMachine) ApplyTransactions(ctx context.Context, txs [][]byte, r *l
 		// check if the transaction is a 'same block' duplicate
 		if found := deDuplicator.Found(hashString); found {
 			return lib.ErrDuplicateTx(hashString)
+		}
+		// reject alternate valid signature envelopes for the same multisig intent
+		if intentID := multisigIntentIDs[i]; len(intentID) != 0 {
+			var intentKey [crypto.HashSize]byte
+			copy(intentKey[:], intentID)
+			if found := multisigIntentDeDuplicator.Found(intentKey); found {
+				duplicateErr := lib.ErrDuplicateTx(lib.BytesToString(intentID))
+				if allowOversize {
+					r.AddFailed(lib.NewFailedTx(tx, duplicateErr))
+					continue
+				}
+				return duplicateErr
+			}
 		}
 		// get the tx size
 		txSize := uint64(len(tx))

--- a/fsm/transaction.go
+++ b/fsm/transaction.go
@@ -1,6 +1,7 @@
 package fsm
 
 import (
+	"bytes"
 	"github.com/canopy-network/canopy/lib"
 	"github.com/canopy-network/canopy/lib/crypto"
 	"google.golang.org/protobuf/types/known/anypb"
@@ -228,6 +229,9 @@ func (s *StateMachine) CheckSignature(tx *lib.Transaction, authorizedSigners [][
 	publicKey, e := crypto.NewPublicKeyFromBytes(tx.Signature.PublicKey)
 	if e != nil {
 		return nil, ErrInvalidPublicKey(e)
+	}
+	if !bytes.Equal(tx.Signature.PublicKey, publicKey.Bytes()) {
+		return nil, ErrInvalidSignature()
 	}
 	// Legacy "RLP" was historically an ordinary memo for non-Ethereum keys.
 	// RLP.V2 is reserved and always requires an Ethereum key.

--- a/fsm/transaction.go
+++ b/fsm/transaction.go
@@ -230,6 +230,9 @@ func (s *StateMachine) CheckSignature(tx *lib.Transaction, authorizedSigners [][
 	if e != nil {
 		return nil, ErrInvalidPublicKey(e)
 	}
+	if multiKey, ok := publicKey.(*crypto.BLS12381MultiPublicKey); ok && multiKey.Threshold() == 0 {
+		return nil, ErrInvalidSignature()
+	}
 	if !bytes.Equal(tx.Signature.PublicKey, publicKey.Bytes()) {
 		return nil, ErrInvalidSignature()
 	}

--- a/fsm/transaction.go
+++ b/fsm/transaction.go
@@ -335,6 +335,19 @@ func (s *StateMachine) CheckReplay(tx *lib.Transaction, txHash string) lib.Error
 				}
 			}
 		}
+		intentID, e := tx.GetMultisigIntentID()
+		if e != nil {
+			return e
+		}
+		if len(intentID) != 0 {
+			txResult, err = store.GetTxByHash(intentID)
+			if err != nil {
+				return err
+			}
+			if txResult != nil && txResult.TxHash != "" {
+				return lib.ErrDuplicateTx(lib.BytesToString(intentID))
+			}
+		}
 	}
 	// RLP.V2 uses the account nonce for replay protection and a canonical CreatedHeight sentinel.
 	if tx.Memo == RLPV2Indicator {

--- a/fsm/transaction_test.go
+++ b/fsm/transaction_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/ethereum/go-ethereum/core/types"
 	ethCrypto "github.com/ethereum/go-ethereum/crypto"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/anypb"
 	"math"
 	"math/big"
@@ -617,6 +618,30 @@ func TestCheckSignatureRejectsNonCanonicalPublicKey(t *testing.T) {
 		Signature: key.Sign(signBytes),
 	}
 	_, errI = (&StateMachine{}).CheckSignature(tx, [][]byte{key.PublicKey().Address().Bytes()}, nil)
+	require.ErrorContains(t, errI, "invalid signature")
+}
+
+func TestCheckSignatureRejectsThresholdZeroMultisig(t *testing.T) {
+	key, err := crypto.NewBLS12381PrivateKey()
+	require.NoError(t, err)
+	encoded, err := proto.MarshalOptions{Deterministic: true}.Marshal(&crypto.MultiPublicKey{
+		PublicKeys: [][]byte{key.PublicKey().Bytes()},
+		Bitmap:     []byte{0},
+	})
+	require.NoError(t, err)
+	publicKey, err := crypto.NewMultiBLSFromPublicKey(encoded)
+	require.NoError(t, err)
+	tx := &lib.Transaction{Time: 1}
+	signBytes, errI := tx.GetSignBytes()
+	require.NoError(t, errI)
+	identitySignature := make([]byte, crypto.BLS12381SignatureSize)
+	identitySignature[0] = 0xc0
+	require.True(t, publicKey.VerifyBytes(signBytes, identitySignature))
+	tx.Signature = &lib.Signature{
+		PublicKey: encoded,
+		Signature: identitySignature,
+	}
+	_, errI = (&StateMachine{}).CheckSignature(tx, [][]byte{publicKey.Address().Bytes()}, nil)
 	require.ErrorContains(t, errI, "invalid signature")
 }
 

--- a/fsm/transaction_test.go
+++ b/fsm/transaction_test.go
@@ -606,6 +606,20 @@ func TestCheckSignature(t *testing.T) {
 	}
 }
 
+func TestCheckSignatureRejectsNonCanonicalPublicKey(t *testing.T) {
+	key, err := crypto.NewETHSECP256K1PrivateKey()
+	require.NoError(t, err)
+	tx := &lib.Transaction{Time: 1}
+	signBytes, errI := tx.GetSignBytes()
+	require.NoError(t, errI)
+	tx.Signature = &lib.Signature{
+		PublicKey: key.PublicKey().(*crypto.ETHSECP256K1PublicKey).BytesWithPrefix(),
+		Signature: key.Sign(signBytes),
+	}
+	_, errI = (&StateMachine{}).CheckSignature(tx, [][]byte{key.PublicKey().Address().Bytes()}, nil)
+	require.ErrorContains(t, errI, "invalid signature")
+}
+
 func TestCheckReplay(t *testing.T) {
 	tests := []struct {
 		name   string

--- a/fsm/transaction_test.go
+++ b/fsm/transaction_test.go
@@ -1,6 +1,7 @@
 package fsm
 
 import (
+	"bytes"
 	"context"
 	"crypto/ecdsa"
 	"github.com/canopy-network/canopy/lib"
@@ -14,6 +15,7 @@ import (
 	"google.golang.org/protobuf/types/known/anypb"
 	"math"
 	"math/big"
+	"sort"
 	"testing"
 	"time"
 )
@@ -347,6 +349,9 @@ func TestCheckTxAcceptsSerializedMultiBLSSigner(t *testing.T) {
 	require.NoError(t, sm.UpdateParam("fee", ParamSendFee, &lib.UInt64Wrapper{Value: 1}))
 
 	signers := newTestKeyGroups(t, 3)
+	sort.Slice(signers, func(i, j int) bool {
+		return bytes.Compare(signers[i].PublicKey.Bytes(), signers[j].PublicKey.Bytes()) < 0
+	})
 	points := make([]kyber.Point, 0, len(signers))
 	for _, kg := range signers {
 		point, err := crypto.BytesToBLS12381Point(kg.PublicKey.Bytes())

--- a/fsm/transaction_test.go
+++ b/fsm/transaction_test.go
@@ -347,60 +347,117 @@ func TestCheckTx(t *testing.T) {
 func TestCheckTxAcceptsSerializedMultiBLSSigner(t *testing.T) {
 	sm := newTestStateMachine(t)
 	require.NoError(t, sm.UpdateParam("fee", ParamSendFee, &lib.UInt64Wrapper{Value: 1}))
+	address, recipient, _, txBytes := newAlternateMultisigSendTransactions(t, sm)
 
+	got, err := sm.CheckTx(txBytes, crypto.HashString(txBytes), nil)
+	require.NoError(t, err)
+	require.Equal(t, address.Bytes(), got.sender.Bytes())
+	gotMsg, ok := got.msg.(*MessageSend)
+	require.True(t, ok)
+	require.Equal(t, recipient.Bytes(), gotMsg.ToAddress)
+}
+
+func TestApplyTransactionsRejectsAlternateMultisigSignerSubsets(t *testing.T) {
+	t.Run("mempool selection records the alternate envelope as failed", func(t *testing.T) {
+		sm := newTestStateMachine(t)
+		require.NoError(t, sm.UpdateParam("fee", ParamSendFee, &lib.UInt64Wrapper{Value: 1}))
+		address, _, txAB, txAC := newAlternateMultisigSendTransactions(t, sm)
+		require.NoError(t, sm.AccountAdd(address, 20))
+
+		results := new(lib.ApplyBlockResults)
+		require.NoError(t, sm.ApplyTransactions(context.Background(), [][]byte{txAB, txAC}, results, true))
+		require.Len(t, results.Results, 1)
+		require.Len(t, results.Failed, 1)
+		require.ErrorContains(t, results.Failed[0].Error, "is a duplicate")
+	})
+
+	t.Run("block validation rejects the alternate envelope", func(t *testing.T) {
+		sm := newTestStateMachine(t)
+		require.NoError(t, sm.UpdateParam("fee", ParamSendFee, &lib.UInt64Wrapper{Value: 1}))
+		address, _, txAB, txAC := newAlternateMultisigSendTransactions(t, sm)
+		require.NoError(t, sm.AccountAdd(address, 20))
+
+		err := sm.ApplyTransactions(context.Background(), [][]byte{txAB, txAC}, new(lib.ApplyBlockResults), false)
+		require.ErrorContains(t, err, "is a duplicate")
+	})
+}
+
+func TestCheckTxRejectsIndexedMultisigIntentWithAlternateSignerSubset(t *testing.T) {
+	sm := newTestStateMachine(t)
+	require.NoError(t, sm.UpdateParam("fee", ParamSendFee, &lib.UInt64Wrapper{Value: 1}))
+	address, recipient, txABBytes, txACBytes := newAlternateMultisigSendTransactions(t, sm)
+	require.NotEqual(t, crypto.Hash(txABBytes), crypto.Hash(txACBytes))
+
+	txAB := new(lib.Transaction)
+	require.NoError(t, lib.Unmarshal(txABBytes, txAB))
+	require.NoError(t, sm.store.(lib.StoreI).IndexTx(&lib.TxResult{
+		Sender:      address.Bytes(),
+		Recipient:   recipient.Bytes(),
+		MessageType: MessageSendName,
+		Height:      sm.Height() - 1,
+		Index:       0,
+		Transaction: txAB,
+		TxHash:      crypto.HashString(txABBytes),
+	}))
+
+	_, err := sm.CheckTx(txACBytes, crypto.HashString(txACBytes), nil)
+	require.ErrorContains(t, err, "is a duplicate")
+}
+
+func newAlternateMultisigSendTransactions(
+	t *testing.T,
+	sm StateMachine,
+) (address, recipient crypto.AddressI, txAB, txAC []byte) {
+	t.Helper()
 	signers := newTestKeyGroups(t, 3)
 	sort.Slice(signers, func(i, j int) bool {
 		return bytes.Compare(signers[i].PublicKey.Bytes(), signers[j].PublicKey.Bytes()) < 0
 	})
-	points := make([]kyber.Point, 0, len(signers))
-	for _, kg := range signers {
-		point, err := crypto.BytesToBLS12381Point(kg.PublicKey.Bytes())
+	points := make([]kyber.Point, len(signers))
+	for i, signer := range signers {
+		point, err := crypto.BytesToBLS12381Point(signer.PublicKey.Bytes())
 		require.NoError(t, err)
-		points = append(points, point)
+		points[i] = point
 	}
 
-	multiKey, err := crypto.NewAccountAuthMultiBLSFromPoints(points, nil, 2)
+	accountKey, err := crypto.NewAccountAuthMultiBLSFromPoints(points, nil, 2)
 	require.NoError(t, err)
-
+	address = accountKey.Address()
+	recipient = newTestAddress(t, 4)
 	msg := &MessageSend{
-		FromAddress: multiKey.Address().Bytes(),
-		ToAddress:   newTestAddressBytes(t, 4),
-		Amount:      100,
+		FromAddress: address.Bytes(),
+		ToAddress:   recipient.Bytes(),
+		Amount:      5,
 	}
-	a, err := lib.NewAny(msg)
+	anyMsg, err := lib.NewAny(msg)
 	require.NoError(t, err)
-
-	tx := &lib.Transaction{
+	base := &lib.Transaction{
 		MessageType:   msg.Name(),
-		Msg:           a,
+		Msg:           anyMsg,
 		CreatedHeight: sm.Height(),
 		Time:          uint64(time.Now().UnixMicro()),
 		Fee:           1,
 		NetworkId:     uint64(sm.NetworkID),
 		ChainId:       sm.Config.ChainId,
 	}
-	signBytes, err := tx.GetSignBytes()
+	signBytes, err := base.GetSignBytes()
 	require.NoError(t, err)
 
-	require.NoError(t, multiKey.AddSigner(signers[0].PrivateKey.Sign(signBytes), 0))
-	require.NoError(t, multiKey.AddSigner(signers[2].PrivateKey.Sign(signBytes), 2))
-	aggregateSignature, err := multiKey.AggregateSignatures()
-	require.NoError(t, err)
-	tx.Signature = &lib.Signature{
-		PublicKey: multiKey.Bytes(),
-		Signature: aggregateSignature,
+	makeEnvelope := func(indices ...int) []byte {
+		multiKey, keyErr := crypto.NewAccountAuthMultiBLSFromPoints(points, nil, 2)
+		require.NoError(t, keyErr)
+		for _, index := range indices {
+			require.NoError(t, multiKey.AddSigner(signers[index].PrivateKey.Sign(signBytes), index))
+		}
+		aggregate, aggregateErr := multiKey.AggregateSignatures()
+		require.NoError(t, aggregateErr)
+		tx := proto.Clone(base).(*lib.Transaction)
+		tx.Signature = &lib.Signature{PublicKey: multiKey.Bytes(), Signature: aggregate}
+		encoded, marshalErr := lib.Marshal(tx)
+		require.NoError(t, marshalErr)
+		return encoded
 	}
-
-	txBytes, err := lib.Marshal(tx)
-	require.NoError(t, err)
-
-	got, err := sm.CheckTx(txBytes, crypto.HashString(txBytes), nil)
-	require.NoError(t, err)
-	require.EqualExportedValues(t, tx, got.tx)
-	require.Equal(t, multiKey.Address().Bytes(), got.sender.Bytes())
-	gotMsg, ok := got.msg.(*MessageSend)
-	require.True(t, ok)
-	require.EqualExportedValues(t, msg, gotMsg)
+	return address, recipient, makeEnvelope(0, 1), makeEnvelope(0, 2)
 }
 
 func TestCheckTxRejectsReversedGovernanceRange(t *testing.T) {

--- a/lib/crypto/bls.go
+++ b/lib/crypto/bls.go
@@ -325,6 +325,13 @@ func NewMultiBLSFromPublicKey(publicKey []byte) (MultiPublicKeyI, error) {
 	if len(mpk.PublicKeys) == 0 || len(mpk.Bitmap) == 0 || mpk.Threshold > uint32(len(mpk.PublicKeys)) {
 		return nil, errInvalidPK
 	}
+	if mpk.Threshold > 0 {
+		for i := 1; i < len(mpk.PublicKeys); i++ {
+			if bytes.Compare(mpk.PublicKeys[i-1], mpk.PublicKeys[i]) >= 0 {
+				return nil, errInvalidPK
+			}
+		}
+	}
 	// Reject unused bits because kyber ignores them during verification.
 	if remainder := len(mpk.PublicKeys) % 8; remainder != 0 {
 		paddingMask := byte(0xff << remainder)

--- a/lib/crypto/bls.go
+++ b/lib/crypto/bls.go
@@ -322,6 +322,13 @@ func NewMultiBLSFromPublicKey(publicKey []byte) (MultiPublicKeyI, error) {
 	if len(mpk.PublicKeys) == 0 || len(mpk.Bitmap) == 0 || mpk.Threshold > uint32(len(mpk.PublicKeys)) {
 		return nil, errInvalidPK
 	}
+	// Reject unused bits because kyber ignores them during verification.
+	if remainder := len(mpk.PublicKeys) % 8; remainder != 0 {
+		paddingMask := byte(0xff << remainder)
+		if mpk.Bitmap[len(mpk.Bitmap)-1]&paddingMask != 0 {
+			return nil, errInvalidPK
+		}
+	}
 	var points []kyber.Point
 	seen := make(map[string]struct{}, len(mpk.PublicKeys))
 	// convert to a kyber.point
@@ -343,7 +350,12 @@ func NewMultiBLSFromPublicKey(publicKey []byte) (MultiPublicKeyI, error) {
 	if err = mask.SetMask(mpk.Bitmap); err != nil {
 		return nil, err
 	}
-	return newBLSMultiPublicKey(mask, mpk.Threshold), nil
+	key := newBLSMultiPublicKey(mask, mpk.Threshold)
+	// Reject semantically equivalent protobuf encodings that would produce different transaction hashes.
+	if !bytes.Equal(publicKey, key.Bytes()) {
+		return nil, errInvalidPK
+	}
+	return key, nil
 }
 
 // NewAccountAuthMultiBLSFromPublicKey creates a serialized multisig public key intended for account authorization.
@@ -445,7 +457,7 @@ func (b *BLS12381MultiPublicKey) Bytes() []byte {
 	for _, key := range b.mask.Publics() {
 		publicKeys = append(publicKeys, NewBLS12381PublicKey(key).Bytes())
 	}
-	bz, _ := proto.Marshal(&MultiPublicKey{
+	bz, _ := proto.MarshalOptions{Deterministic: true}.Marshal(&MultiPublicKey{
 		PublicKeys: publicKeys,
 		Bitmap:     b.Bitmap(),
 		Threshold:  b.threshold,

--- a/lib/crypto/bls.go
+++ b/lib/crypto/bls.go
@@ -178,6 +178,9 @@ func BytesToBLS12381Point(bz []byte) (kyber.Point, error) {
 	if err := point.UnmarshalBinary(bz); err != nil {
 		return nil, err
 	}
+	if point.Equal(newBLSSuite().G1().Point().Null()) {
+		return nil, errors.New("invalid bls public key: point at infinity")
+	}
 	return point, nil
 }
 

--- a/lib/crypto/bls_test.go
+++ b/lib/crypto/bls_test.go
@@ -5,6 +5,7 @@ import (
 	"github.com/drand/kyber"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/proto"
+	"sort"
 	"testing"
 )
 
@@ -125,7 +126,13 @@ func TestMultiBLSThresholdEnforcedByVerifyBytes(t *testing.T) {
 		var err error
 		keys[i], err = NewBLS12381PrivateKey()
 		require.NoError(t, err)
+	}
+	sort.Slice(keys, func(i, j int) bool {
+		return bytes.Compare(keys[i].PublicKey().Bytes(), keys[j].PublicKey().Bytes()) < 0
+	})
+	for i := range keys {
 		publicKeys[i] = keys[i].PublicKey().Bytes()
+		var err error
 		points[i], err = BytesToBLS12381Point(publicKeys[i])
 		require.NoError(t, err)
 	}
@@ -175,6 +182,13 @@ func TestAccountAuthMultiBLSConstructorsRequirePositiveThreshold(t *testing.T) {
 	_, err := NewAccountAuthMultiBLSFromPoints(points, nil, 0)
 	require.ErrorIs(t, err, errAccountAuthThreshold)
 
+	sort.Slice(points, func(i, j int) bool {
+		left, leftErr := points[i].MarshalBinary()
+		require.NoError(t, leftErr)
+		right, rightErr := points[j].MarshalBinary()
+		require.NoError(t, rightErr)
+		return bytes.Compare(left, right) < 0
+	})
 	accountAuthKey, err := NewAccountAuthMultiBLSFromPoints(points, nil, 2)
 	require.NoError(t, err)
 	require.Equal(t, uint32(2), accountAuthKey.(*BLS12381MultiPublicKey).Threshold())
@@ -187,6 +201,16 @@ func TestAccountAuthMultiBLSConstructorsRequirePositiveThreshold(t *testing.T) {
 	require.NoError(t, err)
 	_, err = NewAccountAuthMultiBLSFromPublicKey(consensusStyleKey.(*BLS12381MultiPublicKey).Bytes())
 	require.ErrorIs(t, err, errAccountAuthThreshold)
+
+	reversed := accountAuthKey.PublicKeys()
+	encoded, err := proto.MarshalOptions{Deterministic: true}.Marshal(&MultiPublicKey{
+		PublicKeys: [][]byte{reversed[2].Bytes(), reversed[1].Bytes(), reversed[0].Bytes()},
+		Bitmap:     accountAuthKey.Bitmap(),
+		Threshold:  2,
+	})
+	require.NoError(t, err)
+	_, err = NewMultiBLSFromPublicKey(encoded)
+	require.Error(t, err)
 }
 
 func TestBLSRejectsPointAtInfinity(t *testing.T) {

--- a/lib/crypto/bls_test.go
+++ b/lib/crypto/bls_test.go
@@ -83,7 +83,8 @@ func TestMultiBLSBytesRoundTripPreservesOrderAndBitmap(t *testing.T) {
 	require.NoError(t, multiKey.AddSigner(keys[1].Sign([]byte("hello")), 0))
 	require.NoError(t, multiKey.AddSigner(keys[0].Sign([]byte("hello")), 2))
 
-	roundTrip, err := NewMultiBLSFromPublicKey(multiKey.(*BLS12381MultiPublicKey).Bytes())
+	canonical := multiKey.(*BLS12381MultiPublicKey).Bytes()
+	roundTrip, err := NewMultiBLSFromPublicKey(canonical)
 	require.NoError(t, err)
 
 	originalPublicKeys := multiKey.PublicKeys()
@@ -101,6 +102,18 @@ func TestMultiBLSBytesRoundTripPreservesOrderAndBitmap(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, enabled, roundTripEnabled)
 	}
+
+	var encoded MultiPublicKey
+	require.NoError(t, proto.Unmarshal(canonical, &encoded))
+	encoded.Bitmap[0] |= 0x80
+	paddingVariant, err := proto.Marshal(&encoded)
+	require.NoError(t, err)
+	_, err = NewMultiBLSFromPublicKey(paddingVariant)
+	require.Error(t, err)
+
+	unknownFieldVariant := append(bytes.Clone(canonical), 0x78, 0x01)
+	_, err = NewMultiBLSFromPublicKey(unknownFieldVariant)
+	require.Error(t, err)
 }
 
 func TestMultiBLSThresholdEnforcedByVerifyBytes(t *testing.T) {

--- a/lib/crypto/bls_test.go
+++ b/lib/crypto/bls_test.go
@@ -188,3 +188,20 @@ func TestAccountAuthMultiBLSConstructorsRequirePositiveThreshold(t *testing.T) {
 	_, err = NewAccountAuthMultiBLSFromPublicKey(consensusStyleKey.(*BLS12381MultiPublicKey).Bytes())
 	require.ErrorIs(t, err, errAccountAuthThreshold)
 }
+
+func TestBLSRejectsPointAtInfinity(t *testing.T) {
+	infinity, err := newBLSSuite().G1().Point().Null().MarshalBinary()
+	require.NoError(t, err)
+
+	_, err = BytesToBLS12381Public(infinity)
+	require.Error(t, err)
+
+	encoded, err := proto.MarshalOptions{Deterministic: true}.Marshal(&MultiPublicKey{
+		PublicKeys: [][]byte{infinity},
+		Bitmap:     []byte{1},
+		Threshold:  1,
+	})
+	require.NoError(t, err)
+	_, err = NewMultiBLSFromPublicKey(encoded)
+	require.Error(t, err)
+}

--- a/lib/crypto/key_batch.go
+++ b/lib/crypto/key_batch.go
@@ -3,6 +3,7 @@ package crypto
 import (
 	"context"
 	"crypto/rand"
+	"encoding/binary"
 	"fmt"
 	"github.com/allegro/bigcache/v3"
 	oasisEd25519 "github.com/oasisprotocol/curve25519-voi/primitives/ed25519"
@@ -202,16 +203,12 @@ func (bt *BatchTuple) Key() string {
 	pk := bt.PublicKey.Bytes()
 	// calculate the total length of the key
 	totalLen := len(pk) + len(bt.Message) + len(bt.Signature)
-	// create the buffer and offset variables
-	b, offset := make([]byte, totalLen), 0
-	// copy pubkey in first part
-	copy(b[offset:], pk)
-	offset += len(pk)
-	// copy message in second part
-	copy(b[offset:], bt.Message)
-	offset += len(bt.Message)
-	// copy signature in third part
-	copy(b[offset:], bt.Signature)
+	// length-prefix each part so bytes cannot move across component boundaries
+	b := make([]byte, 0, totalLen+3*binary.MaxVarintLen64)
+	for _, part := range [][]byte{pk, bt.Message, bt.Signature} {
+		b = binary.AppendUvarint(b, uint64(len(part)))
+		b = append(b, part...)
+	}
 	// return string version
 	return string(b)
 }

--- a/lib/crypto/key_batch_test.go
+++ b/lib/crypto/key_batch_test.go
@@ -43,6 +43,15 @@ func TestBatchVerifierAcceptsSerializedMultiBLSKey(t *testing.T) {
 	require.Equal(t, []int(nil), b.Verify())
 }
 
+func TestBatchTupleKeySeparatesComponents(t *testing.T) {
+	key, err := NewEd25519PrivateKey()
+	require.NoError(t, err)
+	signature := key.Sign([]byte("message"))
+	original := BatchTuple{PublicKey: key.PublicKey(), Message: []byte("message"), Signature: signature}
+	shifted := BatchTuple{PublicKey: key.PublicKey(), Message: append([]byte("message"), signature[0]), Signature: signature[1:]}
+	require.NotEqual(t, original.Key(), shifted.Key())
+}
+
 func TestKeyBatchFuzz(t *testing.T) {
 	for i := 0; i < 100; i++ {
 		b := NewBatchVerifier()

--- a/lib/tx.go
+++ b/lib/tx.go
@@ -26,6 +26,9 @@ const (
 	EventsPageName         = "events-page"
 )
 
+// multisigIntentDomainV1 separates threshold-multisig intent IDs from other hashes.
+const multisigIntentDomainV1 byte = 0x01
+
 // Messages must be pre-registered for Transaction JSON unmarshalling
 var RegisteredMessages map[string]MessageI
 
@@ -161,6 +164,37 @@ func (x *Transaction) GetSignBytes() ([]byte, ErrorI) {
 		ChainId:       x.ChainId,
 		Nonce:         x.Nonce,
 	})
+}
+
+// GetMultisigIntentID returns a stable replay identifier for a threshold-BLS
+// transaction. The identifier intentionally excludes the signer bitmap and aggregate
+// signature so alternate valid signer subsets produce the same ID.
+//
+// Layout: SHA-256(0x01 || multisig account address || SHA-256(canonical sign bytes)).
+// A nil ID means the transaction does not use a threshold-BLS account key.
+func (x *Transaction) GetMultisigIntentID() ([]byte, ErrorI) {
+	if x == nil || x.Signature == nil || len(x.Signature.PublicKey) == 0 {
+		return nil, nil
+	}
+	publicKey, err := PublicKeyFromBytes(x.Signature.PublicKey)
+	if err != nil {
+		return nil, err
+	}
+	multiKey, ok := publicKey.(*crypto.BLS12381MultiPublicKey)
+	if !ok || multiKey.Threshold() == 0 {
+		return nil, nil
+	}
+	signBytes, err := x.GetSignBytes()
+	if err != nil {
+		return nil, err
+	}
+	address := multiKey.Address().Bytes()
+	signHash := crypto.Hash(signBytes)
+	preimage := make([]byte, 1+len(address)+len(signHash))
+	preimage[0] = multisigIntentDomainV1
+	copy(preimage[1:], address)
+	copy(preimage[1+len(address):], signHash)
+	return crypto.Hash(preimage), nil
 }
 
 // Sign() executes a digital signature on the transaction

--- a/lib/tx_test.go
+++ b/lib/tx_test.go
@@ -1,12 +1,15 @@
 package lib
 
 import (
+	"bytes"
 	"encoding/json"
+	"sort"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/canopy-network/canopy/lib/crypto"
+	"github.com/drand/kyber"
 	"github.com/stretchr/testify/require"
 )
 
@@ -14,6 +17,74 @@ func TestTransactionNonceUsesProtocolFieldNumber(t *testing.T) {
 	field := new(Transaction).ProtoReflect().Descriptor().Fields().ByName("nonce")
 	require.NotNil(t, field)
 	require.EqualValues(t, 10, field.Number())
+}
+
+func TestMultisigIntentIDIgnoresSignerSubset(t *testing.T) {
+	keys := make([]crypto.PrivateKeyI, 3)
+	for i := range keys {
+		var err error
+		keys[i], err = crypto.NewBLS12381PrivateKey()
+		require.NoError(t, err)
+	}
+	sort.Slice(keys, func(i, j int) bool {
+		return bytes.Compare(keys[i].PublicKey().Bytes(), keys[j].PublicKey().Bytes()) < 0
+	})
+	points := make([]kyber.Point, len(keys))
+	for i := range keys {
+		var err error
+		points[i], err = crypto.BytesToBLS12381Point(keys[i].PublicKey().Bytes())
+		require.NoError(t, err)
+	}
+
+	makeTx := func(bitmap byte) *Transaction {
+		multiKey, err := crypto.NewAccountAuthMultiBLSFromPoints(points, []byte{bitmap}, 2)
+		require.NoError(t, err)
+		msg, err := NewAny(&Signature{})
+		require.NoError(t, err)
+		return &Transaction{
+			MessageType:   "test",
+			Msg:           msg,
+			Signature:     &Signature{PublicKey: multiKey.Bytes(), Signature: []byte{bitmap}},
+			CreatedHeight: 2,
+			Time:          1,
+			Fee:           1,
+			NetworkId:     1,
+			ChainId:       1,
+		}
+	}
+
+	txAB, txAC := makeTx(0b00000011), makeTx(0b00000101)
+	idAB, err := txAB.GetMultisigIntentID()
+	require.NoError(t, err)
+	idAC, err := txAC.GetMultisigIntentID()
+	require.NoError(t, err)
+	require.Len(t, idAB, crypto.HashSize)
+	require.Equal(t, idAB, idAC)
+	publicKey, err := PublicKeyFromBytes(txAB.Signature.PublicKey)
+	require.NoError(t, err)
+	signBytes, err := txAB.GetSignBytes()
+	require.NoError(t, err)
+	preimage := append([]byte{multisigIntentDomainV1}, publicKey.Address().Bytes()...)
+	preimage = append(preimage, crypto.Hash(signBytes)...)
+	require.Equal(t, crypto.Hash(preimage), idAB)
+
+	otherPolicy, keyErr := crypto.NewAccountAuthMultiBLSFromPoints(points, []byte{0b00000111}, 3)
+	require.NoError(t, keyErr)
+	txOtherPolicy := makeTx(0b00000111)
+	txOtherPolicy.Signature.PublicKey = otherPolicy.Bytes()
+	otherPolicyID, err := txOtherPolicy.GetMultisigIntentID()
+	require.NoError(t, err)
+	require.NotEqual(t, idAB, otherPolicyID)
+
+	txAC.Fee++
+	changedID, err := txAC.GetMultisigIntentID()
+	require.NoError(t, err)
+	require.NotEqual(t, idAB, changedID)
+
+	txAB.Signature.PublicKey = keys[0].PublicKey().Bytes()
+	notMultisig, err := txAB.GetMultisigIntentID()
+	require.NoError(t, err)
+	require.Nil(t, notMultisig)
 }
 
 func TestTransactionCheckBasic(t *testing.T) {

--- a/lib/util.go
+++ b/lib/util.go
@@ -329,6 +329,12 @@ func Unmarshal(protoBytes []byte, ptr any) ErrorI {
 		if err := rejectUnknownForCriticalMessages(msg); err != nil {
 			return ErrUnmarshal(err)
 		}
+		if _, ok := msg.(*Transaction); ok {
+			canonical, err := marshaller.Marshal(msg)
+			if err != nil || !bytes.Equal(protoBytes, canonical) {
+				return ErrUnmarshal(fmt.Errorf("non-canonical transaction encoding"))
+			}
+		}
 	}
 	// exit
 	return nil

--- a/lib/util_test.go
+++ b/lib/util_test.go
@@ -493,7 +493,7 @@ func TestUnmarshalRejectsUnknownBlockFields(t *testing.T) {
 	require.NoError(t, Unmarshal(bz, &Block{}))
 }
 
-func TestUnmarshalRejectsUnknownTransactionFields(t *testing.T) {
+func TestUnmarshalRejectsNonCanonicalTransaction(t *testing.T) {
 	tx := &Transaction{
 		MessageType:   "noop",
 		Msg:           &anypb.Any{},
@@ -508,6 +508,10 @@ func TestUnmarshalRejectsUnknownTransactionFields(t *testing.T) {
 
 	withUnknown := appendUnknownField(bz)
 	err = Unmarshal(withUnknown, &Transaction{})
+	require.Error(t, err)
+	withDuplicateTime := protowire.AppendTag(append([]byte(nil), bz...), 5, protowire.VarintType)
+	withDuplicateTime = protowire.AppendVarint(withDuplicateTime, tx.Time)
+	err = Unmarshal(withDuplicateTime, &Transaction{})
 	require.Error(t, err)
 
 	require.NoError(t, Unmarshal(bz, &Transaction{}))

--- a/p2p/conn.go
+++ b/p2p/conn.go
@@ -399,9 +399,9 @@ func (c *MultiConn) waitForAndHandleWireBytes(m *limiter.Monitor) (proto.Message
 	// restrict the instantaneous data flow to rate bytes per second
 	// Limit() request maxPacketSize bytes from the limiter and the limiter
 	// will block the execution until at or below the desired rate of flow
-	//m.Limit(int(maxPacketSize), int64(dataFlowRatePerS), true)
+	m.Limit(int(maxPacketSize), int64(dataFlowRatePerS), true)
 	// read the proto message from the wire
-	_, err := receiveProtoMsg(c.conn, msg)
+	lenM, err := receiveProtoMsg(c.conn, msg)
 	if err != nil {
 		return nil, err
 	}
@@ -409,7 +409,7 @@ func (c *MultiConn) waitForAndHandleWireBytes(m *limiter.Monitor) (proto.Message
 		c.p2p.metrics.ReceiveWireTime.Observe(time.Since(receiveStart).Seconds())
 	}
 	// update the limiter
-	//m.Update(lenM)
+	m.Update(lenM)
 	// unmarshal the payload from proto.any
 	return lib.FromAny(msg.Payload)
 }

--- a/store/indexer.go
+++ b/store/indexer.go
@@ -462,8 +462,16 @@ func indexedTxHashes(result *lib.TxResult) ([][]byte, lib.ErrorI) {
 		return nil, err
 	}
 	hashes := [][]byte{hash}
-	if ethHash := ethTxHash(result.Transaction); len(ethHash) != 0 && !bytes.Equal(ethHash, hash) {
+	ethHash := ethTxHash(result.Transaction)
+	if len(ethHash) != 0 && !bytes.Equal(ethHash, hash) {
 		hashes = append(hashes, ethHash)
+	}
+	intentID, err := result.Transaction.GetMultisigIntentID()
+	if err != nil {
+		return nil, err
+	}
+	if len(intentID) != 0 && !bytes.Equal(intentID, hash) && !bytes.Equal(intentID, ethHash) {
+		hashes = append(hashes, intentID)
 	}
 	return hashes, nil
 }

--- a/store/indexer_test.go
+++ b/store/indexer_test.go
@@ -4,11 +4,13 @@ import (
 	"bytes"
 	"encoding/hex"
 	"math/big"
+	"sort"
 	"testing"
 	"time"
 
 	"github.com/canopy-network/canopy/lib"
 	"github.com/canopy-network/canopy/lib/crypto"
+	"github.com/drand/kyber"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	ethCrypto "github.com/ethereum/go-ethereum/crypto"
@@ -81,6 +83,33 @@ func TestDeleteTxsForHeightRemovesEthereumHashAlias(t *testing.T) {
 	require.True(t, got == nil || got.TxHash == "")
 }
 
+func TestMultisigIntentAliasIndexAndDelete(t *testing.T) {
+	store, _, cleanup := testStore(t)
+	defer cleanup()
+
+	txResult := newMultisigTxResult(t)
+	intentID, err := txResult.Transaction.GetMultisigIntentID()
+	require.NoError(t, err)
+	require.NotEmpty(t, intentID)
+	require.NotEqual(t, txResult.TxHash, lib.BytesToString(intentID))
+
+	require.NoError(t, store.IndexTx(txResult))
+	got, err := store.GetTxByHash(intentID)
+	require.NoError(t, err)
+	require.EqualExportedValues(t, txResult, got)
+
+	_, err = store.Commit()
+	require.NoError(t, err)
+	require.NoError(t, store.DeleteTxsForHeight(testHeight))
+
+	raw, err := store.Indexer.db.Get(store.txHashKey(intentID))
+	require.NoError(t, err)
+	got, err = store.GetTxByHash(intentID)
+	require.NoError(t, err)
+	require.Empty(t, raw)
+	require.True(t, got == nil || got.TxHash == "")
+}
+
 const ethGasPriceTestValue = 10_000_000_000
 
 func ptrAddress(address common.Address) *common.Address { return &address }
@@ -112,6 +141,34 @@ func newRLPBackedTxResult(t *testing.T) (*lib.TxResult, common.Hash) {
 		},
 		TxHash: hex.EncodeToString(protoHash),
 	}, ethTx.Hash()
+}
+
+func newMultisigTxResult(t *testing.T) *lib.TxResult {
+	keys := make([]crypto.PrivateKeyI, 3)
+	for i := range keys {
+		var err error
+		keys[i], err = crypto.NewBLS12381PrivateKey()
+		require.NoError(t, err)
+	}
+	sort.Slice(keys, func(i, j int) bool {
+		return bytes.Compare(keys[i].PublicKey().Bytes(), keys[j].PublicKey().Bytes()) < 0
+	})
+	points := make([]kyber.Point, len(keys))
+	for i, key := range keys {
+		point, err := crypto.BytesToBLS12381Point(key.PublicKey().Bytes())
+		require.NoError(t, err)
+		points[i] = point
+	}
+	multiKey, err := crypto.NewAccountAuthMultiBLSFromPoints(points, []byte{0b00000011}, 2)
+	require.NoError(t, err)
+	result, tx, _, _, _ := newTestTxResult(t)
+	tx.Signature = &lib.Signature{PublicKey: multiKey.Bytes(), Signature: []byte("aggregate")}
+	hash, err := tx.GetHash()
+	require.NoError(t, err)
+	result.Sender = multiKey.Address().Bytes()
+	result.Recipient = result.Sender
+	result.TxHash = lib.BytesToString(hash)
+	return result
 }
 
 func newTestTxResult(t *testing.T) (r *lib.TxResult, tx *lib.Transaction, hash []byte, msg *lib.CommitID, address crypto.AddressI) {


### PR DESCRIPTION
## Summary

- require canonical encoding for transaction envelopes and multisig public keys
- reject unused multisig bitmap bits and alternate public-key representations
- reject BLS identity public keys and threshold-zero transaction multisigs
- add regression coverage for noncanonical and invalid encodings

## Testing

- go test ./lib ./lib/crypto ./fsm ./store
- go test -race ./lib/crypto -run '^TestBLSRejectsPointAtInfinity$' -count=1
- go test -race ./fsm -run '^TestCheckSignatureRejectsThresholdZeroMultisig$' -count=1