### PR TITLE
docs(readme): correct the test command and the Go version badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ _Official golang implementation of the Canopy Network Protocol_
 
 [![GoDoc](https://img.shields.io/badge/godoc-reference-white.svg)](https://godoc.org/github.com/canopy-network/canopy)
 [![Getting Started](https://img.shields.io/badge/getting%20started-guide-white)](https://canopynetwork.org)
-[![Go Version](https://img.shields.io/badge/golang-v1.21-white.svg)](https://golang.org)
+[![Go Version](https://img.shields.io/badge/golang-v1.26-white.svg)](https://golang.org)
 [![Next.js Version](https://img.shields.io/badge/next%20js-v14.2.3-white.svg)](https://nextjs.org/)
 
 
@@ -78,7 +78,7 @@ make docker/up && make docker/logs
 ➪ To run Canopy unit tests, use the Go testing tools:
 
 ```bash
-make test
+make test/all
 ```
 
 ## How to Contribute


### PR DESCRIPTION
## Description

Two inaccuracies in README.md that affect anyone following it.

## Changes Made

- **Test command.** The "Running Tests" section says to run `make test`. No such target exists in the Makefile — it is `make test/all`. The documented command fails outright.
- **Go version badge.** The badge advertises v1.21, but `go.mod` has required Go 1.26.0 since the toolchain bump.

## Testing

Documentation only; no code affected.

## Note

This touches the badge block, which #548 also edits. The changes are independent (that PR changes badge link targets, this one changes the version in the badge image URL), but may need a trivial rebase depending on merge order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
