### PR TITLE
fix(release): bundle Go plugin artifacts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,7 +65,16 @@ jobs:
           GOARCH=amd64 CGO_ENABLED=0 GOOS=linux go build -a -o dist/signer-linux-amd64 ./cmd/signer/...
           GOARCH=arm64 CGO_ENABLED=0 GOOS=linux go build -a -o dist/signer-linux-arm64 ./cmd/signer/...
           GOARCH=arm64 CGO_ENABLED=0 GOOS=darwin go build -a -o dist/signer-darwin-arm64 ./cmd/signer/...
-          sha256sum dist/cli-* dist/signer-* > dist/SHA256SUMS
+          (
+            cd plugin/go
+            GOARCH=amd64 CGO_ENABLED=0 GOOS=linux go build -a -o ../../dist/go-plugin .
+            tar -czf ../../dist/go-plugin-linux-amd64.tar.gz -C ../../dist go-plugin
+            rm ../../dist/go-plugin
+            GOARCH=arm64 CGO_ENABLED=0 GOOS=linux go build -a -o ../../dist/go-plugin .
+            tar -czf ../../dist/go-plugin-linux-arm64.tar.gz -C ../../dist go-plugin
+            rm ../../dist/go-plugin
+          )
+          sha256sum dist/cli-* dist/signer-* dist/go-plugin-* > dist/SHA256SUMS
 
       - name: Create GitHub release
         uses: softprops/action-gh-release@v3
@@ -79,6 +88,8 @@ jobs:
             dist/signer-linux-amd64
             dist/signer-linux-arm64
             dist/signer-darwin-arm64
+            dist/go-plugin-linux-amd64.tar.gz
+            dist/go-plugin-linux-arm64.tar.gz
             dist/SHA256SUMS
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- build Go plugin archives in the main release workflow
- attach amd64 and arm64 plugin archives to every Canopy release
- include plugin archives in SHA256SUMS

## Validation
- cross-compiled the Go plugin for linux/amd64 and linux/arm64 locally
- current v0.1.23+beta plugin release workflow completed successfully