### PR TITLE
fix: add flush mechanism for queues in full nodes

### DIFF
--- a/cmd/rpc/server.go
+++ b/cmd/rpc/server.go
@@ -33,7 +33,7 @@ const (
 
 	// uses golang's semver naming convention
 	// https://pkg.go.dev/golang.org/x/mod/semver
-	SoftwareVersion = "v0.1.23+beta"
+	SoftwareVersion = "v0.1.25+beta"
 	ContentType     = "Content-MessageType"
 	ApplicationJSON = "application/json; charset=utf-8"
 

--- a/controller/consensus.go
+++ b/controller/consensus.go
@@ -115,6 +115,8 @@ func (c *Controller) Sync() {
 		case <-limiter.TimeToReset():
 			limiter.Reset()
 		case <-requestTicker.C:
+			// Remove timed-out requests before attempting to refill the queue
+			c.applyTimeouts(queue)
 			// Get current chain height
 			fsmHeight := c.FSM.Height()
 			// Get an updated list of available peers
@@ -151,8 +153,6 @@ func (c *Controller) Sync() {
 				maxHeight, minVDFIterations = m, v
 				c.log.Debugf("Updated chain %d with max height: %d and iterations %d", c.Config.ChainId, maxHeight, minVDFIterations)
 			}
-			// Remove any block requests that have timed out
-			c.applyTimeouts(queue)
 		}
 	}
 	// Syncing complete

--- a/controller/consensus.go
+++ b/controller/consensus.go
@@ -624,6 +624,9 @@ func (c *Controller) UpdateP2PMustConnect(v *lib.ConsensusValidators) {
 	// update the validator count metric
 	lenMustConnects := len(mustConnects)
 	c.Metrics.UpdateValidatorCount(lenMustConnects)
+	// inform the P2P module whether this node is a validator; full nodes (non-validators)
+	// enable the inbox dead-letter policy that drops a backed-up inbox to avoid stalling
+	c.P2P.SetSelfIsValidator(selfIsValidator)
 	// if this node 'is validator'
 	if selfIsValidator {
 		// log the must connect update

--- a/lib/metrics.go
+++ b/lib/metrics.go
@@ -120,6 +120,7 @@ type P2PMetrics struct {
 	PacketsPerMessage   prometheus.Histogram   // number of packets per message
 	SendQueueTimeout    prometheus.Counter     // count of send queue timeout errors
 	SendQueueFull       *prometheus.CounterVec // count of send queue full events by topic
+	InboxFlush          *prometheus.CounterVec // count of messages dropped by the full-node inbox dead-letter flush by topic
 
 	// Heartbeat / liveness telemetry (low-cardinality; no per-peer labels)
 	HeartbeatPingSent prometheus.Counter   // heartbeat ping packets queued for send
@@ -374,6 +375,10 @@ func NewMetricsServer(nodeAddress crypto.AddressI, chainID float64, softwareVers
 			SendQueueFull: promauto.NewCounterVec(prometheus.CounterOpts{
 				Name: "canopy_p2p_send_queue_full_total",
 				Help: "Total count of send queue full events by topic",
+			}, []string{"topic"}),
+			InboxFlush: promauto.NewCounterVec(prometheus.CounterOpts{
+				Name: "canopy_p2p_inbox_flush_dropped_total",
+				Help: "Total count of messages dropped by the full-node inbox dead-letter flush by topic",
 			}, []string{"topic"}),
 
 			HeartbeatPingSent: promauto.NewCounter(prometheus.CounterOpts{

--- a/p2p/conn.go
+++ b/p2p/conn.go
@@ -26,6 +26,7 @@ const (
 	dataFlowRatePerS       = maxMessageSize                      // the maximum number of bytes that may be sent or received per second per MultiConn
 	maxChanSize            = 1                                   // maximum number of items in a channel before blocking
 	maxInboxQueueSize      = 1000                                // maximum number of items in inbox queue before blocking
+	inboxFlushThreshold    = maxInboxQueueSize * 4 / 5           // 80% full: on full nodes, trigger a dead-letter flush of the inbox to avoid stalling
 	maxStreamSendQueueSize = 1000                                // maximum number of items in a stream send queue before blocking
 	keepAlivePeriod        = 10 * time.Second                    // TCP keep-alive probe interval
 	heartbeatInterval      = time.Second                         // how often to send heartbeat pings
@@ -494,6 +495,7 @@ type Stream struct {
 	mu           sync.Mutex                   // mutex to prevent race conditions when sending packets (all packets of the same message should be one right after the other)
 	closed       bool                         // flag to identify if stream is closed
 	logger       lib.LoggerI
+	p2p          *P2P // back-reference to the P2P module (used for validator status + metrics on the inbox DLQ)
 }
 
 // queueSends() schedules the packets to be sent ensuring coordination with the mutex
@@ -567,6 +569,9 @@ func (s *Stream) handlePacket(peerInfo *lib.PeerInfo, packet *Packet, metrics *l
 			metrics.ReceiveAssemblyTime.Observe(time.Since(assemblyStart).Seconds())
 		}
 		//s.logger.Debugf("Inbox %s queue: %d", lib.Topic_name[int32(packet.StreamId)], len(s.inbox))
+		// full-node dead-letter policy: if the inbox is critically backed up, drop the entire
+		// backlog so the node can recover with fresh messages instead of stalling (see dropInboxIfBackedUp)
+		s.dropInboxIfBackedUp()
 		// add to inbox for other parts of the app to read
 		select {
 		case s.inbox <- m:
@@ -581,6 +586,37 @@ func (s *Stream) handlePacket(peerInfo *lib.PeerInfo, packet *Packet, metrics *l
 		s.msgAssembler = s.msgAssembler[:0]
 	}
 	return 0, nil
+}
+
+// dropInboxIfBackedUp() full-node-only DLQ: when the inbox hits inboxFlushThreshold (80%), drop the
+// entire backlog so the node recovers with fresh messages instead of stalling (no-op for validators)
+func (s *Stream) dropInboxIfBackedUp() {
+	// only full nodes flush; validators must not drop messages. Also guard the reserved
+	// heartbeat stream which has a nil inbox.
+	if s.inbox == nil || s.p2p == nil || s.p2p.SelfIsValidator() {
+		return
+	}
+	// fast path: nothing to do unless the inbox is critically backed up
+	if len(s.inbox) < inboxFlushThreshold {
+		return
+	}
+	// drain the entire backlog non-blockingly
+	dropped := 0
+	for {
+		select {
+		case <-s.inbox:
+			dropped++
+		default:
+			if dropped > 0 {
+				topic := lib.Topic_name[int32(s.topic)]
+				s.logger.Errorf("DLQ: %s inbox exceeded %d msgs on full node; dropped %d backlog messages to avoid stalling", topic, inboxFlushThreshold, dropped)
+				if s.p2p.metrics != nil {
+					s.p2p.metrics.InboxFlush.WithLabelValues(topic).Add(float64(dropped))
+				}
+			}
+			return
+		}
+	}
 }
 
 // HELPERS BELOW

--- a/p2p/p2p.go
+++ b/p2p/p2p.go
@@ -58,9 +58,10 @@ type P2P struct {
 	config                 lib.Config
 	metrics                *lib.Metrics
 	log                    lib.LoggerI
-	gossip                 bool     // whether gossip mode is active
-	failedPeers            sync.Map // peers that have connection errors
-	mustConnectIndex       sync.Map // pubKey string -> netAddress (for reconnect/dial correctness)
+	gossip                 bool        // whether gossip mode is active
+	selfIsValidator        atomic.Bool // whether this node is an active validator (full nodes get the inbox DLQ, validators don't)
+	failedPeers            sync.Map    // peers that have connection errors
+	mustConnectIndex       sync.Map    // pubKey string -> netAddress (for reconnect/dial correctness)
 }
 
 // New() creates an initialized pointer instance of a P2P object
@@ -545,6 +546,7 @@ func (p *P2P) NewStreams() (streams map[lib.Topic]*Stream) {
 			sendQueue:    make(chan *PacketWithTiming, maxStreamSendQueueSize),
 			inbox:        p.Inbox(i),
 			logger:       p.log,
+			p2p:          p,
 		}
 	}
 	// reserved stream for heartbeats (not forwarded to application inbox)
@@ -554,6 +556,7 @@ func (p *P2P) NewStreams() (streams map[lib.Topic]*Stream) {
 		sendQueue:    make(chan *PacketWithTiming, maxStreamSendQueueSize),
 		inbox:        nil,
 		logger:       p.log,
+		p2p:          p,
 	}
 	return
 }
@@ -845,6 +848,16 @@ func (p *P2P) UpdateQueueDepthMetrics() {
 // SetGossipMode sets the gossip mode for the P2P instance
 func (p *P2P) SetGossipMode(gossip bool) {
 	p.gossip = gossip
+}
+
+// SetSelfIsValidator records whether this node is a validator (validators are exempt from the inbox DLQ)
+func (p *P2P) SetSelfIsValidator(isValidator bool) {
+	p.selfIsValidator.Store(isValidator)
+}
+
+// SelfIsValidator returns whether this node is currently an active validator.
+func (p *P2P) SelfIsValidator() bool {
+	return p.selfIsValidator.Load()
 }
 
 // GossipMode returns the current gossip mode for the P2P instance


### PR DESCRIPTION
## Full-node inbox dead-letter (DLQ) to prevent stalls

### Problem
On full nodes, when the inbox consumer falls behind (e.g. degraded connections to validators), the shared per-topic inbox channels (`BLOCK`, `TX`, …) fill to 100%. Once full, the receive service can only drop the **newest** message, so fresh block announcements never get through and the node **stops progressing**, while validators are unaffected.

Symptoms:

`ERROR: CRITICAL: Inbox BLOCK queue full in receive service ERROR: Dropping newest message WARN: ⚠️ TX: 1000 msgs (100.0% full)
`

### Change
Add a dead-letter policy for **full nodes only** (validators are exempt): when an inbox reaches **80%** capacity, drop the entire backlog and start fresh, making room for new messages instead of stalling.

- **`p2p`**: track `selfIsValidator` (`SetSelfIsValidator`/`SelfIsValidator`); add `Stream.dropInboxIfBackedUp()` invoked in `handlePacket` before enqueue. No-op for validators and the heartbeat stream.
- **`controller`**: wire validator status to P2P from `UpdateP2PMustConnect`.
- **`lib/metrics`**: add `canopy_p2p_inbox_flush_dropped_total{topic}` counter.

### Why it's safe
Dropped messages are recoverable, so nothing is permanently lost:
- **Syncing**: the sync loop re-requests missing heights via its request queue + timeouts.
- **At tip**: continued peer gossip trips the `NewHeightTracker` (≥1/3 of peers ahead) and triggers a fresh sync. The flush is actually what *restores* visibility of the new-height gossip that drives recovery (the old drop-newest behavior discarded exactly those messages).

### Impact
- Full nodes self-heal instead of stalling under inbox backpressure.
- Validators: no behavioral change (never drop consensus/block messages).