### PR TITLE
fix(lib): remove deprecated net.Error.Temporary() from the proxy accept loop

### DIFF
--- a/lib/peer.go
+++ b/lib/peer.go
@@ -538,13 +538,8 @@ func (p *ValidatorTCPProxy) acceptLoop(ctx context.Context, ln net.Listener, tar
 				return
 			default:
 			}
-			// if there's a temporary error (DEPRECATED)
-			if ne, ok := err.(net.Error); ok && ne.Temporary() {
-				p.log.Warnf("validator tcp proxy temporary accept error on port %d: %v", port, err)
-				time.Sleep(50 * time.Millisecond)
-				continue
-			}
-			// check the accept error
+			// back off briefly and retry; a listener that is genuinely gone is
+			// caught by the ctx.Done() check above
 			p.log.Warnf("validator tcp proxy accept error on port %d: %v", port, err)
 			time.Sleep(50 * time.Millisecond)
 			continue


### PR DESCRIPTION
## Description

`net.Error.Temporary()` has been deprecated since Go 1.18 because its semantics are not well defined. staticcheck reports it as SA1019.

In this accept loop the call was also **dead code**. Both branches did exactly the same thing — log a warning, sleep 50ms, continue — differing only in the wording of the log line:

```go
if ne, ok := err.(net.Error); ok && ne.Temporary() {
    p.log.Warnf("validator tcp proxy temporary accept error on port %d: %v", port, err)
    time.Sleep(50 * time.Millisecond)
    continue
}
p.log.Warnf("validator tcp proxy accept error on port %d: %v", port, err)
time.Sleep(50 * time.Millisecond)
continue
```

Deliberate shutdown is already handled by the `ctx.Done()` check immediately above.

## Changes Made

- Collapsed to the single retry path and dropped the deprecated call.

## Testing

- `go build ./...`
- `go test ./lib/` passes
- staticcheck no longer reports SA1019 at `lib/peer.go:542`

No behaviour change beyond one log message no longer being labelled "temporary".

🤖 Generated with [Claude Code](https://claude.com/claude-code)
