### PR TITLE
ci: enforce gofmt and check for known vulnerabilities

### DIFF
--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -28,6 +28,44 @@ jobs:
         uses: actions/checkout@v4
       - name: Build Services
         run: make build/canopy-full
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: 1.26
+      - name: Checkout code
+        uses: actions/checkout@v4
+      # Note: .docker/ is excluded because it contains Dockerfiles named
+      # Dockerfile.go, which gofmt tries (and fails) to parse as Go source.
+      - name: Check formatting
+        run: |
+          unformatted=$(find . -name '*.go' \
+            -not -path './.docker/*' \
+            -not -path '*/node_modules/*' \
+            -print0 | xargs -0 gofmt -l)
+          if [ -n "$unformatted" ]; then
+            echo "The following files are not gofmt'd:"
+            echo "$unformatted"
+            echo ""
+            echo "Run 'gofmt -w' on them and commit the result."
+            exit 1
+          fi
+      # cmd/rpc embeds the built wallet and explorer assets, and the embed
+      # directories are gitignored, so any tool that has to type-check the
+      # module fails on a fresh checkout. Placeholders are enough to satisfy
+      # the embed without paying for a full npm build in this job.
+      - name: Create web asset placeholders
+        run: |
+          mkdir -p cmd/rpc/web/explorer/dist cmd/rpc/web/wallet/out
+          touch cmd/rpc/web/explorer/dist/.gitkeep cmd/rpc/web/wallet/out/.gitkeep
+      - name: Check for known vulnerabilities
+        run: |
+          go install golang.org/x/vuln/cmd/govulncheck@latest
+          govulncheck ./...
+
   test:
     name: Test
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Description

CONTRIBUTING.md requires all Go code to be `gofmt`'d, but nothing enforces it — and three files on `main` are currently unformatted. There is also no vulnerability scanning, so advisories in the dependency graph go unnoticed.

## Changes Made

Adds a `Lint` job with two gates:

- **gofmt** — fails with the list of offending files and the command to fix them
- **govulncheck** — fails only when a known vulnerability is actually reachable from this codebase

Two implementation notes worth knowing:

- **`.docker/` is excluded from the gofmt sweep.** It contains Dockerfiles named `Dockerfile.go` (e.g. `.docker/auto-update/Dockerfile.go`), which gofmt tries to parse as Go and reports syntax errors on. Renaming those would be the cleaner fix, but is out of scope here.
- **The job creates empty `//go:embed` placeholders** before running govulncheck. The wallet/explorer asset directories are gitignored, so on a fresh checkout the module does not type-check at all and govulncheck fails before it starts. A `.gitkeep` satisfies an `all:` embed and avoids paying for an npm build in the lint job.

## Merge order

The gofmt gate **fails on `main` today**. It should land after the two formatting fixes (#558 and #559), or you may prefer to squash them together.

## Deliberately not included

`go vet` currently reports ~55 copylocks findings, almost all protobuf `MessageState` copies in generated-adjacent code. It cannot be made blocking without a much larger cleanup, so I left it out rather than adding a step that is red from day one.

## Testing

Both gates were run locally against this branch. The gofmt gate correctly identifies exactly the three unformatted files; govulncheck exits 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
