### PR TITLE
fix(store): make node.copy() actually copy

### DIFF
--- a/store/smt.go
+++ b/store/smt.go
@@ -1177,7 +1177,28 @@ func (x *node) replaceChild(oldKey, newKey []byte) {
 }
 
 // copy() returns a shallow copy of the node
-func (x *node) copy() *node { return &(*x) }
+//
+// The node struct is rebuilt field by field rather than dereferenced and
+// re-addressed: `&(*x)` is simply `x` and returns the original pointer, and a
+// plain `*x` struct copy would copy the protobuf MessageState embedded in
+// lib.Node (a lock copy, reported by `go vet`). The byte slices and the *key
+// are shared with the original, which is what "shallow" means here.
+func (x *node) copy() *node {
+	if x == nil {
+		return nil
+	}
+	return &node{
+		Key: x.Key,
+		Node: lib.Node{
+			Value:         x.Node.Value,
+			LeftChildKey:  x.Node.LeftChildKey,
+			RightChildKey: x.Node.RightChildKey,
+			Key:           x.Node.Key,
+			Bitmask:       x.Node.Bitmask,
+		},
+		delete: x.delete,
+	}
+}
 
 // NODE LIST CODE BELOW
 


### PR DESCRIPTION
## Description

`node.copy()` was:

```go
func (x *node) copy() *node { return &(*x) }
```

`&(*x)` is just `x` — dereferencing and immediately re-addressing a pointer yields the same pointer. Every caller that asked for a copy got an **alias** to the original node, so mutating the "copy" mutated the original. staticcheck reports the expression as SA4001.

This is already known to be load-bearing. `store/store.go` carries a comment saying the SMT node cache "MUST NOT be persisted across blocks", precisely because:

> `node.copy()` is a no-op alias, so the parallel commit mutates cached `*node` objects in place. Reusing them later can serve stale nodes [...] diverging from the on-disk snapshot.

Fixing the copy removes the reason that workaround exists. This PR leaves the workaround in place — it only makes the primitive honest.

## Changes Made

- `copy()` now rebuilds the node field by field and returns a distinct pointer.

Rebuilt field by field rather than with `*x` because `lib.Node` embeds a protobuf `MessageState`; a plain struct copy would be a lock copy that `go vet` rejects. Byte slices and the `*key` are still shared, which is what the existing "shallow copy" doc comment describes.

## Testing

- Full suite passes: `go test ./... -p=1`
- State root over a deterministic 500-write / 167-delete workload is **byte-identical** before and after:

```
main                     ROOT=3944f19bc128472bd163bd081b5bc648fd97f535ca823b88f6b5da8548e391a6
fix/smt-node-copy-no-op  ROOT=3944f19bc128472bd163bd081b5bc648fd97f535ca823b88f6b5da8548e391a6
```

## Note for reviewers

This is consensus-critical storage code. The root comparison above and a green suite are good signals, but not proof — you may well want to run it against a real chain replay before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
