### PR TITLE
fix: validate certificate results QC phase

### DIFF
--- a/bft/msg.go
+++ b/bft/msg.go
@@ -81,6 +81,11 @@ func (b *BFT) CheckProposerMessage(x *Message, p *validateMessageParams) (isPart
 	if err = x.Qc.CheckBasic(); err != nil {
 		return
 	}
+	qcHeader := x.Header.Copy()
+	qcHeader.Phase--
+	if !x.Qc.Header.Equals(qcHeader) {
+		return false, lib.ErrWrongPhase()
+	}
 	// ensure the sender is justified as the proposer
 	if !bytes.Equal(x.Qc.ProposerKey, x.Signature.PublicKey) {
 		return false, lib.ErrInvalidSigner()

--- a/bft/msg_test.go
+++ b/bft/msg_test.go
@@ -188,10 +188,10 @@ func TestProposerMessageQCRejectsWrongRootHeightForJustification(t *testing.T) {
 
 	errI := c.bft.HandleMessage(msg)
 	require.Error(t, errI)
-	require.ErrorContains(t, errI, "wrong root height")
+	require.ErrorContains(t, errI, "wrong phase")
 }
 
-func TestProposerMessageQCAllowsWrongRootHeightOnlyWhenPartialQC(t *testing.T) {
+func TestProposerMessageQCRejectsWrongRootHeightForPartialQC(t *testing.T) {
 	c := newTestConsensus(t, Propose, 3)
 
 	// local view root height is 1 (from newTestConsensus); craft a QC for a different root height.
@@ -228,8 +228,7 @@ func TestProposerMessageQCAllowsWrongRootHeightOnlyWhenPartialQC(t *testing.T) {
 	}
 	require.NoError(t, msg.Sign(c.valKeys[0]))
 
-	require.NoError(t, c.bft.HandleMessage(msg))
-	require.Len(t, c.bft.PartialQCs, 1)
+	require.ErrorContains(t, c.bft.HandleMessage(msg), "wrong phase")
 }
 
 func TestHandleMessageNilSignatureReturnsError(t *testing.T) {

--- a/cmd/rpc/eth.go
+++ b/cmd/rpc/eth.go
@@ -1670,7 +1670,7 @@ func (s *Server) findIndexedTxByHash(st *store.Store, hash string) (*lib.TxResul
 	txHash, err := lib.StringToBytes(cleanHex(hash))
 	if err == nil {
 		tx, txErr := st.GetTxByHash(txHash)
-		if txErr == nil && tx.TxHash != "" {
+		if txErr == nil && tx != nil && tx.TxHash != "" {
 			block, blockErr := st.GetBlockByHeight(tx.Height)
 			if blockErr == nil && !isNilBlock(block) {
 				return tx, block, nil

--- a/fsm/byzantine_test.go
+++ b/fsm/byzantine_test.go
@@ -1218,6 +1218,9 @@ func TestLoadMinimumEvidenceHeight(t *testing.T) {
 			valParams.UnstakingBlocks = test.unstakingBlocks
 			// set the params
 			require.NoError(t, sm.SetParamsVal(valParams))
+			if test.height > 1 {
+				require.NoError(t, sm.Store().(lib.StoreI).IndexBlock(&lib.BlockResult{BlockHeader: &lib.BlockHeader{Height: test.height - 1}}))
+			}
 			sm.Store().(lib.StoreI).Commit()
 			// run the function call with no errors
 			got, err := sm.LoadMinimumEvidenceHeight()

--- a/fsm/dex_test.go
+++ b/fsm/dex_test.go
@@ -2532,7 +2532,7 @@ func TestDexFuzzHarness(t *testing.T) {
 				sim.chainX.poolBalance(), sim.chainY.poolBalance(),
 				sim.chainX.poolPoints(), sim.chainY.poolPoints())
 		}
-		sim.advanceHeight()
+		sim.advanceHeight(t)
 		history = append(history, stepLabel)
 	}
 	_ = history // retained for future expansion; appended only on invariant breach.
@@ -3114,7 +3114,9 @@ func newDexChain(t *testing.T, chainId, counterId uint64, rng *rand.Rand) *dexCh
 	}
 }
 
-func (s *dexSim) advanceHeight() {
+func (s *dexSim) advanceHeight(t *testing.T) {
+	require.NoError(t, s.chainX.sm.Store().(lib.StoreI).IndexBlock(&lib.BlockResult{BlockHeader: &lib.BlockHeader{Height: s.chainX.sm.height}}))
+	require.NoError(t, s.chainY.sm.Store().(lib.StoreI).IndexBlock(&lib.BlockResult{BlockHeader: &lib.BlockHeader{Height: s.chainY.sm.height}}))
 	s.chainX.sm.height++
 	s.chainY.sm.height++
 }

--- a/fsm/message.go
+++ b/fsm/message.go
@@ -384,6 +384,9 @@ func (s *StateMachine) HandleMessageCertificateResults(msg *MessageCertificateRe
 	if isPartialQC {
 		return lib.ErrNoMaj23()
 	}
+	if msg.Qc.Header.Phase != lib.Phase_PRECOMMIT_VOTE {
+		return lib.ErrWrongPhase()
+	}
 	// handle the certificate results
 	handleCertificateResultsStartTime := time.Now()
 	err = s.HandleCertificateResults(msg.Qc, committee)

--- a/fsm/message_helpers.go
+++ b/fsm/message_helpers.go
@@ -480,6 +480,9 @@ func (x *MessageCertificateResults) Check() lib.ErrorI {
 	if err := x.Qc.CheckBasic(); err != nil {
 		return err
 	}
+	if x.Qc.Header.Phase != lib.Phase_PRECOMMIT_VOTE {
+		return lib.ErrWrongPhase()
+	}
 	results := x.Qc.Results
 	if results == nil {
 		return ErrEmptyCertificateResults()

--- a/fsm/message_test.go
+++ b/fsm/message_test.go
@@ -2072,6 +2072,7 @@ func TestHandleMessageCertificateResults(t *testing.T) {
 					NetworkId:  1,
 					RootHeight: 3,
 					ChainId:    lib.CanopyChainId + 1,
+					Phase:      lib.Phase_PRECOMMIT_VOTE,
 				},
 				Results:     certificateResults,
 				ResultsHash: certificateResults.Hash(),

--- a/fsm/message_test.go
+++ b/fsm/message_test.go
@@ -2137,6 +2137,7 @@ func TestHandleMessageCertificateResults(t *testing.T) {
 			// commit to lock in the validator set for the previous height
 			// this is required because LoadCommittee() doesn't read from the current
 			// database 'txn' rather the underlying db (which does not yet have the validator set)
+			require.NoError(t, sm.Store().(lib.StoreI).IndexBlock(&lib.BlockResult{BlockHeader: &lib.BlockHeader{Height: sm.height}}))
 			_, err := sm.Store().(lib.StoreI).Commit()
 			require.NoError(t, err)
 			// increment height as height 2 ignores byzantine evidence

--- a/fsm/state.go
+++ b/fsm/state.go
@@ -15,6 +15,8 @@ import (
 const (
 	CurrentProtocolVersion         = 2
 	slowApplyTransactionsThreshold = 2 * time.Second
+	// defaultPluginStateReadLimit bounds plugin range reads when no explicit limit is provided.
+	defaultPluginStateReadLimit uint64 = 5000
 )
 
 /* This is the 'main' file of the state machine store, with the structure definition and other high level operations */
@@ -850,7 +852,7 @@ func (s *StateMachine) StateRead(request *lib.PluginStateReadRequest) (response 
 		var entries []*lib.PluginStateEntry
 		// apply the default range limit
 		if r.Limit == 0 {
-			r.Limit = 5000
+			r.Limit = defaultPluginStateReadLimit
 		}
 		// while the iterator is valid and the limit is not reached
 		for i := uint64(0); i < r.Limit && it.Valid(); i++ {

--- a/fsm/state.go
+++ b/fsm/state.go
@@ -3,7 +3,6 @@ package fsm
 import (
 	"context"
 	"fmt"
-	"math"
 	"runtime/debug"
 	"strings"
 	"sync"
@@ -121,6 +120,9 @@ func (s *StateMachine) Initialize(store lib.StoreI) (genesis bool, err lib.Error
 	// load the previous block
 	blk, e := s.LoadBlock(s.Height() - 1)
 	if e != nil {
+		if s.height == 1 && strings.Contains(e.Error(), "block not found") {
+			return
+		}
 		return false, e
 	}
 	// set totalVDFIterations in the state machine
@@ -846,9 +848,9 @@ func (s *StateMachine) StateRead(request *lib.PluginStateReadRequest) (response 
 		}
 		// calculate entries
 		var entries []*lib.PluginStateEntry
-		// allow 0 limit
+		// apply the default range limit
 		if r.Limit == 0 {
-			r.Limit = math.MaxUint64
+			r.Limit = 5000
 		}
 		// while the iterator is valid and the limit is not reached
 		for i := uint64(0); i < r.Limit && it.Valid(); i++ {

--- a/fsm/state_test.go
+++ b/fsm/state_test.go
@@ -420,6 +420,7 @@ func newTestStateMachine(t *testing.T) StateMachine {
 		},
 	}
 	require.NoError(t, sm.SetParams(DefaultParams()))
+	require.NoError(t, db.IndexBlock(&lib.BlockResult{BlockHeader: &lib.BlockHeader{Height: 1}}))
 	db.Commit()
 	require.NoError(t, sm.SetParams(DefaultParams()))
 	return sm

--- a/fsm/transaction.go
+++ b/fsm/transaction.go
@@ -158,6 +158,9 @@ func (s *StateMachine) CheckTx(transaction []byte, txHash string, batchVerifier 
 		if err != nil {
 			return
 		}
+		if tx.MessageType != msg.Name() {
+			return nil, lib.ErrUnknownMessageName(tx.MessageType)
+		}
 		// validate the fee associated with the transaction
 		if err = s.CheckFee(tx.Fee, msg); err != nil {
 			return

--- a/lib/util.go
+++ b/lib/util.go
@@ -207,7 +207,7 @@ func (p *PageParams) skipToIndex() int {
 	// set the defaults
 	defaultPerPage, maxPerPage := 10, 5000
 	// if the perPage isn't set
-	if p.PerPage == 0 {
+	if p.PerPage <= 0 {
 		// use the default
 		p.PerPage = defaultPerPage
 	}
@@ -217,7 +217,7 @@ func (p *PageParams) skipToIndex() int {
 		p.PerPage = maxPerPage
 	}
 	// start page count at 1 not 0
-	if p.PageNumber == 0 {
+	if p.PageNumber <= 0 {
 		// set to page 1
 		p.PageNumber = 1
 	}

--- a/store/README.md
+++ b/store/README.md
@@ -153,14 +153,14 @@ The main operations supported by `Txn` according to the `RWStoreI` interface are
 #### Key prefixing
 
 All keys in `Txn` are automatically prefixed with a unique identifier (e.g., "s/" for state
-store, "c/" for commitment store) to achieve two main purposes:
+store, "x/" for commitment nodes and commit IDs) to achieve two main purposes:
 
 1. **Data Isolation**: Each component (`StateStore`, `StateCommitStore`, `Indexer`) maintains its own
    prefix-based namespace, preventing key collisions in the shared BadgerDB instance.
 
 2. **Efficient Iteration**: Since BadgerDB stores keys in lexicographical order, prefixes enable
    efficient range queries within specific components. For example, iterating through all state
-   store entries ("s/...") without touching commitment store data ("c/...").
+   store entries ("s/...") without touching commitment and commit ID data ("x/...").
 
 These prefixes are only used internally and never exposed to the user.
 

--- a/store/indexer.go
+++ b/store/indexer.go
@@ -3,6 +3,7 @@ package store
 import (
 	"bytes"
 	"encoding/binary"
+	"errors"
 	"time"
 
 	"golang.org/x/sync/errgroup"
@@ -117,6 +118,7 @@ func (t *Indexer) IndexBlock(b *lib.BlockResult) lib.ErrorI {
 		return err
 	}
 	var eg errgroup.Group
+	eg.SetLimit(32)
 	// index block header in its own goroutine
 	eg.Go(func() error {
 		hashKey, err := t.indexBlockByHash(b.BlockHeader.Hash, bz)
@@ -220,6 +222,9 @@ func (t *Indexer) GetBlockHeaderByHeight(height uint64) (*lib.BlockResult, lib.E
 // blocks are indexed contiguously by height, so the page params are derived from the
 // oldest and newest indexed heights instead of walking the entire block index
 func (t *Indexer) GetBlocks(p lib.PageParams) (page *lib.Page, err lib.ErrorI) {
+	if p.PerPage > 100 {
+		p.PerPage = 100
+	}
 	results, page := make(lib.BlockResults, 0), lib.NewPage(p, lib.BlockResultsPageName)
 	// get the height boundaries of the index
 	oldest, newest, found, err := t.blockHeightBounds()
@@ -636,6 +641,9 @@ func (t *Indexer) IsValidDoubleSigner(address []byte, height uint64) (bool, lib.
 func (t *Indexer) IndexEvent(e *lib.Event, index int) lib.ErrorI {
 	// index the event by hash
 	hashKey, err := t.indexEventByHash(e)
+	if err != nil {
+		return err
+	}
 	// index the event by height and index
 	heightAndIndexKey := t.eventHeightAndIndexKey(e.Height, uint64(index))
 	// store the hash key by height.index
@@ -720,6 +728,9 @@ func (t *Indexer) getEvent(hashKey []byte) (*lib.Event, lib.ErrorI) {
 	bz, err := t.db.Get(hashKey)
 	if err != nil {
 		return nil, err
+	}
+	if len(bz) == 0 {
+		return nil, ErrStoreGet(errors.New("event not found"))
 	}
 	ptr := new(lib.Event)
 	if err = lib.Unmarshal(bz, ptr); err != nil {
@@ -854,6 +865,9 @@ func (t *Indexer) getQC(heightKey []byte) (*lib.QuorumCertificate, lib.ErrorI) {
 	if err != nil {
 		return nil, err
 	}
+	if len(bz) == 0 {
+		return nil, ErrStoreGet(errors.New("quorum certificate not found"))
+	}
 	// convert to QC object
 	ptr := new(lib.QuorumCertificate)
 	if err = lib.Unmarshal(bz, ptr); err != nil {
@@ -867,6 +881,9 @@ func (t *Indexer) getBlock(hashKey []byte, transactions bool) (*lib.BlockResult,
 	bz, err := t.db.Get(hashKey)
 	if err != nil {
 		return nil, err
+	}
+	if len(bz) == 0 {
+		return nil, ErrStoreGet(errors.New("block not found"))
 	}
 	ptr := new(lib.BlockHeader)
 	if err = lib.Unmarshal(bz, ptr); err != nil {
@@ -911,6 +928,9 @@ func (t *Indexer) getTx(key []byte) (*lib.TxResult, lib.ErrorI) {
 	bz, err := t.db.Get(key)
 	if err != nil {
 		return nil, err
+	}
+	if len(bz) == 0 {
+		return nil, nil
 	}
 	ptr := new(lib.TxResult)
 	if err = lib.Unmarshal(bz, ptr); err != nil {

--- a/store/smt_test.go
+++ b/store/smt_test.go
@@ -2035,7 +2035,7 @@ func NewTestSMT(t *testing.T, preset *NodeList, root []byte, keyBitSize int) (*S
 	// make a writable reader that reads from the last height
 	versionedStore := NewVersionedStore(db.NewSnapshot(), db.NewBatch(), 1)
 	require.NoError(t, err)
-	memStore := NewTxn(versionedStore, versionedStore, []byte(stateCommitmentPrefix), false, false, true, 1)
+	memStore := NewTxn(versionedStore, versionedStore, []byte(stateCommitIDPrefix), false, false, true, 1)
 	// if there's no preset - use the default 3 nodes
 	if preset == nil {
 		if root != nil {

--- a/store/store.go
+++ b/store/store.go
@@ -67,20 +67,22 @@ iteration over stored data.
 */
 
 type Store struct {
-	version    uint64        // version of the store
-	db         *pebble.DB    // underlying database
-	writer     *pebble.Batch // the shared batch writer that allows committing it all at once
-	ss         *Txn          // reference to the state store
-	sc         *SMT          // reference to the state commitment store
-	*Indexer                 // reference to the indexer store
-	metrics    *lib.Metrics  // telemetry
-	syncing    atomic.Bool   // when true, skip compaction to avoid write stalls during sync
-	log        lib.LoggerI   // logger
-	config     lib.Config    // config
-	mu         *sync.Mutex   // mutex for concurrent commits
-	compaction atomic.Bool   // atomic boolean for compaction status
-	backup     atomic.Bool   // atomic boolean for backup status
-	isTxn      bool          // flag indicating if the store is in transaction mode
+	version    uint64         // version of the store
+	db         *pebble.DB     // underlying database
+	writer     *pebble.Batch  // the shared batch writer that allows committing it all at once
+	ss         *Txn           // reference to the state store
+	sc         *SMT           // reference to the state commitment store
+	*Indexer                  // reference to the indexer store
+	metrics    *lib.Metrics   // telemetry
+	syncing    atomic.Bool    // when true, skip compaction to avoid write stalls during sync
+	log        lib.LoggerI    // logger
+	config     lib.Config     // config
+	mu         *sync.Mutex    // mutex for concurrent commits
+	compaction atomic.Bool    // atomic boolean for compaction status
+	backup     atomic.Bool    // atomic boolean for backup status
+	isTxn      bool           // flag indicating if the store is in transaction mode
+	ownsDB     bool           // whether Close should close the shared database
+	jobs       sync.WaitGroup // background compaction and backup jobs
 }
 
 // New() creates a new instance of a StoreI either in memory or an actual disk DB
@@ -189,6 +191,7 @@ func NewStoreWithDB(config lib.Config, db *pebble.DB, metrics *lib.Metrics, log 
 		mu:         &sync.Mutex{},
 		compaction: atomic.Bool{},
 		backup:     atomic.Bool{},
+		ownsDB:     true,
 	}, nil
 }
 
@@ -536,6 +539,9 @@ func (s *Store) IsRootCached() bool { return s.sc != nil }
 // Root() retrieves the root hash of the StateCommitStore, representing the current root of the
 // Sparse Merkle Tree. This hash is used for verifying the integrity and consistency of the state.
 func (s *Store) Root() (root []byte, err lib.ErrorI) {
+	if s.isTxn {
+		return nil, ErrCommitDB(fmt.Errorf("root is not supported for nested transactions"))
+	}
 	// if smt not cached
 	if s.sc == nil {
 		startTime := time.Now()
@@ -567,6 +573,10 @@ func (s *Store) Root() (root []byte, err lib.ErrorI) {
 
 // Reset() discard and re-sets the stores writer
 func (s *Store) Reset() {
+	if s.isTxn {
+		s.Discard()
+		return
+	}
 	// create a new batch for the next version
 	nextVersion := s.version + 1
 	newWriter := s.db.NewBatch()
@@ -599,11 +609,15 @@ func (s *Store) Discard() {
 	}
 }
 
-// Close() discards the writer and closes the database connection
+// Close() discards the writer and closes an owned database connection
 func (s *Store) Close() lib.ErrorI {
+	s.jobs.Wait()
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.Discard()
+	if !s.ownsDB {
+		return nil
+	}
 	if err := s.db.Flush(); err != nil {
 		return ErrCloseDB(fmt.Errorf("flush error: %v", err))
 	}
@@ -676,7 +690,9 @@ func (s *Store) MaybeCompact() {
 	compactionInterval := s.config.StoreConfig.LSSCompactionInterval
 	version := s.Version()
 	if compactionInterval > 0 && version%compactionInterval == 0 {
+		s.jobs.Add(1)
 		go func() {
+			defer s.jobs.Done()
 			now := time.Now()
 			// trigger compaction of store keys
 			if err := s.Compact(version, latestStatePrefix); err != nil {
@@ -718,13 +734,14 @@ func (s *Store) MaybeBackup() {
 		return
 	}
 	// ensure that only one backup can run at a time to avoid overlapping backups
-	if s.backup.Load() {
+	if !s.backup.CompareAndSwap(false, true) {
 		s.log.Debugf("data backup skipped [%d]: already in progress", version)
 		return
 	}
-	s.backup.Store(true)
 	// perform the backup in a separate goroutine to avoid blocking the main thread
+	s.jobs.Add(1)
 	go func() {
+		defer s.jobs.Done()
 		var err error
 		start := time.Now()
 		defer func() {
@@ -754,16 +771,21 @@ func (s *Store) MaybeBackup() {
 		// flush the memtable to SST before checkpointing so the backup does not
 		// depend on WAL replay for recovery (commits use NoSync so WAL records
 		// may not be durable on disk at checkpoint time)
+		s.mu.Lock()
+		version = s.Version()
 		if err = s.db.Flush(); err != nil {
+			s.mu.Unlock()
 			err = fmt.Errorf("flush before checkpoint: %w", err)
 			return
 		}
 		// perform the backup using pebble's checkpointing mechanism which creates a
 		// consistent snapshot of the database at the specified directory
 		if err = s.db.Checkpoint(tempBackupDir); err != nil {
+			s.mu.Unlock()
 			err = fmt.Errorf("checkpoint creation: %w", err)
 			return
 		}
+		s.mu.Unlock()
 		// write the current height to a separate file
 		heightFile := filepath.Join(tempBackupDir, "height.txt")
 		if err = os.WriteFile(heightFile, fmt.Appendf(nil, "%d", version), 0644); err != nil {

--- a/store/store.go
+++ b/store/store.go
@@ -25,12 +25,11 @@ const (
 var (
 	logOnce sync.Once // helper to log the compression method used once
 
-	latestStatePrefix     = lib.JoinLenPrefix([]byte("s/")) // prefix designated for the LatestStateStore where the most recent blobs of state data are held
-	historicStatePrefix   = lib.JoinLenPrefix([]byte("h/")) // prefix designated for the HistoricalStateStore where the historical blobs of state data are held
-	stateCommitmentPrefix = lib.JoinLenPrefix([]byte("c/")) // prefix designated for the StateCommitmentStore (immutable, tree DB) built of hashes of state store data
-	indexerPrefix         = lib.JoinLenPrefix([]byte("i/")) // prefix designated for indexer (transactions, blocks, and quorum certificates)
-	stateCommitIDPrefix   = lib.JoinLenPrefix([]byte("x/")) // prefix designated for the commit ID (height and state merkle root)
-	lastCommitIDPrefix    = lib.JoinLenPrefix([]byte("a/")) // prefix designated for the latest commit ID for easy access (latest height and latest state merkle root)
+	latestStatePrefix   = lib.JoinLenPrefix([]byte("s/")) // prefix designated for the LatestStateStore where the most recent blobs of state data are held
+	historicStatePrefix = lib.JoinLenPrefix([]byte("h/")) // prefix designated for the HistoricalStateStore where the historical blobs of state data are held
+	indexerPrefix       = lib.JoinLenPrefix([]byte("i/")) // prefix designated for indexer (transactions, blocks, and quorum certificates)
+	stateCommitIDPrefix = lib.JoinLenPrefix([]byte("x/")) // shared prefix for state commitment nodes and commit IDs (height and state merkle root)
+	lastCommitIDPrefix  = lib.JoinLenPrefix([]byte("a/")) // prefix designated for the latest commit ID for easy access (latest height and latest state merkle root)
 
 	_ lib.StoreI = &Store{} // enforce the Store interface
 )
@@ -212,7 +211,7 @@ func (s *Store) NewReadOnly(queryVersion uint64) (lib.StoreI, lib.ErrorI) {
 		log:        s.log,
 		db:         s.db,
 		ss:         stateReader,
-		sc:         NewDefaultSMT(NewTxn(hssReader, nil, stateCommitmentPrefix, false, false, true)),
+		sc:         NewDefaultSMT(NewTxn(hssReader, nil, stateCommitIDPrefix, false, false, true)),
 		Indexer:    &Indexer{NewTxn(hssReader, nil, indexerPrefix, false, false, false), s.config},
 		metrics:    s.metrics,
 		mu:         &sync.Mutex{},
@@ -361,7 +360,6 @@ func (s *Store) Rollback(targetVersion uint64) lib.ErrorI {
 	for _, prefix := range [][]byte{
 		historicStatePrefix,
 		indexerPrefix,
-		stateCommitmentPrefix,
 		stateCommitIDPrefix,
 	} {
 		if err = s.pruneVersionWindow(
@@ -814,7 +812,7 @@ func (s *Store) Compact(version uint64, prefix []byte) lib.ErrorI {
 
 // CompactAll is a helper function that runs compaction for all store prefixes sequentially
 func (s *Store) CompactAll(version uint64) lib.ErrorI {
-	prefixes := [][]byte{latestStatePrefix, historicStatePrefix, stateCommitmentPrefix, indexerPrefix}
+	prefixes := [][]byte{latestStatePrefix, historicStatePrefix, stateCommitIDPrefix, indexerPrefix}
 	for _, prefix := range prefixes {
 		if err := s.Compact(version, prefix); err != nil {
 			return err

--- a/store/txn.go
+++ b/store/txn.go
@@ -114,7 +114,7 @@ func (t *Txn) Get(key []byte) ([]byte, lib.ErrorI) {
 			return nil, nil
 		}
 		// TODO: should a sentinel value be returned when a key is found but the value is nil
-		return v.value, nil
+		return bytes.Clone(v.value), nil
 	}
 	// if not found, retrieve from the parent reader
 	return t.reader.Get(lib.AppendWithBuffer(&t.txn.rbuf, t.prefix, key))
@@ -142,6 +142,7 @@ func (t *Txn) DeleteAt(key []byte, version uint64) lib.ErrorI {
 
 // update() modifies or adds an operation to the txn
 func (t *Txn) update(key []byte, val []byte, version uint64, opAction op) (e lib.ErrorI) {
+	key, val = bytes.Clone(key), bytes.Clone(val)
 	hashedKey := lib.MemHash(key)
 	t.txn.l.Lock()
 	defer t.txn.l.Unlock()


### PR DESCRIPTION
Changelog:

- Reject certificate-result QCs unless they are precommit votes.
- Recheck the phase before applying certificate results.
- Require post-election proposer messages and their QCs to reference the same view.
- Use the existing x/ namespace consistently for SMT writes, historical proofs, and compaction.
- Harden store bounds, indexing, backups, derived stores, and transactions; reject mismatched transaction message names.