### PR TITLE
fix: bound inbound transaction spam resources

### DIFF
--- a/lib/mempool.go
+++ b/lib/mempool.go
@@ -13,6 +13,11 @@ import (
 
 var _ Mempool = &FeeMempool{} // Mempool interface enforcement for FeeMempool implementation
 
+const (
+	failedTxCacheMaxEntries = 5000
+	failedTxCacheMaxTxBytes = 4 * 1024
+)
+
 // Mempool interface is a model for a pre-block, in-memory, Transaction store
 type Mempool interface {
 	Contains(txHash string) bool                             // whether the mempool has this transaction already (de-duplicated by hash)
@@ -376,6 +381,15 @@ func (f *FailedTxCache) Add(failed *FailedTx) (added bool) {
 	f.l.Lock()
 	// unlock when the function completes
 	defer f.l.Unlock()
+	if failed == nil || len(failed.bytes) > failedTxCacheMaxTxBytes {
+		return false
+	}
+	if _, exists := f.cache[failed.Hash]; !exists && len(f.cache) >= failedTxCacheMaxEntries {
+		for hash := range f.cache {
+			delete(f.cache, hash)
+			break
+		}
+	}
 	// add a new 'failed tx' type to the cache
 	f.cache[failed.Hash] = failed
 	// exit with 'added'

--- a/lib/mempool_test.go
+++ b/lib/mempool_test.go
@@ -597,3 +597,14 @@ func TestFailedTxCacheGetFailedForAddressEmptyReturnsAll(t *testing.T) {
 	// an empty address returns every failed tx in the cache, regardless of address
 	require.ElementsMatch(t, []*FailedTx{failedTx1, failedTx2}, cache.GetFailedForAddress(""))
 }
+
+func TestFailedTxCacheLimits(t *testing.T) {
+	cache := NewFailedTxCache()
+	for i := 0; i < failedTxCacheMaxEntries; i++ {
+		cache.cache[string(rune(i))] = &FailedTx{}
+	}
+	require.True(t, cache.Add(&FailedTx{Hash: "new"}))
+	require.Len(t, cache.cache, failedTxCacheMaxEntries)
+	require.Contains(t, cache.cache, "new")
+	require.False(t, cache.Add(&FailedTx{Hash: "oversized", bytes: make([]byte, failedTxCacheMaxTxBytes+1)}))
+}

--- a/lib/peer.go
+++ b/lib/peer.go
@@ -237,7 +237,7 @@ type peerInfoJSON struct {
 
 // MessageCache is a simple p2p message de-duplicator that protects redundancy in the p2p network
 type MessageCache struct {
-	queue   *list.List            // a FIFO list of MessageAndMetadata
+	queue   *list.List            // a FIFO list of message hashes
 	deDupe  *DeDuplicator[string] // the O(1) de-duplicator
 	maxSize int                   // the max size before evicting the oldest
 }
@@ -262,17 +262,13 @@ func (c *MessageCache) Add(msg *MessageAndMetadata) (ok bool) {
 		return false
 	}
 	// add the new message to the front
-	c.queue.PushFront(msg)
+	c.queue.PushFront(key)
 	// if the queue size is exceeded
 	if c.queue.Len() > c.maxSize {
 		// get the oldest element
 		e := c.queue.Back()
-		// cast it to a MessageAndMetadata
-		message := e.Value.(*MessageAndMetadata)
-		// create a key for the message
-		toDeleteKey := crypto.HashString(message.Message)
 		// delete it from the underlying de-duplicator
-		c.deDupe.Delete(toDeleteKey)
+		c.deDupe.Delete(e.Value.(string))
 		// remove it from the queue
 		c.queue.Remove(e)
 	}

--- a/lib/peer_test.go
+++ b/lib/peer_test.go
@@ -58,13 +58,9 @@ func TestMessageCacheAdd(t *testing.T) {
 			cache: MessageCache{
 				queue: func() (l *list.List) {
 					l = list.New()
-					l.PushFront(&MessageAndMetadata{
-						Message: func() []byte {
-							bz, err := Marshal(&StringWrapper{Value: "b"})
-							require.NoError(t, err)
-							return bz
-						}(),
-					})
+					bz, err := Marshal(&StringWrapper{Value: "b"})
+					require.NoError(t, err)
+					l.PushFront(crypto.HashString(bz))
 					return
 				}(),
 				deDupe: &DeDuplicator[string]{m: map[string]struct{}{
@@ -100,13 +96,9 @@ func TestMessageCacheAdd(t *testing.T) {
 			cache: MessageCache{
 				queue: func() (l *list.List) {
 					l = list.New()
-					l.PushFront(&MessageAndMetadata{
-						Message: func() []byte {
-							bz, err := Marshal(&StringWrapper{Value: "b"})
-							require.NoError(t, err)
-							return bz
-						}(),
-					})
+					bz, err := Marshal(&StringWrapper{Value: "b"})
+					require.NoError(t, err)
+					l.PushFront(crypto.HashString(bz))
 					return
 				}(),
 				deDupe: &DeDuplicator[string]{m: map[string]struct{}{

--- a/p2p/conn.go
+++ b/p2p/conn.go
@@ -399,9 +399,9 @@ func (c *MultiConn) waitForAndHandleWireBytes(m *limiter.Monitor) (proto.Message
 	// restrict the instantaneous data flow to rate bytes per second
 	// Limit() request maxPacketSize bytes from the limiter and the limiter
 	// will block the execution until at or below the desired rate of flow
-	//m.Limit(int(maxPacketSize), int64(dataFlowRatePerS), true)
+	m.Limit(int(maxPacketSize), int64(dataFlowRatePerS), true)
 	// read the proto message from the wire
-	_, err := receiveProtoMsg(c.conn, msg)
+	lenM, err := receiveProtoMsg(c.conn, msg)
 	if err != nil {
 		return nil, err
 	}
@@ -409,7 +409,7 @@ func (c *MultiConn) waitForAndHandleWireBytes(m *limiter.Monitor) (proto.Message
 		c.p2p.metrics.ReceiveWireTime.Observe(time.Since(receiveStart).Seconds())
 	}
 	// update the limiter
-	//m.Update(lenM)
+	m.Update(lenM)
 	// unmarshal the payload from proto.any
 	return lib.FromAny(msg.Payload)
 }

--- a/p2p/p2p.go
+++ b/p2p/p2p.go
@@ -9,6 +9,7 @@ import (
 	"slices"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/canopy-network/canopy/lib"
@@ -184,7 +185,7 @@ func (p *P2P) ListenForInboundPeers(listenAddress *lib.PeerAddress) {
 // DialForOutboundPeers() uses the config and peer book to try to max out the outbound peer connections
 func (p *P2P) DialForOutboundPeers() {
 	// create a tracking variable to ensure not 'over dialing'
-	dialing := 0
+	var dialing atomic.Int32
 	getPeerFromString := func(address string) (*lib.PeerAddress, error) {
 		// start a peer address structure using the basic configurations
 		peer := &lib.PeerAddress{PeerMeta: &lib.PeerMeta{NetworkId: p.meta.NetworkId, ChainId: p.meta.ChainId}}
@@ -207,7 +208,7 @@ func (p *P2P) DialForOutboundPeers() {
 		// dial in a non-blocking fashion
 		go func() {
 			// increment dialing
-			dialing++
+			dialing.Add(1)
 			// dial the peer with exponential backoff
 			p.DialWithBackoff(peerAddress, true)
 		}()
@@ -219,7 +220,7 @@ func (p *P2P) DialForOutboundPeers() {
 		func() {
 			// exit if maxed out config or none left to dial
 			outbound := p.PeerSet.outbound
-			if outbound > 0 && outbound+dialing >= p.config.MaxOutbound {
+			if outbound > 0 && outbound+int(dialing.Load()) >= p.config.MaxOutbound {
 				return
 			}
 			// try to get a peer to dial
@@ -243,8 +244,8 @@ func (p *P2P) DialForOutboundPeers() {
 			p.log.Debugf("Executing P2P Dial for more outbound peers")
 			// sequential operation means we'll never be dialing more than 1 peer at a time
 			// the peer should be added before the next execution of the loop
-			dialing++
-			defer func() { dialing-- }()
+			dialing.Add(1)
+			defer func() { dialing.Add(-1) }()
 			if err := p.Dial(peer, false, false); err != nil {
 				p.book.AddFailedDialAttempt(peer)
 				p.log.Debug(err.Error())


### PR DESCRIPTION
A few small changes to make inbound transaction spam less painful:

- turned the inbound P2P bandwidth limiter back on
- changed the message dedupe cache to keep hashes instead of full messages
- capped the failed transaction cache at 5,000 normal-sized transactions
- oversized failures still get removed from the mempool, they just won’t hang around for RPC display

This doesn’t change transaction validity, fee ordering, or consensus behavior.

Tested with `go test ./lib ./controller ./p2p`.