### PR TITLE
fix(lib): log instead of silently swallowing errors in LogNonSigners

### DIFF
--- a/lib/consensus.go
+++ b/lib/consensus.go
@@ -223,15 +223,15 @@ func (x *AggregateSignature) LogNonSigners(validatorList *ConsensusValidators, p
 	// if an error occurred during the conversion
 	if err != nil {
 		// exit with error
+		logger.Errorf("LogNonSigners: could not build the validator set: %s", err.Error())
 		return
 	}
 	// create a copy of the multi-public-key from the validator set
 	key := vs.MultiKey.Copy()
 	// set the 'who signed' bitmap in a copy of the key
 	if e := key.SetBitmap(x.Bitmap); e != nil {
-		// convert the error to a lib.ErrorI
-		err = ErrInvalidSignerBitmap(e)
 		// exit with error
+		logger.Errorf("LogNonSigners: %s", ErrInvalidSignerBitmap(e).Error())
 		return
 	}
 	producerAddress, producerNetAddress := "", ""
@@ -252,9 +252,8 @@ func (x *AggregateSignature) LogNonSigners(validatorList *ConsensusValidators, p
 		signed, er := key.SignerEnabledAt(i)
 		// if an error occurred during this check
 		if er != nil {
-			// convert the error to a lib.ErrorI
-			err = ErrInvalidSignerBitmap(er)
 			// exit
+			logger.Errorf("LogNonSigners: %s", ErrInvalidSignerBitmap(er).Error())
 			return
 		}
 		// if so, add to the pubkeys and add to the power


### PR DESCRIPTION
## Description

`LogNonSigners` has no return values, so these two assignments discarded the error entirely:

```go
err = ErrInvalidSignerBitmap(e)
return
```

A malformed signer bitmap caused non-signer logging to stop with no trace at all — exactly the moment an operator would want a log line. The early `NewValidatorSet` failure returned silently for the same reason.

staticcheck flagged the dead assignments as SA4006.

## Changes Made

- All three error paths now log through the `LoggerI` the function already receives.
- Removed the dead assignments to `err`.

Control flow is unchanged: the function still returns early on each error.

## Testing

- `go build ./...`
- `go test ./lib/` passes
- staticcheck no longer reports SA4006 in `lib/consensus.go`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
