### PR TITLE
docs(crypto): warn that the deprecated ripemd160 import is consensus critical

### DIFF
--- a/lib/crypto/secp256k1.go
+++ b/lib/crypto/secp256k1.go
@@ -8,6 +8,12 @@ import (
 	"encoding/json"
 	ethCrypto "github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/crypto/secp256k1"
+	// DO NOT REPLACE: golang.org/x/crypto/ripemd160 is deprecated upstream and
+	// staticcheck reports it as SA1019, but RIPEMD-160 is part of the SECP256K1
+	// address derivation below and therefore consensus critical. Swapping it for
+	// a "modern" hash would change every SECP256K1 address on the network and
+	// hard-fork the chain. If the package is ever removed from x/crypto, vendor
+	// an equivalent RIPEMD-160 implementation rather than changing the algorithm.
 	"golang.org/x/crypto/ripemd160"
 )
 
@@ -160,6 +166,7 @@ func (s *SECP256K1PublicKey) UnmarshalJSON(b []byte) (err error) {
 // - BTC, BCH, BSV, (and other forks) <1 byte version> + RIPEMD-160(SHA-256(pubkey)) + <4 byte Checksum>
 // `RIPEMD-160(SHA-256(pubkey))` seems to be the most common theme in addressing for SECP256K1 public keys
 func (s *SECP256K1PublicKey) Address() AddressI {
+	// consensus critical: this hash defines the on-chain address format
 	hasher := ripemd160.New()
 	hasher.Write(Hash(s.Bytes()))
 	address := Address(hasher.Sum(nil))


### PR DESCRIPTION
## Description

staticcheck reports `golang.org/x/crypto/ripemd160` as SA1019, and the package's own deprecation notice advises using a modern hash like SHA-256 instead.

**Acting on that advice here would split the chain.** `RIPEMD-160(SHA-256(pubkey))` defines the SECP256K1 address format in `SECP256K1PublicKey.Address()`, so changing the hash changes every SECP256K1 address on the network.

This is the kind of thing a contributor running a linter fixes in good faith without realising the blast radius.

## Changes Made

- Comment at the import explaining why the deprecated package is intentional, and what to do instead if it is ever removed from `x/crypto` (vendor an equivalent implementation, do not change the algorithm).
- Comment at the `Address()` call site marking the hash as consensus critical.

Comments only; no functional change.

## Testing

- `go build ./...`
- `go test ./lib/crypto/` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
