### PR TITLE
chore: fix qemu random error

### DIFF
--- a/.docker/auto-update/Dockerfile
+++ b/.docker/auto-update/Dockerfile
@@ -1,4 +1,13 @@
-FROM node:24-alpine AS builder
+# Pin the builder to the native build platform (e.g. amd64 on CI) so the
+# Node/vite frontend build never runs under QEMU emulation. Emulating the
+# rollup/esbuild native code for a foreign arch (linux/arm64) crashes with
+# "qemu: uncaught target signal 4 (Illegal instruction)". The frontend output
+# is architecture-independent and the Go binaries are cross-compiled below.
+FROM --platform=$BUILDPLATFORM node:24-alpine AS builder
+
+# Populated automatically by buildx for the requested target platform.
+ARG TARGETOS
+ARG TARGETARCH
 
 ARG BRANCH='latest'
 ARG CLI_DIR
@@ -31,13 +40,13 @@ RUN apk update && apk add --no-cache make bash nodejs npm
 RUN make build/wallet
 RUN make build/explorer
 
-# Builds auto-update CLI
-RUN CGO_ENABLED=0 GOOS=linux go build -a -o bin ./cmd/auto-update/.
+# Builds auto-update CLI (cross-compiled for the target arch)
+RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -o bin ./cmd/auto-update/.
 
 # Only build if the file at ${BIN_PATH} doesn't already exist
 RUN if [ ! -f "${BIN_PATH}" ]; then \
     echo "File ${BIN_PATH} not found. Building it..."; \
-    CGO_ENABLED=0 GOOS=linux go build -a -o "${BIN_PATH}" ./cmd/main/...; \
+    CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -o "${BIN_PATH}" ./cmd/main/...; \
   else \
     echo "File ${BIN_PATH} already exists. Skipping build."; \
   fi

--- a/.docker/auto-update/Dockerfile.csharp
+++ b/.docker/auto-update/Dockerfile.csharp
@@ -1,4 +1,13 @@
-FROM node:24-alpine AS builder
+# Pin the builder to the native build platform (e.g. amd64 on CI) so the
+# Node/vite frontend build never runs under QEMU emulation. Emulating the
+# rollup/esbuild native code for a foreign arch (linux/arm64) crashes with
+# "qemu: uncaught target signal 4 (Illegal instruction)". The frontend output
+# is architecture-independent and the Go binaries are cross-compiled below.
+FROM --platform=$BUILDPLATFORM node:24-alpine AS builder
+
+# Populated automatically by buildx for the requested target platform.
+ARG TARGETOS
+ARG TARGETARCH
 
 ARG BRANCH='latest'
 ARG BIN_PATH=/bin/cli
@@ -34,11 +43,11 @@ RUN apk update && apk add --no-cache make bash nodejs npm
 RUN make build/wallet
 RUN make build/explorer
 
-# Build auto-update coordinator
-RUN CGO_ENABLED=0 GOOS=linux go build -a -o bin ./cmd/auto-update/.
+# Build auto-update coordinator (cross-compiled for the target arch)
+RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -o bin ./cmd/auto-update/.
 
-# Build CLI
-RUN CGO_ENABLED=0 GOOS=linux go build -a -o "${BIN_PATH}" ./cmd/main/...
+# Build CLI (cross-compiled for the target arch)
+RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -o "${BIN_PATH}" ./cmd/main/...
 
 # =============================================================================
 # Final image for C# plugin

--- a/.docker/auto-update/Dockerfile.go
+++ b/.docker/auto-update/Dockerfile.go
@@ -1,4 +1,13 @@
-FROM node:24-alpine AS builder
+# Pin the builder to the native build platform (e.g. amd64 on CI) so the
+# Node/vite frontend build never runs under QEMU emulation. Emulating the
+# rollup/esbuild native code for a foreign arch (linux/arm64) crashes with
+# "qemu: uncaught target signal 4 (Illegal instruction)". The frontend output
+# is architecture-independent and the Go binaries are cross-compiled below.
+FROM --platform=$BUILDPLATFORM node:24-alpine AS builder
+
+# Populated automatically by buildx for the requested target platform.
+ARG TARGETOS
+ARG TARGETARCH
 
 ARG BRANCH='latest'
 ARG BIN_PATH=/bin/cli
@@ -34,11 +43,11 @@ RUN apk update && apk add --no-cache make bash nodejs npm
 RUN make build/wallet
 RUN make build/explorer
 
-# Build auto-update coordinator
-RUN CGO_ENABLED=0 GOOS=linux go build -a -o bin ./cmd/auto-update/.
+# Build auto-update coordinator (cross-compiled for the target arch)
+RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -o bin ./cmd/auto-update/.
 
-# Build CLI
-RUN CGO_ENABLED=0 GOOS=linux go build -a -o "${BIN_PATH}" ./cmd/main/...
+# Build CLI (cross-compiled for the target arch)
+RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -o "${BIN_PATH}" ./cmd/main/...
 
 # =============================================================================
 # Final image for Go plugin

--- a/.docker/auto-update/Dockerfile.kotlin
+++ b/.docker/auto-update/Dockerfile.kotlin
@@ -1,4 +1,13 @@
-FROM node:24-alpine AS builder
+# Pin the builder to the native build platform (e.g. amd64 on CI) so the
+# Node/vite frontend build never runs under QEMU emulation. Emulating the
+# rollup/esbuild native code for a foreign arch (linux/arm64) crashes with
+# "qemu: uncaught target signal 4 (Illegal instruction)". The frontend output
+# is architecture-independent and the Go binaries are cross-compiled below.
+FROM --platform=$BUILDPLATFORM node:24-alpine AS builder
+
+# Populated automatically by buildx for the requested target platform.
+ARG TARGETOS
+ARG TARGETARCH
 
 ARG BRANCH='latest'
 ARG BIN_PATH=/bin/cli
@@ -34,11 +43,11 @@ RUN apk update && apk add --no-cache make bash nodejs npm
 RUN make build/wallet
 RUN make build/explorer
 
-# Build auto-update coordinator
-RUN CGO_ENABLED=0 GOOS=linux go build -a -o bin ./cmd/auto-update/.
+# Build auto-update coordinator (cross-compiled for the target arch)
+RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -o bin ./cmd/auto-update/.
 
-# Build CLI
-RUN CGO_ENABLED=0 GOOS=linux go build -a -o "${BIN_PATH}" ./cmd/main/...
+# Build CLI (cross-compiled for the target arch)
+RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -o "${BIN_PATH}" ./cmd/main/...
 
 # =============================================================================
 # Final image for Kotlin plugin

--- a/.docker/auto-update/Dockerfile.python
+++ b/.docker/auto-update/Dockerfile.python
@@ -1,4 +1,13 @@
-FROM node:24-alpine AS builder
+# Pin the builder to the native build platform (e.g. amd64 on CI) so the
+# Node/vite frontend build never runs under QEMU emulation. Emulating the
+# rollup/esbuild native code for a foreign arch (linux/arm64) crashes with
+# "qemu: uncaught target signal 4 (Illegal instruction)". The frontend output
+# is architecture-independent and the Go binaries are cross-compiled below.
+FROM --platform=$BUILDPLATFORM node:24-alpine AS builder
+
+# Populated automatically by buildx for the requested target platform.
+ARG TARGETOS
+ARG TARGETARCH
 
 ARG BRANCH='latest'
 ARG BIN_PATH=/bin/cli
@@ -34,11 +43,11 @@ RUN apk update && apk add --no-cache make bash nodejs npm
 RUN make build/wallet
 RUN make build/explorer
 
-# Build auto-update coordinator
-RUN CGO_ENABLED=0 GOOS=linux go build -a -o bin ./cmd/auto-update/.
+# Build auto-update coordinator (cross-compiled for the target arch)
+RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -o bin ./cmd/auto-update/.
 
-# Build CLI
-RUN CGO_ENABLED=0 GOOS=linux go build -a -o "${BIN_PATH}" ./cmd/main/...
+# Build CLI (cross-compiled for the target arch)
+RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -o "${BIN_PATH}" ./cmd/main/...
 
 # =============================================================================
 # Final image for Python plugin

--- a/.docker/auto-update/Dockerfile.typescript
+++ b/.docker/auto-update/Dockerfile.typescript
@@ -1,4 +1,13 @@
-FROM node:24-alpine AS builder
+# Pin the builder to the native build platform (e.g. amd64 on CI) so the
+# Node/vite frontend build never runs under QEMU emulation. Emulating the
+# rollup/esbuild native code for a foreign arch (linux/arm64) crashes with
+# "qemu: uncaught target signal 4 (Illegal instruction)". The frontend output
+# is architecture-independent and the Go binaries are cross-compiled below.
+FROM --platform=$BUILDPLATFORM node:24-alpine AS builder
+
+# Populated automatically by buildx for the requested target platform.
+ARG TARGETOS
+ARG TARGETARCH
 
 ARG BRANCH='latest'
 ARG BIN_PATH=/bin/cli
@@ -34,11 +43,11 @@ RUN apk update && apk add --no-cache make bash nodejs npm
 RUN make build/wallet
 RUN make build/explorer
 
-# Build auto-update coordinator
-RUN CGO_ENABLED=0 GOOS=linux go build -a -o bin ./cmd/auto-update/.
+# Build auto-update coordinator (cross-compiled for the target arch)
+RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -o bin ./cmd/auto-update/.
 
-# Build CLI
-RUN CGO_ENABLED=0 GOOS=linux go build -a -o "${BIN_PATH}" ./cmd/main/...
+# Build CLI (cross-compiled for the target arch)
+RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -o "${BIN_PATH}" ./cmd/main/...
 
 # =============================================================================
 # Final image for TypeScript plugin

--- a/cmd/rpc/server.go
+++ b/cmd/rpc/server.go
@@ -33,7 +33,7 @@ const (
 
 	// uses golang's semver naming convention
 	// https://pkg.go.dev/golang.org/x/mod/semver
-	SoftwareVersion = "v0.1.26+beta"
+	SoftwareVersion = "v0.1.27+beta"
 	ContentType     = "Content-MessageType"
 	ApplicationJSON = "application/json; charset=utf-8"
 


### PR DESCRIPTION
# Fix non-deterministic `Illegal instruction` crash in multi-arch Docker release builds

## Problem

The Docker release jobs in `.github/workflows/release.yml` build every image for `linux/amd64,linux/arm64` using buildx + QEMU. The entire `builder` stage — including the `make build/wallet` / `make build/explorer` frontend build (`vite build`) — runs under QEMU user-mode emulation on the `linux/arm64` leg.

During the `rendering chunks` phase, Rollup/esbuild's native code hits an instruction QEMU can't emulate and the build dies:

```
qemu: uncaught target signal 4 (Illegal instruction) - core dumped
make: *** [Makefile:44: build/wallet] Illegal instruction (core dumped)
ERROR: process "/bin/sh -c make build/wallet" did not complete successfully: exit code: 2
```

This is **non-deterministic**: the six `docker-*` jobs run on independent runners with no shared build cache, so each one independently re-emulates arm64 and rolls the dice. In the failing run only `main` and `csharp` crashed while `go`/`python`/`typescript`/`kotlin` happened to pass, even though their builder stages are byte-identical. It builds fine locally because that's a native (non-emulated) build.

## Root cause

Compiling the frontend under QEMU emulation. The wallet/explorer output is static, architecture-independent JS/CSS/HTML — there is no reason to emulate a foreign CPU to produce it.

## Fix

Adopt the standard buildx cross-compilation pattern in all six release Dockerfiles under `.docker/auto-update/`:

- Pin the `builder` stage to the native build platform so the Node/vite build and Go toolchain always run natively (no QEMU):
  ```dockerfile
  FROM --platform=$BUILDPLATFORM node:24-alpine AS builder
  ```
- Declare the buildx-provided target args and **cross-compile** the Go binaries for the requested arch (they're `CGO_ENABLED=0`, so this is trivial):
  ```dockerfile
  ARG TARGETOS
  ARG TARGETARCH
  ...
  RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -o bin ./cmd/auto-update/.
  RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -o "${BIN_PATH}" ./cmd/main/...
  ```

The frontend is built once (natively) and embedded into the Go binary via `//go:embed`; the Go binary is then cross-compiled per target arch.

## Multi-arch is preserved

Only the `builder` stage is pinned to `$BUILDPLATFORM`. The final runtime stages (`FROM alpine:...` / `FROM node:...`) are untouched and have **no** `--platform`, so buildx still instantiates them once per requested platform and assembles a single multi-arch manifest:

- `linux/amd64` image ← `GOARCH=amd64` binary (with embedded frontend)
- `linux/arm64` image ← `GOARCH=arm64` binary (with embedded frontend)

Same static frontend inside both; each has the correct native Go binary.

## Files changed

- `.docker/auto-update/Dockerfile`
- `.docker/auto-update/Dockerfile.go`
- `.docker/auto-update/Dockerfile.csharp`
- `.docker/auto-update/Dockerfile.python`
- `.docker/auto-update/Dockerfile.typescript`
- `.docker/auto-update/Dockerfile.kotlin`

## Testing

- Verified both Go binaries cross-compile to arm64 with the embedded assets:
  ```
  $ GOARCH=arm64 CGO_ENABLED=0 GOOS=linux go build ./cmd/auto-update/.
  $ GOARCH=arm64 CGO_ENABLED=0 GOOS=linux go build ./cmd/main/...
  # both -> ELF 64-bit LSB executable, ARM aarch64, statically linked
  ```
- Confirmed the builder stages were identical across all variants, ruling out a per-job difference and confirming the flaky-QEMU root cause.

## Notes

- No plugin cross-compilation was needed here — the language plugin binaries (go/csharp/etc.) are downloaded from the GitHub release at runtime, not built in these Dockerfiles.
- Builds are also faster now, since compilation runs natively instead of under emulation.
