### PR TITLE
fix(store): return the error from indexEventByHash in IndexEvent

### DIFF
--- a/store/indexer.go
+++ b/store/indexer.go
@@ -628,6 +628,11 @@ func (t *Indexer) IsValidDoubleSigner(address []byte, height uint64) (bool, lib.
 func (t *Indexer) IndexEvent(e *lib.Event, index int) lib.ErrorI {
 	// index the event by hash
 	hashKey, err := t.indexEventByHash(e)
+	// if indexing by hash failed, hashKey is not usable as a target for the
+	// secondary indexes below, so exit before writing them
+	if err != nil {
+		return err
+	}
 	// index the event by height and index
 	heightAndIndexKey := t.eventHeightAndIndexKey(e.Height, uint64(index))
 	// store the hash key by height.index


### PR DESCRIPTION
## Description

`IndexEvent` assigned the error from `indexEventByHash` and then overwrote it on the next call without ever checking it:

```go
hashKey, err := t.indexEventByHash(e)
heightAndIndexKey := t.eventHeightAndIndexKey(e.Height, uint64(index))
if err = t.indexEventByHeightAndIndex(heightAndIndexKey, hashKey); err != nil {
```

If the primary hash index write failed, the failure was silently discarded. The function then carried on writing the height, chainId and address indexes, all pointing at a `hashKey` that was never persisted — leaving dangling secondary index entries and reporting success to the caller.

staticcheck flagged this as SA4006.

## Changes Made

- Check the error from `indexEventByHash` before it is reassigned, and return early.

## Testing

- `go build ./...`
- `go test ./store/` passes
- staticcheck no longer reports SA4006 in `store/indexer.go`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
