### PR TITLE
fix(csharp): handle empty CheckTx state responses

### DIFF
--- a/plugin/csharp/src/CanopyPlugin/contract.cs
+++ b/plugin/csharp/src/CanopyPlugin/contract.cs
@@ -69,9 +69,10 @@ namespace CanopyPlugin
         public async Task<PluginCheckResponse> CheckTxAsync(PluginCheckRequest request)
         {
             // validate fee
+            var feeQueryId = (ulong)Random.NextInt64();
             var resp = await Plugin.StateReadAsync(this, new PluginStateReadRequest
             {
-                Keys = { new PluginKeyRead { QueryId = (ulong)Random.NextInt64(), Key = ByteString.CopyFrom(KeyForFeeParams()) } }
+                Keys = { new PluginKeyRead { QueryId = feeQueryId, Key = ByteString.CopyFrom(KeyForFeeParams()) } }
             });
 
             if (resp.Error != null)
@@ -80,7 +81,26 @@ namespace CanopyPlugin
             }
 
             // convert bytes into fee parameters
-            var minFees = Unmarshal<FeeParams>(resp.Results[0].Entries[0].Value.ToByteArray());
+            var feeEntry = resp.Results
+                .FirstOrDefault(result => result != null && result.QueryId == feeQueryId)?
+                .Entries
+                .FirstOrDefault();
+
+            if (feeEntry == null || feeEntry.Value == null || feeEntry.Value.Length == 0)
+            {
+                return new PluginCheckResponse { Error = ErrUnmarshal("fee params") };
+            }
+
+            FeeParams? minFees;
+            try
+            {
+                minFees = Unmarshal<FeeParams>(feeEntry.Value.ToByteArray());
+            }
+            catch (InvalidProtocolBufferException)
+            {
+                return new PluginCheckResponse { Error = ErrUnmarshal("fee params") };
+            }
+
             if (minFees == null)
             {
                 return new PluginCheckResponse { Error = ErrUnmarshal("fee params") };


### PR DESCRIPTION
## What changed?

  Updated the C# plugin's `CheckTxAsync` implementation to handle missing or malformed fee parameter responses safely.

  The code no longer assumes that `StateRead` always returns:

  ```csharp
  resp.Results[0].Entries[0]

  Instead, it now:

  - Matches the response using the generated query ID
  - Checks for missing results or entries
  - Handles empty fee parameter data
  - Catches invalid protobuf data and returns a plugin error

  ## Why?

  When the state response was empty or incomplete, CheckTxAsync could throw an exception instead of returning a proper transaction validation error. This could cause the
  plugin request to fail unexpectedly.

  ## Testing

  - git diff --check passed

  ## Notes

  This is a defensive null-safety and error-handling fix. No protocol or public API changes were made.