### PR TITLE
fix: handle Marshal error in CertificateResult.Hash()

### DIFF
--- a/bft/bft.go
+++ b/bft/bft.go
@@ -342,13 +342,19 @@ func (b *BFT) StartProposePhase() {
 	} else {
 		b.Block, b.Results = b.HighQC.Block, b.HighQC.Results
 	}
+	// compute the results hash
+	resultsHash, err := b.Results.Hash()
+	if err != nil {
+		b.log.Error(err.Error())
+		return
+	}
 	// send PROPOSE message to the replicas
 	b.SendToReplicas(b.ValidatorSet, &Message{
 		Header: b.View.Copy(),
 		Qc: &QC{
 			Header:      vote.Qc.Header, // the current view
 			Results:     b.Results,      // the proposed `certificate results`
-			ResultsHash: b.Results.Hash(),
+			ResultsHash: resultsHash,
 			Block:       b.Block,
 			BlockHash:   b.GetBlockHash(),
 			ProposerKey: vote.Qc.ProposerKey, // self-public-key, Replicas use this to validate the Aggregate (multi) Signature
@@ -413,12 +419,18 @@ func (b *BFT) StartProposeVotePhase() {
 	if err := b.RunVDF(b.GetBlockHash()); err != nil {
 		b.log.Errorf("RunVDF() failed with error, %s", err.Error())
 	}
+	// compute the results hash
+	resultsHash, err := b.Results.Hash()
+	if err != nil {
+		b.log.Errorf("Results.Hash() failed with error, %s", err.Error())
+		return
+	}
 	// send vote to the proposer
 	b.SendToProposer(&Message{
 		Qc: &QC{ // NOTE: Replicas use the QC to communicate important information so that it's aggregable by the Leader
 			Header:      b.View.Copy(),
 			BlockHash:   b.GetBlockHash(),
-			ResultsHash: b.Results.Hash(),
+			ResultsHash: resultsHash,
 			ProposerKey: b.ProposerKey,
 		},
 	})
@@ -442,13 +454,20 @@ func (b *BFT) StartPrecommitPhase() {
 		b.RoundInterrupt()
 		return
 	}
+	// compute the results hash
+	resultsHash, err := b.Results.Hash()
+	if err != nil {
+		b.log.Error(err.Error())
+		b.RoundInterrupt()
+		return
+	}
 	// send PRECOMMIT msg to Replicas
 	b.SendToReplicas(b.ValidatorSet, &Message{
 		Header: b.Copy(),
 		Qc: &QC{
 			Header:      vote.Qc.Header,   // vote view
 			BlockHash:   b.GetBlockHash(), // vote block payload
-			ResultsHash: b.Results.Hash(), // vote certificate results payload
+			ResultsHash: resultsHash,      // vote certificate results payload
 			ProposerKey: b.ProposerKey,
 			Signature:   as,
 		},
@@ -480,12 +499,19 @@ func (b *BFT) StartPrecommitVotePhase() {
 	b.HighQC.Block = b.Block
 	b.HighQC.Results = b.Results
 	b.log.Infof("🔒 Locked on proposal %s", lib.BytesToTruncatedString(b.HighQC.BlockHash))
+	// compute the results hash
+	resultsHash, err := b.Results.Hash()
+	if err != nil {
+		b.log.Error(err.Error())
+		b.RoundInterrupt()
+		return
+	}
 	// send vote to the proposer
 	b.SendToProposer(&Message{
 		Qc: &QC{ // NOTE: Replicas use the QC to communicate important information so that it's aggregable by the Leader
 			Header:      b.View.Copy(),
 			BlockHash:   b.GetBlockHash(),
-			ResultsHash: b.Results.Hash(),
+			ResultsHash: resultsHash,
 			ProposerKey: b.ProposerKey,
 		},
 	})
@@ -509,13 +535,20 @@ func (b *BFT) StartCommitPhase() {
 		b.RoundInterrupt()
 		return
 	}
+	// compute the results hash
+	resultsHash, err := b.Results.Hash()
+	if err != nil {
+		b.log.Error(err.Error())
+		b.RoundInterrupt()
+		return
+	}
 	// SEND MSG TO REPLICAS
 	b.SendToReplicas(b.ValidatorSet, &Message{
 		Header: b.Copy(), // header
 		Qc: &QC{
 			Header:      vote.Qc.Header,   // vote view
 			BlockHash:   b.GetBlockHash(), // vote block payload
-			ResultsHash: b.Results.Hash(), // vote certificate results payload
+			ResultsHash: resultsHash,      // vote certificate results payload
 			ProposerKey: b.ProposerKey,
 			Signature:   as,
 		},
@@ -677,7 +710,12 @@ func (b *BFT) CheckProposerAndProposal(msg *Message) (interrupt bool) {
 	}
 
 	// confirm is expected proposal
-	if !bytes.Equal(b.GetBlockHash(), msg.Qc.BlockHash) || !bytes.Equal(b.Results.Hash(), msg.Qc.ResultsHash) {
+	resultsHash, err := b.Results.Hash()
+	if err != nil {
+		b.log.Error(err.Error())
+		return true
+	}
+	if !bytes.Equal(b.GetBlockHash(), msg.Qc.BlockHash) || !bytes.Equal(resultsHash, msg.Qc.ResultsHash) {
 		b.log.Error(ErrMismatchedProposals().Error())
 		return true
 	}
@@ -759,8 +797,13 @@ func (b *BFT) SafeNode(msg *Message) lib.ErrorI {
 	if msg == nil || msg.Qc == nil || msg.HighQc == nil {
 		return ErrNoSafeNodeJustification()
 	}
+	// compute the results hash for comparison
+	resultsHash, err := msg.Qc.Results.Hash()
+	if err != nil {
+		return err
+	}
 	// ensure the messages' HighQC justifies its proposal (should have the same hashes)
-	if !bytes.Equal(b.BlockToHash(msg.Qc.Block), msg.HighQc.BlockHash) || !bytes.Equal(msg.Qc.Results.Hash(), msg.HighQc.ResultsHash) {
+	if !bytes.Equal(b.BlockToHash(msg.Qc.Block), msg.HighQc.BlockHash) || !bytes.Equal(resultsHash, msg.HighQc.ResultsHash) {
 		return ErrMismatchedProposals()
 	}
 	// if the hashes of the Locked proposal is the same as the Leader's message

--- a/bft/msg.go
+++ b/bft/msg.go
@@ -320,7 +320,12 @@ func (b *BFT) GetValidateMessageParams(msg *Message) (*validateMessageParams, li
 	// get variables needed to validate the messages
 	var blockHash, resultsHash []byte
 	if b.Block != nil {
-		blockHash, resultsHash = b.GetBlockHash(), b.Results.Hash()
+		blockHash = b.GetBlockHash()
+		var hashErr lib.ErrorI
+		resultsHash, hashErr = b.Results.Hash()
+		if hashErr != nil {
+			return nil, hashErr
+		}
 	}
 	return &validateMessageParams{
 		view:              b.View.Copy(),

--- a/controller/consensus.go
+++ b/controller/consensus.go
@@ -807,7 +807,10 @@ func (c *Controller) ConsensusSummary() ([]byte, lib.ErrorI) {
 	consensusSummary.BlockHash = c.Consensus.BlockHash
 	// if exists, populate the proposal hash
 	if c.Consensus.Results != nil {
-		consensusSummary.ResultsHash = c.Consensus.Results.Hash()
+		resultsHash, err := c.Consensus.Results.Hash()
+		if err == nil {
+			consensusSummary.ResultsHash = resultsHash
+		}
 	}
 	// if high qc exists, populate the block hash and results hash
 	if c.Consensus.HighQC != nil {

--- a/lib/certificate.go
+++ b/lib/certificate.go
@@ -401,11 +401,14 @@ func (x *CertificateResult) Equals(y *CertificateResult) bool {
 }
 
 // Hash() returns the cryptographic hash of the canonical Sign Bytes of the CertificateResult
-func (x *CertificateResult) Hash() []byte {
+func (x *CertificateResult) Hash() ([]byte, ErrorI) {
 	// convert the certificate results to proto bytes
-	bz, _ := Marshal(x)
+	bz, err := Marshal(x)
+	if err != nil {
+		return nil, err
+	}
 	// return the hash of the bytes
-	return crypto.Hash(bz)
+	return crypto.Hash(bz), nil
 }
 
 // REWARD RECIPIENT CODE BELOW


### PR DESCRIPTION
## Problem

`CertificateResult.Hash()` silently ignored the error from `Marshal()`:

```go
func (x *CertificateResult) Hash() []byte {
    bz, _ := Marshal(x)  // error ignored!
    return crypto.Hash(bz)
}
```

If marshaling fails, this returns a hash of nil bytes, which could lead to **incorrect consensus decisions** in the BFT protocol.

## Changes

### `lib/certificate.go`
- `Hash()` now returns `([]byte, ErrorI)` instead of `[]byte`
- Error from `Marshal()` is properly propagated

### `bft/bft.go` (6 call sites)
- `StartProposePhase()`: compute hash before struct literal, return on error
- `StartProposeVotePhase()`: compute hash before sending vote
- `StartPrecommitPhase()`: compute hash before sending precommit
- `StartPrecommitVotePhase()`: compute hash before sending vote
- `StartCommitPhase()`: compute hash before sending commit
- `CheckProposerAndProposal()`: handle error when comparing hashes
- `SafeNode()`: handle error when validating HighQC

### `bft/msg.go`
- `GetValidateMessageParams()`: handle error when computing results hash

### `controller/consensus.go`
- Handle error when populating consensus summary

## Impact

- **Before:** Marshal failure → hash of nil bytes → potential consensus divergence
- **After:** Marshal failure → error propagated → BFT handles gracefully