### PR TITLE
fix(controller): defer telemetry duration evaluation

### DIFF
--- a/controller/block.go
+++ b/controller/block.go
@@ -333,8 +333,8 @@ func (c *Controller) CommitCertificate(qc *lib.QuorumCertificate, block *lib.Blo
 		// reset mempool FSM
 		c.Mempool.FSM.Reset()
 	}
-	// update telemetry (using proper defer to ensure time.Since is evaluated at defer execution)
-	defer c.UpdateTelemetry(qc, block, time.Since(start))
+	// update telemetry at return time so the duration includes all commit work
+	defer func() { c.UpdateTelemetry(qc, block, time.Since(start)) }()
 	if !syncing {
 		// publish root chain information to all nested chain subscribers
 		for _, id := range c.RCManager.ChainIds() {


### PR DESCRIPTION
## Summary

Fixes block processing telemetry in `CommitCertificate` so `time.Since(start)` is evaluated when the function actually returns, rather than when the defer statement is registered.

## Problem

Passing `time.Since(start)` directly as an argument to a deferred call evaluates the duration immediately. As a result, the reported block processing time does not include the remaining commit work.

## Fix

Wrap `UpdateTelemetry` in a deferred closure, matching the behavior already used by `CommitCertificateParallel`.

This ensures telemetry records the full commit duration, including the work performed after the defer is registered.

## Scope

- No consensus behavior changes
- No state transition changes
- Telemetry-only fix
- Keeps serial and parallel commit paths consistent