### PR TITLE
chore: update README badge URLs to link to proper GitHub views

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,8 +103,8 @@ make test
 - PRs should be opened against the `development` branch.
 
 [![Pre-Release](https://img.shields.io/github/release-pre/canopy-network/canopy.svg)](https://github.com/canopy-network/canopy/releases)
-[![Contributors](https://img.shields.io/github/contributors/canopy-network/canopy.svg)](https://github.com/canopy-network/canopy/pulse)
-[![Last Commit](https://img.shields.io/github/last-commit/canopy-network/canopy.svg)](https://github.com/canopy-network/canopy/pulse)
+[![Contributors](https://img.shields.io/github/contributors/canopy-network/canopy.svg)](https://github.com/canopy-network/canopy/graphs/contributors)
+[![Last Commit](https://img.shields.io/github/last-commit/canopy-network/canopy.svg)](https://github.com/canopy-network/canopy/commits/main)
 
 ## Contact
 


### PR DESCRIPTION
Both badges pointed to /pulse  now each links to where that data actually lives