### PR TITLE
fix(lib): copy OrderId in DexLimitOrder.Copy

### DIFF
--- a/lib/dex.go
+++ b/lib/dex.go
@@ -57,6 +57,7 @@ func (x *DexLimitOrder) Copy() *DexLimitOrder {
 		AmountForSale:   x.AmountForSale,
 		RequestedAmount: x.RequestedAmount,
 		Address:         bytes.Clone(x.Address),
+		OrderId:         bytes.Clone(x.OrderId),
 	}
 }
 

--- a/lib/dex_test.go
+++ b/lib/dex_test.go
@@ -1,6 +1,7 @@
 package lib
 
 import (
+	"bytes"
 	"encoding/json"
 	"testing"
 
@@ -77,6 +78,7 @@ func TestDexLimitOrder_Copy(t *testing.T) {
 		AmountForSale:   1000,
 		RequestedAmount: 2000,
 		Address:         []byte("test-address"),
+		OrderId:         []byte("order-id-20-bytes-00"),
 	}
 
 	copy := original.Copy()
@@ -86,6 +88,18 @@ func TestDexLimitOrder_Copy(t *testing.T) {
 	}
 	if copy.RequestedAmount != original.RequestedAmount {
 		t.Errorf("expected requestedAmount %d, got %d", original.RequestedAmount, copy.RequestedAmount)
+	}
+	if !bytes.Equal(copy.Address, original.Address) {
+		t.Errorf("expected address %x, got %x", original.Address, copy.Address)
+	}
+	// OrderId identifies the originating order in emitted swap events, so the copy must carry it
+	if !bytes.Equal(copy.OrderId, original.OrderId) {
+		t.Errorf("expected orderId %x, got %x", original.OrderId, copy.OrderId)
+	}
+	// the copy must be deep: mutating the original's slices must not affect the copy
+	original.Address[0], original.OrderId[0] = 'X', 'X'
+	if copy.Address[0] == 'X' || copy.OrderId[0] == 'X' {
+		t.Error("expected Copy() to deep-copy Address and OrderId")
 	}
 }
 


### PR DESCRIPTION
## Description

`DexLimitOrder` has four fields (`amountForSale`, `requestedAmount`, `address`, `OrderId`), but `DexLimitOrder.Copy()` only copies the first three - `OrderId` is silently dropped.

`DexBatch.CopyOrders` builds both order slices via `order.Copy()`, so every consumer downstream of it sees `OrderId == nil`. In `fsm/dex.go` that value is passed straight into the emitted swap event:

```go
if err = s.EventDexSwap(order.Address, order.OrderId, dX, dY, chainId, false, dY != 0); err != nil {
```

The `OrderId` is populated correctly upstream (`fsm/transaction.go` sets it to the first 20 bytes of the tx hash, and `fsm/message.go` carries it into the batch), so the local-origin settlement path reads it off the batch directly and works. Only the remote-origin path goes through `Copy()` and loses it.

The result is that cross-chain DEX swap events are emitted with an empty `orderId` while local ones carry the correct value. Since `orderId` is part of the public event JSON, off-chain indexers and API consumers cannot correlate a remote swap back to its originating order.

This is deterministic across nodes and does not affect consensus - events are not part of the state root or `TransactionRoot` - so the impact is observability/indexing correctness rather than funds or liveness.

## Related Issues

None found - I searched open and closed issues and PRs for `DexLimitOrder` / `OrderId` / dex copy semantics and found nothing covering this.

## Changes Made

- `DexLimitOrder.Copy()` now copies `OrderId` via `bytes.Clone`, matching how `Address` is already handled.
- Strengthened the existing `TestDexLimitOrder_Copy`: it now sets `OrderId`, asserts both `Address` and `OrderId` round-trip, and asserts the copy is genuinely deep by mutating the original's slices afterwards.

The existing test never set `OrderId`, which is why the omission went unnoticed.

## Checklist

- [x] I have tested the changes locally and verified they work as intended.
- [ ] I have appropriately titled my branch `issue-#<issue-number>`. (No issue exists for this; happy to rename if you'd like one opened first.)
- [ ] I have run re-built the web-wallet and/or block explorer (if applicable). (Not applicable - Go only.)
- [ ] I have run `npm run prettier` to format the web-wallet and/or block explorer (if applicable). (Not applicable.)
- [ ] I have updated documentation (if applicable). (Not applicable.)
- [x] I have included tests for the changes (if applicable).

## Additional Notes

Verification on `development`:

- The strengthened test fails before the fix (`expected orderId 6f726465722d69642d32302d62797465732d3030, got` - empty) and passes after it.
- `go test ./lib/` passes in full.
- `go test $(go list ./... | grep -v cmd/auto-update)` - the CI test command - passes across the repository.
- `go build ./...` succeeds; `gofmt` reports no changes for either touched file.

One adjacent observation I deliberately left out to keep this PR single-purpose: `DexBatch.Copy()` is shallow - `Orders`/`Deposits`/`Withdrawals`/`Receipts` alias the original slices. I traced the current processing paths and found no in-place mutation of those slices today, so it is latent fragility rather than a live bug. Happy to follow up separately if you'd like it hardened.
