### PR TITLE
fix(lib): drop unreachable negative-length check in preflightProtoBytes

### DIFF
--- a/lib/util.go
+++ b/lib/util.go
@@ -438,7 +438,9 @@ func preflightProtoBytes(b []byte) error {
 			if l > protoMaxFieldBytes {
 				return fmt.Errorf("length-delimited field exceeds max size: %d > %d", l, protoMaxFieldBytes)
 			}
-			if l < 0 || offset+int(l) > len(b) {
+			// l is a uint64 and is already bounded by protoMaxFieldBytes above,
+			// so the int conversion below cannot overflow.
+			if offset+int(l) > len(b) {
 				return fmt.Errorf("length-delimited field exceeds buffer bounds")
 			}
 			offset += int(l)


### PR DESCRIPTION
## Description

`preflightProtoBytes` guards a length-delimited field with:

```go
if l < 0 || offset+int(l) > len(b) {
```

`protowire.ConsumeVarint` returns a `uint64`, so `l < 0` can never be true. staticcheck reports it as SA4003. It reads as protection against a negative length that the type system already rules out.

## Changes Made

- Removed the dead `l < 0` clause.
- Added a comment recording why the `int(l)` conversion it appeared to guard is in fact safe: the preceding `protoMaxFieldBytes` check bounds `l` to 32MB. This is so the next reader does not re-add the check.

## Testing

- `go build ./...`
- `go test ./lib/` passes
- staticcheck no longer reports SA4003 in `lib/util.go`

No behaviour change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
