### PR TITLE
Stop the inbound accept loop from spamming errors on shutdown

### DIFF
--- a/p2p/p2p.go
+++ b/p2p/p2p.go
@@ -147,6 +147,13 @@ func (p *P2P) ListenForInboundPeers(listenAddress *lib.PeerAddress) {
 		// wait for and then accept inbound tcp connection
 		c, err := p.listener.Accept()
 		if err != nil {
+			// A closed listener means the node is shutting down, not a fault.
+			// Exit the loop quietly instead of logging the same error every
+			// 5 seconds for the rest of the process's life.
+			if strings.Contains(err.Error(), ErrListenerClosed) {
+				p.log.Debugf("Inbound listener closed, stopping accept loop")
+				return
+			}
 			<-time.After(5 * time.Second)
 			p.log.Errorf("Accept error: %v", err)
 			continue


### PR DESCRIPTION
On shutdown the inbound listener is closed and `listener.Accept()` returns `use of closed network connection`. The accept loop logged that as `ERROR`, waited 5s, and retried forever, so a clean shutdown produced a wall of identical ERROR lines (exactly the output in #230).

The package already defines `ErrListenerClosed` for this string. When `Accept` fails with a closed listener, log a single debug line and `return` to end the loop; every other error keeps the existing back-off-and-retry path.

`go build ./p2p/` and `gofmt` are clean, and `go vet ./p2p/` reports nothing new on the changed file (the two pre-existing `set_test.go` warnings are unrelated).

Closes #230