### PR TITLE
chore: gofmt plugin BLS helper files

### DIFF
--- a/plugin/go/crypto/bls.go
+++ b/plugin/go/crypto/bls.go
@@ -99,6 +99,5 @@ func (b *BLS12381PublicKey) Verify(msg []byte, sig []byte) bool {
 	return b.scheme.Verify(b.Point, msg, sig) == nil
 }
 
-func newBLSScheme() *bdn.Scheme    { return bdn.NewSchemeOnG2(newBLSSuite()) }
-func newBLSSuite() pairing.Suite  { return bls12381.NewBLS12381Suite() }
-
+func newBLSScheme() *bdn.Scheme  { return bdn.NewSchemeOnG2(newBLSSuite()) }
+func newBLSSuite() pairing.Suite { return bls12381.NewBLS12381Suite() }

--- a/plugin/go/tutorial/crypto/bls.go
+++ b/plugin/go/tutorial/crypto/bls.go
@@ -99,5 +99,5 @@ func (b *BLS12381PublicKey) Verify(msg []byte, sig []byte) bool {
 	return b.scheme.Verify(b.Point, msg, sig) == nil
 }
 
-func newBLSScheme() *bdn.Scheme    { return bdn.NewSchemeOnG2(newBLSSuite()) }
-func newBLSSuite() pairing.Suite  { return bls12381.NewBLS12381Suite() }
+func newBLSScheme() *bdn.Scheme  { return bdn.NewSchemeOnG2(newBLSSuite()) }
+func newBLSSuite() pairing.Suite { return bls12381.NewBLS12381Suite() }


### PR DESCRIPTION
## Description

`plugin/go/crypto/bls.go` and `plugin/go/tutorial/crypto/bls.go` are not formatted with `gofmt`, so both are reported by `gofmt -l .`. CONTRIBUTING.md requires all Go code to be formatted with the standard tool.

## Changes Made

- Ran `gofmt -w` on the two files. The change is alignment of two single-line function bodies in each.

## Testing

- `gofmt -l plugin/` is now clean
- No functional change; nothing to test beyond formatting

## Note

`fsm/key.go` is also currently unformatted. It is fixed separately, alongside the identifier rename that file needs, so that each PR stays isolated per CONTRIBUTING's "one pull request per fix" guidance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
