### PR TITLE
fix: remove misleading explorer metrics

### DIFF
--- a/cmd/rpc/server.go
+++ b/cmd/rpc/server.go
@@ -33,7 +33,7 @@ const (
 
 	// uses golang's semver naming convention
 	// https://pkg.go.dev/golang.org/x/mod/semver
-	SoftwareVersion = "v0.1.25+beta"
+	SoftwareVersion = "v0.1.26+beta"
 	ContentType     = "Content-MessageType"
 	ApplicationJSON = "application/json; charset=utf-8"
 

--- a/cmd/rpc/web/explorer/src/components/Home/Stages.tsx
+++ b/cmd/rpc/web/explorer/src/components/Home/Stages.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import { motion } from 'framer-motion'
 import { useCardData } from '../../hooks/useApi'
 import { usePersistentNumber } from '../../hooks/usePersistentNumber'
-import { getTotalTransactionCount, getTotalAccountCount, Validators, ValidatorsWithFilters } from '../../lib/api'
+import { getTotalTransactionCount, Validators, ValidatorsWithFilters } from '../../lib/api'
 import { convertNumber, toCNPY } from '../../lib/utils'
 import AnimatedNumber from '../AnimatedNumber'
 
@@ -67,20 +67,8 @@ const Stages = () => {
         return toCNPY(Number(bonded) || 0)
     }, [cardData])
 
-    const liquidSupplyCandidate: number | null = React.useMemo(() => {
-        if (!cardData) return null
-        const s = (cardData as any)?.supply || {}
-        const total = Number(s.total ?? 0)
-        const staked = Number(s.staked ?? 0)
-        if (total > 0) return toCNPY(Math.max(0, total - staked))
-        // fallback to other fields if they don't exist
-        const liquid = s.circulating ?? s.liquidSupply ?? s.liquid ?? 0
-        return toCNPY(Number(liquid) || 0)
-    }, [cardData])
-
     // Async stats stay `null` until a fetch succeeds. We never reset them to a
     // value on failure, so a transient RPC error can't blank the cards.
-    const [totalAccountsCandidate, setTotalAccountsCandidate] = React.useState<number | null>(null)
     const [totalTxsCandidate, setTotalTxsCandidate] = React.useState<number | null>(null)
     const [totalValidatingCandidate, setTotalValidatingCandidate] = React.useState<number | null>(null)
     const [totalDelegatingCandidate, setTotalDelegatingCandidate] = React.useState<number | null>(null)
@@ -105,13 +93,6 @@ const Stages = () => {
                 } else if (!cancelled) {
                     setTotalTxsCandidate(0)
                 }
-            }
-
-            try {
-                const accountStats = await getTotalAccountCount()
-                if (!cancelled) setTotalAccountsCandidate(accountStats.total)
-            } catch (error) {
-                console.error('Error fetching account stats:', error)
             }
 
             try {
@@ -145,8 +126,6 @@ const Stages = () => {
     const latestBlockHeight = usePersistentNumber('blockHeight', latestBlockHeightCandidate)
     const totalSupplyCNPY = usePersistentNumber('totalSupply', totalSupplyCandidate)
     const totalStakeCNPY = usePersistentNumber('totalStake', totalStakeCandidate)
-    const liquidSupplyCNPY = usePersistentNumber('liquidSupply', liquidSupplyCandidate)
-    const totalAccounts = usePersistentNumber('totalAccounts', totalAccountsCandidate)
     const totalTxs = usePersistentNumber('totalTxs', totalTxsCandidate)
     const totalValidating = usePersistentNumber('totalValidating', totalValidatingCandidate)
     const totalDelegating = usePersistentNumber('totalDelegating', totalDelegatingCandidate)
@@ -167,14 +146,6 @@ const Stages = () => {
             subtitle: <p className={stageCardSubtitleClass}>CNPY</p>,
             icon: <i className="fa-solid fa-wallet"></i>,
             metric: 'totalSupply',
-        },
-        {
-            title: 'Liquid Supply',
-            data: convertNumber(liquidSupplyCNPY.value),
-            loading: !liquidSupplyCNPY.hasValue,
-            subtitle: <p className={stageCardSubtitleClass}>CNPY</p>,
-            icon: <i className="fa-solid fa-droplet"></i>,
-            metric: 'liquidSupply',
         },
         {
             title: 'Total Stake',
@@ -199,14 +170,6 @@ const Stages = () => {
             subtitle: <p className={stageCardSubtitleClass}>Delegators</p>,
             icon: <i className="fa-solid fa-coins"></i>,
             metric: 'totalDelegating',
-        },
-        {
-            title: 'Total Accounts',
-            data: convertNumber(totalAccounts.value),
-            loading: !totalAccounts.hasValue,
-            icon: <i className="fa-solid fa-users"></i>,
-            metric: 'accounts',
-            subtitle: <p className={stageCardSubtitleClass}>Indexed accounts</p>,
         },
         {
             title: 'Total Txs',

--- a/cmd/rpc/web/explorer/src/components/staking/SupplyView.tsx
+++ b/cmd/rpc/web/explorer/src/components/staking/SupplyView.tsx
@@ -29,39 +29,21 @@ const SupplyView: React.FC = () => {
         return toCNPY(Number(bonded))
     }, [cardData])
 
-    const liquidSupplyCandidate = React.useMemo(() => {
-        if (!cardData) return null
-        const s = (cardData as any)?.supply || {}
-        const total = Number(s.total ?? 0)
-        const staked = Number(s.staked ?? 0)
-        if (total > 0) return Math.max(0, toCNPY(total - staked))
-        const liquid = s.circulating ?? s.liquidSupply ?? s.liquid ?? 0
-        return toCNPY(Number(liquid))
-    }, [cardData])
-
     const totalSupply = usePersistentNumber('totalSupply', totalSupplyCandidate)
     const stakedSupply = usePersistentNumber('totalStake', stakedSupplyCandidate)
-    const liquidSupply = usePersistentNumber('liquidSupply', liquidSupplyCandidate)
 
     const totalSupplyCNPY = totalSupply.value
     const stakedSupplyCNPY = stakedSupply.value
-    const liquidSupplyCNPY = liquidSupply.value
 
     // First-ever load (no cached value yet) → show "Loading…" instead of 0.
     const isSupplyLoading = !totalSupply.hasValue
     const isStakedLoading = !stakedSupply.hasValue
-    const isLiquidLoading = !liquidSupply.hasValue
     const LoadingValue = () => <span className="text-white/40">Loading…</span>
 
     const stakingRatio = React.useMemo(() => {
         if (totalSupplyCNPY <= 0) return 0
         return Math.max(0, Math.min(100, (stakedSupplyCNPY / totalSupplyCNPY) * 100))
     }, [stakedSupplyCNPY, totalSupplyCNPY])
-
-    const liquidRatio = React.useMemo(() => {
-        if (totalSupplyCNPY <= 0) return Math.max(0, 100 - stakingRatio)
-        return Math.max(0, Math.min(100, (liquidSupplyCNPY / totalSupplyCNPY) * 100))
-    }, [liquidSupplyCNPY, stakingRatio, totalSupplyCNPY])
 
     const supplyMetrics = [
         {
@@ -91,20 +73,6 @@ const SupplyView: React.FC = () => {
             ),
             subValue: 'CNPY',
             icon: 'fa-solid fa-coins',
-        },
-        {
-            title: 'Liquid',
-            value: isLiquidLoading ? (
-                <LoadingValue />
-            ) : (
-                <AnimatedNumber
-                    value={liquidSupplyCNPY}
-                    format={{ minimumFractionDigits: 2, maximumFractionDigits: 2 }}
-                    className="text-white"
-                />
-            ),
-            subValue: 'CNPY',
-            icon: 'fa-solid fa-water',
         },
         {
             title: 'Staking Ratio',
@@ -156,26 +124,14 @@ const SupplyView: React.FC = () => {
                             <span>Staked {stakingRatio.toFixed(2)}%</span>
                         </div>
                         <div className="text-xs uppercase tracking-[0.2em] text-gray-500">of total supply</div>
-                        <div className="flex items-center gap-2 text-[#216cd0]">
-                            <span>Liquid {liquidRatio.toFixed(2)}%</span>
-                            <span className="h-2 w-2 rounded-full bg-[#216cd0]" />
-                        </div>
                     </div>
                     <div className="overflow-hidden rounded-full bg-white/10">
-                        <div className="flex h-3 w-full">
-                            <motion.div
-                                className="bg-[#35cd48]"
-                                initial={{ width: 0 }}
-                                animate={{ width: `${stakingRatio}%` }}
-                                transition={{ duration: 1, delay: 0.5 }}
-                            />
-                            <motion.div
-                                className="bg-[#216cd0]"
-                                initial={{ width: 0 }}
-                                animate={{ width: `${liquidRatio}%` }}
-                                transition={{ duration: 1, delay: 0.7 }}
-                            />
-                        </div>
+                        <motion.div
+                            className="h-3 bg-[#35cd48]"
+                            initial={{ width: 0 }}
+                            animate={{ width: `${stakingRatio}%` }}
+                            transition={{ duration: 1, delay: 0.5 }}
+                        />
                     </div>
                 </div>
             </motion.div>
@@ -212,20 +168,6 @@ const SupplyView: React.FC = () => {
                                             value={stakedSupplyCNPY}
                                             format={{ maximumFractionDigits: 0 }}
                                             className="text-[#35cd48]"
-                                        /> CNPY
-                                    </>
-                                )}
-                            </span>
-                        </div>
-                        <div className="flex justify-between items-center">
-                            <span className="text-gray-400">Liquid</span>
-                            <span className="font-medium text-[#216cd0]">
-                                {isLiquidLoading ? <LoadingValue /> : (
-                                    <>
-                                        <AnimatedNumber
-                                            value={liquidSupplyCNPY}
-                                            format={{ maximumFractionDigits: 0 }}
-                                            className="text-[#216cd0]"
                                         /> CNPY
                                     </>
                                 )}

--- a/cmd/rpc/web/explorer/src/data/stages.json
+++ b/cmd/rpc/web/explorer/src/data/stages.json
@@ -2,10 +2,7 @@
   { "title": "Staking %", "metric": "stakingPercent", "icon": "fa-solid fa-chart-pie", "progress": true },
   { "title": "CNPY Staking", "metric": "cnpyStakingDelta", "icon": "fa-solid fa-coins", "subtitle": "delta" },
   { "title": "Total Supply", "metric": "totalSupply", "icon": "fa-solid fa-wallet", "subtitle": "cnpy" },
-  { "title": "Liquid Supply", "metric": "liquidSupply", "icon": "fa-solid fa-droplet", "subtitle": "cnpy" },
   { "title": "Blocks", "metric": "blocks", "icon": "fa-solid fa-cube", "subtitle": "live" },
   { "title": "Total Stake", "metric": "totalStake", "icon": "fa-solid fa-lock", "subtitle": "cnpy" },
-  { "title": "Total Accounts", "metric": "accounts", "icon": "fa-solid fa-users", "subtitle": "last24h" },
   { "title": "Total Txs", "metric": "txs", "icon": "fa-solid fa-arrow-right-arrow-left", "subtitle": "last24h" }
 ]
-

--- a/cmd/rpc/web/explorer/src/data/staking.json
+++ b/cmd/rpc/web/explorer/src/data/staking.json
@@ -206,7 +206,6 @@
     "metrics": {
       "totalSupply": "Total Supply",
       "stakedSupply": "Staked Supply",
-      "liquidSupply": "Liquid Supply",
       "stakingRatio": "Staking Ratio"
     },
     "table": {


### PR DESCRIPTION
## Summary
- remove the Liquid Supply card from the explorer dashboard
- remove liquid supply values and the liquid distribution segment from the Network Supply page
- remove Total Accounts from the dashboard and stop its now-unneeded account-count request
- remove the corresponding stale explorer data-config entries

## Rationale
Liquid supply is derived as total supply minus staked supply, which can misrepresent the amount that is actually liquid. The account total is also no longer wanted in the dashboard overview.

## Validation
- `npm run build` — passes
- `npx eslint src/components/Home/Stages.tsx src/components/staking/SupplyView.tsx` — passes
- `npm run lint` — currently fails on five pre-existing errors in `ValidatorsPage.tsx`, `api.ts`, and `utils.ts`; no lint errors are reported in the changed files

## Screenshots
Not included; this is a removal-only UI change.

## Compatibility
No `chain.json` or `manifest.json` changes.
