### PR TITLE
fix(fsm): correct nextBatchSement typo to nextBatchSegment

### DIFF
--- a/fsm/dex.go
+++ b/fsm/dex.go
@@ -993,7 +993,7 @@ func (s *StateMachine) GetDexBatches(lockedBatch bool) (b []*lib.DexBatch, err l
 	if lockedBatch {
 		prefix = lib.JoinLenPrefix(dexPrefix, lockedBatchSegment)
 	} else {
-		prefix = lib.JoinLenPrefix(dexPrefix, nextBatchSement)
+		prefix = lib.JoinLenPrefix(dexPrefix, nextBatchSegment)
 	}
 	// iterate over the dex prefix
 	it, err := s.Iterator(prefix)

--- a/fsm/indexer.go
+++ b/fsm/indexer.go
@@ -197,7 +197,7 @@ func (s *StateMachine) indexerBlob(height uint64, stateKeys [][]byte, selectiveS
 		return nil, err
 	}
 	// retrieve next dex batches
-	nextDexBatches, err := sm.IterateAndAppend(lib.JoinLenPrefix(dexPrefix, nextBatchSement))
+	nextDexBatches, err := sm.IterateAndAppend(lib.JoinLenPrefix(dexPrefix, nextBatchSegment))
 	if err != nil {
 		return nil, err
 	}

--- a/fsm/key.go
+++ b/fsm/key.go
@@ -43,8 +43,8 @@ var (
 	orderBookPrefix        = []byte{13} // store key prefix for 'sell orders' before they are bid on
 	retiredCommitteePrefix = []byte{14} // store key prefix for 'retired' (dead) committees
 	dexPrefix              = []byte{15} // store key prefix for 'dex' functionality
-	lockedBatchSegment = []byte{1}
-	nextBatchSement    = []byte{2}
+	lockedBatchSegment     = []byte{1}
+	nextBatchSegment       = []byte{2}
 )
 
 /*
@@ -108,7 +108,7 @@ func KeyForLockedBatch(chainId uint64) []byte {
 }
 
 func KeyForNextBatch(chainId uint64) []byte {
-	return lib.JoinLenPrefix(dexPrefix, nextBatchSement, formatUint64(chainId))
+	return lib.JoinLenPrefix(dexPrefix, nextBatchSegment, formatUint64(chainId))
 }
 
 func AddressFromKey(k []byte) (crypto.AddressI, lib.ErrorI) {


### PR DESCRIPTION
## Description

The dex store key prefix variable is misspelled: `nextBatchSement` should be `nextBatchSegment`.

## Changes Made

- Renamed `nextBatchSement` to `nextBatchSegment` at all four sites:
  - `fsm/key.go` (declaration, and use in `nextBatchSegmentKey`)
  - `fsm/dex.go`
  - `fsm/indexer.go`
- Ran `gofmt` on `fsm/key.go`, whose `var` block alignment was already inconsistent with gofmt output and shifts with the rename.

The name is spelled consistently everywhere, so the rename is mechanical. It names a Go identifier for a store key prefix, not a serialised value, so the on-disk encoding is unchanged.

## Testing

- `go build ./...`
- `go test ./fsm/` passes
- `gofmt -l fsm/key.go` is clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
