### PR TITLE
Add a manual consensus round recovery endpoint

### DIFF
--- a/bft/bft.go
+++ b/bft/bft.go
@@ -43,6 +43,10 @@ type BFT struct {
 	round      atomic.Uint64 // atomic mirror of View.Round for external readers
 	deadlineMs atomic.Int64  // atomic proposal vote mode deadline in unix milliseconds for external readers
 
+	forcedRound        uint64    // admin-scheduled round; 0 means none
+	forcedRoundAt      time.Time // earliest time at which forcedRound may be entered
+	forcedTimeoutRound *uint64   // pending/active timeout round override
+
 	PhaseTimer *time.Timer // ensures the node waits for a configured duration (Round x phaseTimeout) to allow for full voter participation
 
 	PublicKey    []byte             // self consensus public key
@@ -216,7 +220,9 @@ func (b *BFT) HandlePhase() {
 	case CommitProcess:
 		b.StartCommitProcessPhase()
 	case Pacemaker:
-		b.Pacemaker()
+		if !b.Pacemaker() {
+			return
+		}
 	}
 	// after each phase, set the timers for the next phase
 	b.SetTimerForNextPhase(time.Since(startTime))
@@ -570,9 +576,22 @@ func (b *BFT) RoundInterrupt() {
 
 // Pacemaker() begins the Pacemaker process after ROUND-INTERRUPT timeout occurs
 // - sets the highest round that +2/3rds majority of replicas have seen
-func (b *BFT) Pacemaker() {
+func (b *BFT) Pacemaker() bool {
 	b.log.Info(b.View.ToString())
+	forcedRound := b.forcedRound
+	if forcedRound != 0 {
+		if wait := time.Until(b.forcedRoundAt); wait > 0 {
+			b.SetWaitTimers(wait, 0)
+			return false
+		}
+		b.Round = forcedRound - 1
+		b.forcedRound = 0
+	}
 	b.NewRound(false)
+	if forcedRound != 0 {
+		b.log.Warnf("Forced consensus round to %d", b.Round)
+		return true
+	}
 	// sort the pacemaker votes from the highest Round to the lowest Round
 	var sortedVotes []*Message
 	for _, vote := range b.PacemakerMessages {
@@ -602,6 +621,23 @@ func (b *BFT) Pacemaker() {
 		b.Round = pacemakerRound
 		b.round.Store(b.Round)
 	}
+	return true
+}
+
+// ScheduleForceRound enters the exact target round at the first pacemaker
+// boundary at or after at. The caller must hold the Controller lock.
+func (b *BFT) ScheduleForceRound(round uint64, at time.Time, timeoutRound *uint64) error {
+	if round <= b.Round {
+		return fmt.Errorf("target round %d must be greater than current round %d", round, b.Round)
+	}
+	b.forcedRound = round
+	b.forcedRoundAt = at
+	b.forcedTimeoutRound = timeoutRound
+	b.log.Warnf("Scheduled forced consensus round %d at %s", round, at.Format(time.RFC3339Nano))
+	if b.Phase == Pacemaker {
+		b.SetWaitTimers(time.Until(at), 0)
+	}
+	return nil
 }
 
 // PacemakerMessages is a collection of 'View' messages keyed by each Replica's public key
@@ -683,6 +719,9 @@ func (b *BFT) RefreshRootChainInfo() {
 
 // NewHeight() initializes / resets consensus variables preparing for the NewHeight
 func (b *BFT) NewHeight(keepLocks ...bool) {
+	// A force-round recovery is scoped to the height on which it was requested.
+	b.forcedRound = 0
+	b.forcedTimeoutRound = nil
 	// reset VotesForHeight
 	b.Votes = make(VotesForHeight)
 	// reset ProposalsForHeight
@@ -750,6 +789,9 @@ func (b *BFT) SetTimerForNextPhase(processTime time.Duration) {
 
 // WaitTime() returns the wait time (wait and receive consensus messages) for a specific Phase.Round
 func (b *BFT) WaitTime(phase Phase, round uint64) (waitTime time.Duration) {
+	if b.forcedRound == 0 && b.forcedTimeoutRound != nil {
+		round = *b.forcedTimeoutRound
+	}
 	switch phase {
 	case Election:
 		waitTime = b.waitTime(b.Config.ElectionTimeoutMS, round)

--- a/bft/bft_test.go
+++ b/bft/bft_test.go
@@ -745,6 +745,32 @@ func TestPacemaker(t *testing.T) {
 	}
 }
 
+func TestScheduleForceRound(t *testing.T) {
+	c := newTestConsensus(t, Election, 1)
+	c.bft.Round = 2
+	c.bft.round.Store(2)
+	lockedQC := &QC{}
+	c.bft.HighQC = lockedQC
+
+	timeoutRound := uint64(0)
+	require.NoError(t, c.bft.ScheduleForceRound(7, time.Now().Add(time.Hour), &timeoutRound))
+	c.bft.Phase = Pacemaker
+	c.bft.HandlePhase()
+	require.Equal(t, Pacemaker, c.bft.Phase)
+	require.Equal(t, uint64(2), c.bft.Round)
+
+	require.NoError(t, c.bft.ScheduleForceRound(7, time.Now(), &timeoutRound))
+	c.bft.HandlePhase()
+	require.Equal(t, uint64(7), c.bft.CurrentRound())
+	require.Equal(t, Election, c.bft.Phase)
+	require.Same(t, lockedQC, c.bft.HighQC)
+	require.Equal(t, time.Duration(c.bft.Config.ElectionTimeoutMS)*time.Millisecond, c.bft.WaitTime(Election, c.bft.Round+1))
+	require.Error(t, c.bft.ScheduleForceRound(7, time.Now(), nil))
+	c.bft.NewHeight()
+	require.Nil(t, c.bft.forcedTimeoutRound)
+	c.bft.PhaseTimer.Stop()
+}
+
 func TestPhaseHas23Maj(t *testing.T) {
 	c := newTestConsensus(t, Propose, 3)
 	// 75% votes

--- a/cmd/rpc/admin.go
+++ b/cmd/rpc/admin.go
@@ -529,6 +529,27 @@ func (s *Server) ConsensusInfo(w http.ResponseWriter, r *http.Request, _ httprou
 	}
 }
 
+// ConsensusForceRound schedules coordinated recovery at the next pacemaker.
+func (s *Server) ConsensusForceRound(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
+	request := new(struct {
+		Round        uint64  `json:"round"`
+		TimeoutRound *uint64 `json:"timeoutRound,omitempty"`
+		UnixTimeMS   int64   `json:"unixTimeMS"`
+	})
+	if !unmarshal(w, r, request) {
+		return
+	}
+
+	s.controller.Lock()
+	err := s.controller.Consensus.ScheduleForceRound(request.Round, time.UnixMilli(request.UnixTimeMS), request.TimeoutRound)
+	s.controller.Unlock()
+	if err != nil {
+		write(w, lib.NewError(lib.NoCode, lib.RPCModule, err.Error()), http.StatusBadRequest)
+		return
+	}
+	write(w, request, http.StatusOK)
+}
+
 // PeerInfo retrieves node peer information
 func (s *Server) PeerInfo(w http.ResponseWriter, _ *http.Request, _ httprouter.Params) {
 	peers, numInbound, numOutbound := s.controller.P2P.GetAllInfos()

--- a/cmd/rpc/routes.go
+++ b/cmd/rpc/routes.go
@@ -96,6 +96,7 @@ const (
 	ResourceUsageRoutePath     = "/v1/admin/resource-usage"
 	PeerInfoRoutePath          = "/v1/admin/peer-info"
 	ConsensusInfoRoutePath     = "/v1/admin/consensus-info"
+	ForceRoundRoutePath        = "/v1/admin/consensus-force-round"
 	PeerBookRoutePath          = "/v1/admin/peer-book"
 	ConfigRoutePath            = "/v1/admin/config"
 	LogsRoutePath              = "/v1/admin/log"
@@ -195,6 +196,7 @@ const (
 	ResourceUsageRouteName          = "resource-usage"
 	PeerInfoRouteName               = "peer-info"
 	ConsensusInfoRouteName          = "consensus-info"
+	ForceRoundRouteName             = "consensus-force-round"
 	PeerBookRouteName               = "peer-book"
 	ConfigRouteName                 = "config"
 	LogsRouteName                   = "logs"
@@ -297,6 +299,7 @@ var routePaths = routes{
 	ResourceUsageRouteName:          {Method: http.MethodGet, Path: ResourceUsageRoutePath},
 	PeerInfoRouteName:               {Method: http.MethodGet, Path: PeerInfoRoutePath},
 	ConsensusInfoRouteName:          {Method: http.MethodGet, Path: ConsensusInfoRoutePath},
+	ForceRoundRouteName:             {Method: http.MethodPost, Path: ForceRoundRoutePath},
 	PeerBookRouteName:               {Method: http.MethodGet, Path: PeerBookRoutePath},
 	ConfigRouteName:                 {Method: http.MethodGet, Path: ConfigRoutePath},
 	LogsRouteName:                   {Method: http.MethodGet, Path: LogsRoutePath},
@@ -415,6 +418,7 @@ func createAdminRouter(s *Server) *httprouter.Router {
 		ResourceUsageRouteName:          s.ResourceUsage,
 		PeerInfoRouteName:               s.PeerInfo,
 		ConsensusInfoRouteName:          s.ConsensusInfo,
+		ForceRoundRouteName:             s.ConsensusForceRound,
 		PeerBookRouteName:               s.PeerBook,
 		ConfigRouteName:                 s.Config,
 		LogsRouteName:                   logsHandler(s),


### PR DESCRIPTION
Sometimes validators can get stuck at different rounds and need a small nudge to line back up. This adds POST /v1/admin/consensus-force-round for that situation.

The call can be made during any consensus phase. The validator saves it until the next pacemaker boundary, waits for unixTimeMS if it is in the future, then enters the requested round. The command is one-shot, so if that round does not reach consensus the normal pacemaker flow keeps going.

There is also an optional timeoutRound. This lets us enter a high real round while calculating phase timers from a smaller round value. For example, timeoutRound: 0 uses the normal round-zero timings during recovery. The override sticks around for retries and clears at the next height.

Example request:

    {
      "round": 101,
      "timeoutRound": 0,
      "unixTimeMS": 1787500000000
    }

Tested with:

    go test -race ./bft ./cmd/rpc