### PR TITLE
fix(p2p): add missing return after error in sendWireBytes

### DIFF
--- a/p2p/conn.go
+++ b/p2p/conn.go
@@ -462,6 +462,7 @@ func (c *MultiConn) sendWireBytes(message proto.Message, m *limiter.Monitor) {
 	a, err := lib.NewAny(message)
 	if err != nil {
 		c.Error(err)
+		return
 	}
 	// restrict the instantaneous data flow to rate bytes per second
 	// Limit() request maxPacketSize bytes from the limiter and the limiter
@@ -472,6 +473,7 @@ func (c *MultiConn) sendWireBytes(message proto.Message, m *limiter.Monitor) {
 	lenM, err := sendProtoMsg(c.conn, &Envelope{Payload: a})
 	if err != nil {
 		c.Error(err)
+		return
 	}
 	// update the rate limiter with how many bytes were written
 	m.Update(lenM)


### PR DESCRIPTION
## Problem

`sendWireBytes()` in `p2p/conn.go` continued execution after encountering errors, which could lead to sending invalid data over the wire.

### Issue 1: `lib.NewAny()` failure (line 462-465)
```go
a, err := lib.NewAny(message)
if err != nil {
    c.Error(err)
    // Missing return! Continues with nil 'a'
}
```

### Issue 2: `sendProtoMsg()` failure (line 472-475)
```go
lenM, err := sendProtoMsg(c.conn, &Envelope{Payload: a})
if err != nil {
    c.Error(err)
    // Missing return! Updates rate limiter with potentially wrong bytes
}
```

## Fix

Added `return` statements after both error checks to prevent sending invalid data.

## Impact

- **Before:** Error in message serialization → sends nil/invalid data to peer
- **After:** Error in message serialization → logs error and returns gracefully