### PR TITLE
fix(lib): prevent integer overflow in AddToPort

### DIFF
--- a/lib/util.go
+++ b/lib/util.go
@@ -752,6 +752,10 @@ func AddToPort(portStr string, add uint64) (string, ErrorI) {
 	if port < MinAllowedPort {
 		return "", ErrBadPortLowLimit()
 	}
+	// check if add would cause overflow when converting to int
+	if add > math.MaxInt64 {
+		return "", ErrMaxPort()
+	}
 	// add the given number to the port
 	newPort := port + int(add)
 	// ensure the new port doesn't exceed the max port number (65535)


### PR DESCRIPTION
## Problem

`AddToPort()` converts a `uint64` value to `int` without checking for overflow:

```go
newPort := port + int(add)  // int(add) can overflow!
```

If `add` is very large (close to `math.MaxUint64`), `int(add)` would overflow to a negative number, causing the subsequent bounds check to fail.

## Fix

Added overflow check before the conversion:

```go
if add > math.MaxInt64 {
    return "", ErrMaxPort()
}
```

## Impact

- **Before:** Large `add` value → integer overflow → incorrect port calculation
- **After:** Large `add` value → returns `ErrMaxPort()` error