### PR TITLE
fix: bootstrap first consensus block

### DIFF
--- a/controller/block.go
+++ b/controller/block.go
@@ -141,13 +141,22 @@ func (c *Controller) ProduceProposal(evidence *bft.ByzantineEvidence, vdf *crypt
 			if e != nil {
 				return false, e
 			}
-			// load the previous quorum height quorum certificate from the indexer
-			lastCertificate, e := c.FSM.LoadCertificateHashesOnly(c.FSM.Height() - 1)
-			if e != nil {
-				return false, e
+			// The first consensus block has no prior certificate or indexed block.
+			// Later heights must resolve both predecessors from the indexer.
+			var lastCertificate *lib.QuorumCertificate
+			lastBlock := &lib.BlockResult{BlockHeader: new(lib.BlockHeader)}
+			if c.FSM.Height() > 1 {
+				lastCertificate, e = c.FSM.LoadCertificateHashesOnly(c.FSM.Height() - 1)
+				if e != nil {
+					return false, e
+				}
+				lastBlock, e = c.FSM.LoadBlock(c.FSM.Height() - 1)
+				if e != nil {
+					return false, e
+				}
 			}
 			// validate the verifiable delay function from the bft module
-			if vdf != nil {
+			if c.FSM.Height() > 1 && vdf != nil {
 				// if the verifiable delay function is NOT valid for using the last block hash
 				if !crypto.VerifyVDF(lastCertificate.BlockHash, vdf.Output, vdf.Proof, int(vdf.Iterations)) {
 					// nullify the bad VDF
@@ -155,11 +164,6 @@ func (c *Controller) ProduceProposal(evidence *bft.ByzantineEvidence, vdf *crypt
 					// log the issue but still continue with the proposal
 					c.log.Error(lib.ErrInvalidVDF().Error())
 				}
-			}
-			// load the last block from the indexer
-			lastBlock, e := c.FSM.LoadBlock(c.FSM.Height() - 1)
-			if e != nil {
-				return false, e
 			}
 			// replace the VDF and last certificate in the header
 			p.Block.BlockHeader.LastQuorumCertificate, p.Block.BlockHeader.Vdf = lastCertificate, vdf

--- a/fsm/state.go
+++ b/fsm/state.go
@@ -221,10 +221,15 @@ func (s *StateMachine) ApplyBlock(ctx context.Context, b *lib.Block, allowOversi
 	if !rootStartTime.IsZero() {
 		s.Metrics.UpdateFSMApplyBlockRootTime(rootStartTime)
 	}
-	// load the last block from the indexer
-	lastBlock, err := s.LoadBlock(s.height - 1)
-	if err != nil {
-		return nil, nil, err
+	// The state committed from genesis is version 1, but there is no indexed
+	// block yet. Treat the predecessor of the first consensus block as an empty
+	// genesis boundary; later heights must always resolve their prior block.
+	lastBlock := &lib.BlockResult{BlockHeader: new(lib.BlockHeader)}
+	if s.height > 1 {
+		lastBlock, err = s.LoadBlock(s.height - 1)
+		if err != nil {
+			return nil, nil, err
+		}
 	}
 	// get the transaction root
 	transactionRoot, err := r.TransactionRoot()

--- a/fsm/state_test.go
+++ b/fsm/state_test.go
@@ -1,6 +1,7 @@
 package fsm
 
 import (
+	"bytes"
 	"context"
 	"encoding/hex"
 	"encoding/json"
@@ -285,6 +286,43 @@ func TestApplyBlock(t *testing.T) {
 			require.EqualExportedValues(t, test.expectedResults, result.Results[0])
 		})
 	}
+}
+
+func TestApplyFirstBlockWithoutIndexedPredecessor(t *testing.T) {
+	log := lib.NewDefaultLogger()
+	db, err := store.NewStoreInMemory(log)
+	require.NoError(t, err)
+	defer db.Close()
+	sm := StateMachine{
+		store:           db,
+		ProtocolVersion: CurrentProtocolVersion,
+		NetworkID:       1,
+		height:          1,
+		slashTracker:    NewSlashTracker(),
+		events:          new(lib.EventsTracker),
+		Config: lib.Config{
+			MainConfig:         lib.DefaultMainConfig(),
+			StateMachineConfig: lib.DefaultStateMachineConfig(),
+		},
+		log: log,
+		cache: &cache{
+			accounts: make(map[uint64]*Account),
+			pools:    make(map[uint64]*Pool),
+		},
+	}
+	require.NoError(t, sm.SetParams(DefaultParams()))
+
+	block := &lib.Block{BlockHeader: &lib.BlockHeader{
+		Time:            uint64(time.Now().UnixMicro()),
+		ProposerAddress: newTestAddressBytes(t),
+	}}
+	header, result, err := sm.ApplyBlock(context.Background(), block, false)
+	require.NoError(t, err)
+	require.Empty(t, result.Failed)
+	require.EqualValues(t, 1, header.Height)
+	require.Zero(t, header.TotalTxs)
+	require.Zero(t, header.TotalVdfIterations)
+	require.Equal(t, bytes.Repeat([]byte("F"), crypto.HashSize), []byte(header.LastBlockHash))
 }
 
 func TestApplyTransactions_DoesNotReturnCheckErrors(t *testing.T) {


### PR DESCRIPTION
## Summary
- treat the predecessor of height 1 as the empty genesis boundary
- skip prior block/certificate index lookups when producing the first proposal
- add a regression test for applying block 1 without an indexed predecessor

## Production impact
Fresh graduated chains currently remain at height 1 because proposal construction asks the indexer for block 1 before it has been committed. This allows the first block to be produced while preserving strict predecessor checks from height 2 onward.

## Validation
- `go test ./...`
- `go test ./fsm ./controller`
- `git diff --check`