### PR TITLE
fix(bft): return error when committee loading fails

### DIFF
--- a/bft/bft.go
+++ b/bft/bft.go
@@ -126,12 +126,14 @@ func (b *BFT) Start() {
 	// load the committee from the base chain
 	b.ValidatorSet, err = b.Controller.LoadCommittee(b.LoadRootChainId(b.ChainHeight()), b.Controller.RootChainHeight())
 	if err != nil {
-		b.log.Warn(err.Error())
+		b.log.Error(err.Error())
+		return
 	}
 	// load the committee data
 	b.CommitteeData, err = b.Controller.LoadCommitteeData()
 	if err != nil {
-		b.log.Warn(err.Error())
+		b.log.Error(err.Error())
+		return
 	}
 	for {
 		select {


### PR DESCRIPTION
## Problem

In `bft/bft.go` `Start()` function, errors from `LoadCommittee()` and `LoadCommitteeData()` were only logged as warnings:

```go
b.ValidatorSet, err = b.Controller.LoadCommittee(...)
if err != nil {
    b.log.Warn(err.Error())  // Just a warning!
}
```

This allowed the BFT to continue with a potentially nil validator set, which would cause panics when:
- `GetValidator()` is called (line 242)
- `SendToReplicas()` is called (lines 270, 346, 446, etc.)
- `SelectProposerFromCandidates()` is called (line 291)

## Fix

Changed from logging warnings to returning errors:

```go
b.ValidatorSet, err = b.Controller.LoadCommittee(...)
if err != nil {
    b.log.Error(err.Error())
    return  // Stop BFT initialization
}
```

## Impact

- **Before:** Committee loading failure → BFT continues with nil validator set → panic
- **After:** Committee loading failure → BFT stops initialization → error logged