### PR TITLE
chore(docker): move runtime images off end-of-life alpine 3.19

### DIFF
--- a/.docker/Dockerfile
+++ b/.docker/Dockerfile
@@ -10,7 +10,7 @@ RUN make build/wallet
 RUN make build/explorer
 RUN go build -a -o bin ./cmd/main/...
 
-FROM alpine:3.19
+FROM alpine:3.22
 WORKDIR /app
 COPY --from=builder /go/src/github.com/canopy-network/canopy/bin ./
 ENTRYPOINT ["/app/bin"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ RUN if [ ! -f "${BIN_PATH}" ]; then \
   echo "File ${BIN_PATH} already exists. Skipping build."; \
   fi
 
-FROM alpine:3.19
+FROM alpine:3.22
 
 RUN apk add --no-cache pigz ca-certificates
 


### PR DESCRIPTION
## Description

Both runtime stages pin `alpine:3.19`, which has passed end of community support and no longer receives security patches, so the shipped image accumulates unfixed CVEs in its base layer.

## Changes Made

- `Dockerfile` and `.docker/Dockerfile`: `alpine:3.19` -> `alpine:3.22`.

The runtime layer only installs `pigz` and `ca-certificates`, so there is no version-sensitive surface here.

## Not changed — needs a maintainer decision

Neither Dockerfile declares a `USER`, so the node runs as **root**. That is worth fixing, but it is not a one-line change: `.docker/compose.yaml` mounts chain data at `/root/.canopy`, so the data directory would have to move and every volume mapping would have to move with it. I left it out rather than bundling an untested permissions change here — happy to open a follow-up if you want it.

## Caveat

I could not build these images locally (no Docker in my environment), so this is an inspection-only change. Worth a CI build before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
