### PR TITLE
fix(crypto): take *types.Transaction in RecoverPublicKey

### DIFF
--- a/fsm/ethereum.go
+++ b/fsm/ethereum.go
@@ -86,7 +86,7 @@ func rlpToCanopyTransaction(txBytes []byte, memo string) (transaction *lib.Trans
 	// get the signer type (supports: Legacy, EIP-155, EIP-1559, EIP-2930, EIP-4844, EIP-7702)
 	signer := ethTypes.LatestSignerForChainID(tx.ChainId())
 	// recover the public key from the rlp transaction and validate the signature
-	publicKey, err := crypto.RecoverPublicKey(signer, tx)
+	publicKey, err := crypto.RecoverPublicKey(signer, &tx)
 	if err != nil {
 		return nil, ErrInvalidPublicKey(err)
 	}

--- a/lib/crypto/eth_secp256k1.go
+++ b/lib/crypto/eth_secp256k1.go
@@ -111,14 +111,14 @@ func (s *ETHSECP256K1PublicKey) String() string { return hex.EncodeToString(s.By
 func (s *ETHSECP256K1PublicKey) Equals(i PublicKeyI) bool { return bytes.Equal(s.Bytes(), i.Bytes()) }
 
 // RecoverPublicKey() recovers a public key from ethereum the transaction and validates the signature
-func RecoverPublicKey(signer types.Signer, tx types.Transaction) (PublicKeyI, error) {
+func RecoverPublicKey(signer types.Signer, tx *types.Transaction) (PublicKeyI, error) {
 	// extract signature values
 	Vb, R, S := tx.RawSignatureValues()
 	if Vb == nil || R == nil || S == nil {
 		return nil, types.ErrInvalidSig
 	}
 	// compute sighash (what was signed)
-	sigHash := signer.Hash(&tx)
+	sigHash := signer.Hash(tx)
 	// normalize V to 0 or 1
 	var recoveryID byte
 	V := Vb.Uint64()


### PR DESCRIPTION
## Description

`RecoverPublicKey` accepts go-ethereum's `types.Transaction` **by value**. That type carries `atomic.Pointer` caches for the hash, size and sender, and is documented as non-copyable. `go vet` reports it:

```
lib/crypto/eth_secp256k1.go:114: RecoverPublicKey passes lock by value:
types.Transaction contains sync/atomic.Pointer[...] contains atomic.noCopy
```

The only caller is `rlpToCanopyTransaction`, which handles untrusted inbound Ethereum-compatibility transactions, so this is on a hot path.

## Changes Made

- Changed the parameter to `*types.Transaction`.
- `signer.Hash(tx)` now hashes the caller's transaction — and can use its hash cache — instead of a throwaway copy.
- Updated the single caller, which already has an addressable local, to pass `&tx`.

## Testing

- `go build ./...`
- `go test ./lib/crypto/ ./fsm/` passes
- `go vet ./lib/crypto/` no longer reports the copylocks finding

🤖 Generated with [Claude Code](https://claude.com/claude-code)
