### PR TITLE
fix(store): protect Version() with mutex to prevent race condition

### DIFF
--- a/store/store.go
+++ b/store/store.go
@@ -507,7 +507,11 @@ func (s *Store) IncreaseVersion() { func() { s.version++; s.sc = nil }() }
 
 // Version() returns the current version number of the Store, representing the height or version
 // number of the state. This is used to track the versioning of the state data.
-func (s *Store) Version() uint64 { return s.version }
+func (s *Store) Version() uint64 {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.version
+}
 
 // SetSyncing tells the store whether the node is currently syncing
 func (s *Store) SetSyncing(v bool) { s.syncing.Store(v) }


### PR DESCRIPTION
## Problem

`Version()` accessed `s.version` without synchronization:

```go
func (s *Store) Version() uint64 { return s.version }  // No lock!
```

While `Commit()` updates `s.version` while holding the mutex:

```go
s.mu.Lock()
defer s.mu.Unlock()
// ...
s.version = nextVersion  // Updated under lock
```

This creates a race condition when `Version()` is called from:
- RPC handlers (query.go, line 359, 899, 948, 970)
- FSM state (state.go, line 117)
- CLI admin commands (admin.go, line 445)

While `Commit()` is updating the version.

## Fix

```go
func (s *Store) Version() uint64 {
    s.mu.Lock()
    defer s.mu.Unlock()
    return s.version
}
```

## Impact

- **Before:** Potential data race reading s.version during Commit()
- **After:** Thread-safe access to s.version via mutex